### PR TITLE
[COMP-1165] add fixed precision math library (method 1)

### DIFF
--- a/pallets/cash/Cargo.toml
+++ b/pallets/cash/Cargo.toml
@@ -21,6 +21,7 @@ version = '1.3.4'
 frame-support = { default-features = false, version = '2.0.0' }
 frame-system = { default-features = false, version = '2.0.0' }
 runtime-interfaces = { default-features = false, version = '1.0.0', path="../runtime-interfaces"}
+primitive-types = { default-features = false, version = "0.7.3" }
 
 [dev-dependencies]
 sp-core = { default-features = false, version = '2.0.0' }
@@ -33,4 +34,6 @@ std = [
     'codec/std',
     'frame-support/std',
     'frame-system/std',
+    'runtime-interfaces/std',
+    'primitive-types/std',
 ]

--- a/pallets/cash/src/fixed_precision_number.rs
+++ b/pallets/cash/src/fixed_precision_number.rs
@@ -1,0 +1,43 @@
+use primitive_types::U256;
+
+macro_rules! impl_fixed_precision_number {
+    ($t:ident, $name:ident) => {
+        #[derive(Copy, Clone, Eq, PartialEq, Hash)]
+        pub struct $name {
+            decimals: usize,
+            value: $t,
+        }
+
+        pub fn new_fixed_precision_number(decimals: usize, value: $t) -> $name {
+            return $name { decimals, value };
+        }
+
+        impl $name {
+            pub fn overflowing_add(self, other: $name) -> ($name, bool) {
+                // todo: check decimals match
+                if self.decimals != other.decimals {
+                    return (self, true);
+                }
+                let (new_value, overflowed) = self.value.overflowing_add(other.value);
+                let result = new_fixed_precision_number(self.decimals, new_value);
+                (result, overflowed)
+            }
+        }
+    };
+}
+
+impl_fixed_precision_number!(U256, FixedPrecisionNumberU256);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        let x = new_fixed_precision_number(2, U256::one());
+        let (y, overflowed) = x.overflowing_add(x);
+        assert_eq!(overflowed, false);
+        let expected = U256::from(2);
+        assert_eq!(y.value, expected);
+    }
+}

--- a/pallets/cash/src/lib.rs
+++ b/pallets/cash/src/lib.rs
@@ -12,6 +12,8 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
+pub mod fixed_precision_number;
+
 /// Configure the pallet by specifying the parameters and types on which it depends.
 pub trait Trait: frame_system::Trait {
     /// Because this pallet emits events, it depends on the runtime's definition of an event.


### PR DESCRIPTION
When I went to do the implementation for the exp proof of concept, I realized that we
need a method of doing fixed precision math in the style of the crypto domain. The compound
equivalent of this is Exponential.sol which this takes some inspiration from.

During the implementation, I found that unfortunately it is difficult to use traditional
generics and trait bounds for this because in parity's implementation of U256 (for example)
they do not provide interfaces such as `checked_add` that would allow me to use trait bounds
for the generics. Thus, sadly, this approach uses a macro to create a generic fixed precision
decimal type over various implementations of large unsigned values (Uxxx). This only applies
to 512, 256 and 128. 64 and 32 are built-in types and would be incompatible with this macro
which is one of the weaknesses of this approach.

In another PR I will use wrapper types to implement a trait-based generics approach. This
PR is to share this approach and see how it compares with the other trait-based generic
approach.