### PR TITLE
[COMP-1153] patch to get master back to running properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,6 +678,7 @@ dependencies = [
  "frame-benchmarking-cli",
  "jsonrpc-core",
  "pallet-transaction-payment-rpc",
+ "runtime-interfaces",
  "sc-basic-authorship",
  "sc-cli",
  "sc-client-api",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -23,6 +23,7 @@ structopt = '0.3.8'
 
 # local dependencies
 compound-chain-runtime = { path = '../runtime', version = '1.0.0' }
+runtime-interfaces = { path = '../pallets/runtime-interfaces', version = '1.0.0' }
 
 # Substrate dependencies
 frame-benchmarking = '2.0.0'

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -18,7 +18,7 @@ native_executor_instance!(
     pub Executor,
     compound_chain_runtime::api::dispatch,
     compound_chain_runtime::native_version,
-    frame_benchmarking::benchmarking::HostFunctions,
+    (frame_benchmarking::benchmarking::HostFunctions, runtime_interfaces::config_interface::HostFunctions)
 );
 
 type FullClient = sc_service::TFullClient<Block, RuntimeApi, Executor>;


### PR DESCRIPTION
The "host functions" were never registered with the runtime resulting in a runtime failure to start the node. The white checkmark was given in spite of this because the build succeeds.