### PR TITLE
Fix the build in some circumstances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4601,8 +4601,6 @@ version = "1.0.0"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
- "sp-externalities",
- "sp-io",
  "sp-runtime-interface",
 ]
 

--- a/pallets/cash/Cargo.toml
+++ b/pallets/cash/Cargo.toml
@@ -21,10 +21,10 @@ version = '1.3.4'
 frame-support = { default-features = false, version = '2.0.0' }
 frame-system = { default-features = false, version = '2.0.0' }
 runtime-interfaces = { default-features = false, version = '1.0.0', path="../runtime-interfaces"}
+sp-io = { version = "2.0.0", default-features = false, features = ["disable_oom", "disable_panic_handler"] }
 
 [dev-dependencies]
 sp-core = { default-features = false, version = '2.0.0' }
-sp-io = { default-features = false, version = '2.0.0' }
 sp-runtime = { default-features = false, version = '2.0.0' }
 
 [features]
@@ -33,4 +33,6 @@ std = [
     'codec/std',
     'frame-support/std',
     'frame-system/std',
+    'runtime-interfaces/std',
+    'sp-io/std'
 ]

--- a/pallets/runtime-interfaces/Cargo.toml
+++ b/pallets/runtime-interfaces/Cargo.toml
@@ -11,8 +11,6 @@ version = '1.0.0'
 
 [dependencies]
 sp-runtime-interface = {version="2.0.0", default-features=false}
-sp-externalities = {version="0.8.0", default-features=false}
-sp-io = { version = "2.0.0", default-features = false, features = ["disable_oom", "disable_panic_handler"] }
 codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false, features = ["derive"] }
 lazy_static = "1.4.0"
 
@@ -20,5 +18,5 @@ lazy_static = "1.4.0"
 default = ['std']
 std = [
     "sp-runtime-interface/std",
-    "sp-externalities/std",
+    "codec/std"
 ]


### PR DESCRIPTION
Right now when running builds in some subdirectories there was an issue with 'wasm' not found errors. This increases cycle times because you cannot test in these subdirectories.

The issue was traced back to feature std linking. There are some interesting sharp corners within the no-std development system and we just got bit by one of them. The rules are such that when you write up a crate that you want to be no-std compatible you need to add a std feature and under that feature you must add all other crates that have a std feature. 

This is a particularly sharp corner because there is no systematic method for catching this issue at the moment that I am aware of. Another problem with this issue is that due to conditional compilation missing a std link in your feature chain results in impossible to decypher compiler messages. 