### PR TITLE
[COMP-1165] add fixed precision math library (wip)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3506,6 +3506,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
+ "primitive-types",
  "runtime-interfaces",
  "sp-core",
  "sp-io",
@@ -4039,9 +4040,9 @@ checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "primitive-types"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55c21c64d0eaa4d7ed885d959ef2d62d9e488c27c0e02d9aa5ce6c877b7d5f8"
+checksum = "7dd39dcacf71411ba488570da7bbc89b717225e46478b30ba99b92db6b149809"
 dependencies = [
  "fixed-hash",
  "impl-codec",

--- a/pallets/cash/Cargo.toml
+++ b/pallets/cash/Cargo.toml
@@ -21,6 +21,7 @@ version = '1.3.4'
 frame-support = { default-features = false, version = '2.0.0' }
 frame-system = { default-features = false, version = '2.0.0' }
 runtime-interfaces = { default-features = false, version = '1.0.0', path="../runtime-interfaces"}
+primitive-types = { default-features = false, version = "0.7.3" }
 
 [dev-dependencies]
 sp-core = { default-features = false, version = '2.0.0' }
@@ -33,4 +34,5 @@ std = [
     'codec/std',
     'frame-support/std',
     'frame-system/std',
+    'primitive-types/std',
 ]

--- a/pallets/cash/src/fixed_precision_number.rs
+++ b/pallets/cash/src/fixed_precision_number.rs
@@ -1,0 +1,111 @@
+use primitive_types::U256;
+
+/// The math error type
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum MathError {
+    Overflow,
+    PrecisionMismatch,
+}
+
+/// The SafeMath trait allows us to have a consistent way to do safe math operations between
+/// different storage types including primitives u8 u32 u64 as well as parity primitives
+/// U128 U256 U512. This unified interface allows us to implement other safe algorithms on
+/// underlying types such as exp and integer powers in a fully generic way (static dispatch)
+///
+/// There will most likely be some performance improvements we want to make here such as
+/// #[inline_always] annotations but much of that should come naturally from compiler optimization
+pub trait SafeMath {
+    fn add(self, rhs: Self) -> Result<Self, MathError>
+    where
+        Self: Sized; // required due to Result
+}
+
+/// Implement SafeMath for existing primitive types (will likely need to go into a macro :sad:)
+impl SafeMath for U256 {
+    fn add(self, rhs: Self) -> Result<Self, MathError> {
+        convert_overflowing(self.overflowing_add(rhs))
+    }
+}
+
+impl SafeMath for u8 {
+    fn add(self, rhs: Self) -> Result<Self, MathError> {
+        self.checked_add(rhs).ok_or(MathError::Overflow)
+    }
+}
+
+/// The FixedPrecisionNumber represents numbers using a base type to store the mantissa
+/// with a u8 for the number of decimals of precision. For example, if we use
+/// FixedPrecisionNumber<u8> we can represent
+#[derive(Copy, Clone, Debug)]
+pub struct FixedPrecisionNumber<T: SafeMath> {
+    mantissa: T,
+    decimals: u8,
+}
+
+/// Constructor for FixedPrecisionNumber
+pub fn new_fixed_precision_number<T: SafeMath>(
+    mantissa: T,
+    decimals: u8,
+) -> FixedPrecisionNumber<T> {
+    FixedPrecisionNumber { mantissa, decimals }
+}
+
+/// check that the decimals on two FixedPrecisionNumbers are the same, error if not.
+fn check_decimals<T: SafeMath>(
+    lhs: FixedPrecisionNumber<T>,
+    rhs: FixedPrecisionNumber<T>,
+) -> Result<(), MathError> {
+    if lhs.decimals != rhs.decimals {
+        Err(MathError::PrecisionMismatch)
+    } else {
+        Ok(())
+    }
+}
+
+/// The primitive_types crate from substrate has several overflowing_* functions that return
+/// tuples. This is antithetical to the general practice of error handling in rust generally
+/// speaking as well as even being inconsistent with the general convention of the
+/// standard libraries checked_* functions on primitives. This function converts the return
+/// values from tuples to results for easy use with the ? operator downstream.
+fn convert_overflowing<T>(overflowing_result: (T, bool)) -> Result<T, MathError> {
+    let (value, is_overflow) = overflowing_result;
+    if is_overflow {
+        Err(MathError::Overflow)
+    } else {
+        Ok(value)
+    }
+}
+
+impl SafeMath for FixedPrecisionNumber<U256> {
+    fn add(self, rhs: Self) -> Result<FixedPrecisionNumber<U256>, MathError> {
+        check_decimals(self, rhs)?;
+        let new_mantissa = convert_overflowing(self.mantissa.overflowing_add(rhs.mantissa))?;
+        Ok(new_fixed_precision_number(new_mantissa, self.decimals))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_happy_path() -> Result<(), MathError> {
+        // let's do an 18 decimal number on a U256
+        let x = new_fixed_precision_number(U256::one(), 2);
+        // error out if we overflow
+        let twox = x.add(x)?;
+        // make sure we have the correct expected value in the mantissa
+        assert_eq!(twox.mantissa, U256::from(2));
+        assert_eq!(twox.decimals, 2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_overflow_u8() {
+        let result = 255.add(1);
+        assert!(result.is_err());
+        let error = result.err().unwrap();
+        assert_eq!(error, MathError::Overflow)
+    }
+}

--- a/pallets/cash/src/lib.rs
+++ b/pallets/cash/src/lib.rs
@@ -12,6 +12,8 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
+mod fixed_precision_number;
+
 /// Configure the pallet by specifying the parameters and types on which it depends.
 pub trait Trait: frame_system::Trait {
     /// Because this pallet emits events, it depends on the runtime's definition of an event.


### PR DESCRIPTION
The main challenge this addresses is different underlying storage mantissa sizes
for different blockchains and being generic across mantissas while still having
the ability to do safe math.

Introduce the SafeMath trait so that further methods may be implemented in
a generic (static dispatch) way such as exp, sqrt etc. While we will still most
likely use a macro to implement the SafeMath trait for each underlying storage type
and perhaps the FixedPrecisionDecimal type for each underlying storage type, these will be
one-time macros while the rest of the program can be written without macros.