### PR TITLE
Compound Substrate Fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,7 +789,7 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder",
@@ -1324,7 +1324,7 @@ dependencies = [
  "serde_json",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
 ]
 
 [[package]]
@@ -1473,7 +1473,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1491,7 +1491,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1502,14 +1502,14 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-runtime-interface",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "sp-storage",
 ]
 
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "chrono",
  "frame-benchmarking",
@@ -1531,7 +1531,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1540,25 +1540,25 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "sp-tracing",
 ]
 
 [[package]]
 name = "frame-metadata"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-core",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
 ]
 
 [[package]]
 name = "frame-support"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -1576,14 +1576,14 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "sp-tracing",
 ]
 
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2",
@@ -1594,7 +1594,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1606,7 +1606,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1616,7 +1616,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1625,14 +1625,14 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "sp-version",
 ]
 
 [[package]]
 name = "frame-system-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1640,13 +1640,13 @@ dependencies = [
  "parity-scale-codec",
  "sp-core",
  "sp-runtime",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
 ]
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3660,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3669,13 +3669,13 @@ dependencies = [
  "sp-authorship",
  "sp-inherents",
  "sp-runtime",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-babe"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3693,14 +3693,14 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "pallet-balances"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3708,7 +3708,7 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-runtime",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
 ]
 
 [[package]]
@@ -3723,13 +3723,13 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3744,26 +3744,26 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "safe-mix",
  "sp-runtime",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3776,14 +3776,14 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "sp-trie",
 ]
 
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3791,13 +3791,13 @@ dependencies = [
  "serde",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3808,14 +3808,14 @@ dependencies = [
  "sp-inherents",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3826,13 +3826,13 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -3850,14 +3850,14 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
  "serde",
  "sp-api",
  "sp-runtime",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
 ]
 
 [[package]]
@@ -4906,7 +4906,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
@@ -4929,7 +4929,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -4946,7 +4946,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -4967,7 +4967,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4978,7 +4978,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -5023,7 +5023,7 @@ dependencies = [
 [[package]]
 name = "sc-cli-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5034,7 +5034,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "derive_more",
  "fnv",
@@ -5056,7 +5056,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "sp-storage",
  "sp-transaction-pool",
  "sp-trie",
@@ -5068,7 +5068,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5098,7 +5098,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -5109,7 +5109,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "derive_more",
  "fork-tree",
@@ -5154,7 +5154,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "derive_more",
  "futures 0.3.8",
@@ -5178,7 +5178,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -5191,7 +5191,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
@@ -5217,7 +5217,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "log",
  "sc-client-api",
@@ -5231,7 +5231,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -5260,7 +5260,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -5276,7 +5276,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5291,7 +5291,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5309,7 +5309,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -5346,7 +5346,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -5370,7 +5370,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.8",
@@ -5388,7 +5388,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -5408,7 +5408,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -5427,7 +5427,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "async-std",
  "async-trait",
@@ -5481,7 +5481,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
@@ -5496,7 +5496,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -5523,7 +5523,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "futures 0.3.8",
  "libp2p",
@@ -5536,7 +5536,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -5545,7 +5545,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "futures 0.3.8",
  "hash-db",
@@ -5578,7 +5578,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "derive_more",
  "futures 0.3.8",
@@ -5602,7 +5602,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "futures 0.1.30",
  "jsonrpc-core",
@@ -5620,7 +5620,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "directories 3.0.1",
  "exit-future",
@@ -5684,7 +5684,7 @@ dependencies = [
 [[package]]
 name = "sc-service-test"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "fdlimit",
  "futures 0.1.30",
@@ -5721,7 +5721,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5736,7 +5736,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -5756,7 +5756,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
@@ -5777,7 +5777,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "erased-serde",
  "log",
@@ -5796,7 +5796,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "derive_more",
  "futures 0.3.8",
@@ -5818,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "futures 0.3.8",
  "futures-diagnose",
@@ -6237,11 +6237,11 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "log",
  "sp-core",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "sp-wasm-interface",
  "thiserror",
 ]
@@ -6249,7 +6249,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6257,7 +6257,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "sp-version",
  "thiserror",
 ]
@@ -6265,7 +6265,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -6277,55 +6277,55 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-core",
  "sp-io",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "integer-sqrt",
  "num-traits",
  "parity-scale-codec",
  "serde",
  "sp-debug-derive",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
  "sp-runtime",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
  "sp-inherents",
  "sp-runtime",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "futures 0.3.8",
  "log",
@@ -6343,7 +6343,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "serde",
  "serde_json",
@@ -6352,7 +6352,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "futures 0.3.8",
  "futures-timer 3.0.2",
@@ -6366,7 +6366,7 @@ dependencies = [
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "sp-trie",
  "sp-utils",
  "sp-version",
@@ -6378,21 +6378,21 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
  "sp-application-crypto",
  "sp-inherents",
  "sp-runtime",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -6405,14 +6405,14 @@ dependencies = [
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -6421,19 +6421,19 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
  "sp-core",
  "sp-runtime",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-core"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -6463,7 +6463,7 @@ dependencies = [
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "sp-storage",
  "substrate-bip39",
  "thiserror",
@@ -6477,7 +6477,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -6486,7 +6486,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6496,18 +6496,18 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "sp-storage",
 ]
 
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -6518,25 +6518,25 @@ dependencies = [
  "sp-core",
  "sp-keystore",
  "sp-runtime",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-inherents"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "sp-core",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-io"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "futures 0.3.8",
  "hash-db",
@@ -6549,7 +6549,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime-interface",
  "sp-state-machine",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "sp-tracing",
  "sp-trie",
  "sp-wasm-interface",
@@ -6560,7 +6560,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6571,7 +6571,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -6587,7 +6587,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6597,7 +6597,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "backtrace",
 ]
@@ -6605,7 +6605,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "serde",
  "sp-core",
@@ -6614,7 +6614,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -6629,19 +6629,19 @@ dependencies = [
  "sp-arithmetic",
  "sp-core",
  "sp-io",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "sp-externalities",
  "sp-runtime-interface-proc-macro",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "sp-storage",
  "sp-tracing",
  "sp-wasm-interface",
@@ -6651,7 +6651,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -6663,7 +6663,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "serde",
  "serde_json",
@@ -6672,30 +6672,30 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
  "sp-core",
  "sp-runtime",
  "sp-staking",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "hash-db",
  "log",
@@ -6707,7 +6707,7 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-panic-handler",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "sp-trie",
  "thiserror",
  "trie-db",
@@ -6717,62 +6717,56 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa2d6e166cead2d3b1d3d8fe0e787d076b7d0296b1760a0d7d340846d0ba42c5"
-
-[[package]]
-name = "sp-std"
-version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "ref-cast",
  "serde",
  "sp-debug-derive",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "log",
  "sp-core",
  "sp-externalities",
  "sp-io",
  "sp-runtime-interface",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "sp-api",
  "sp-inherents",
  "sp-runtime",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sp-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "log",
  "parity-scale-codec",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -6781,7 +6775,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "derive_more",
  "futures 0.3.8",
@@ -6797,13 +6791,13 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "hash-db",
  "memory-db",
  "parity-scale-codec",
  "sp-core",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "trie-db",
  "trie-root",
 ]
@@ -6811,7 +6805,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "futures 0.3.8",
  "futures-core",
@@ -6823,23 +6817,23 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "serde",
  "sp-runtime",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "wasmi",
 ]
 
@@ -6956,7 +6950,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "platforms",
 ]
@@ -6964,7 +6958,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.8",
@@ -6987,7 +6981,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "async-std",
  "derive_more",
@@ -7001,7 +6995,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "futures 0.1.30",
  "futures 0.3.8",
@@ -7028,7 +7022,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "cfg-if 0.1.10",
  "frame-executive",
@@ -7059,7 +7053,7 @@ dependencies = [
  "sp-runtime-interface",
  "sp-session",
  "sp-state-machine",
- "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=dcf6a3a)",
+ "sp-std",
  "sp-transaction-pool",
  "sp-trie",
  "sp-version",
@@ -7070,7 +7064,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "futures 0.3.8",
  "parity-scale-codec",
@@ -7091,7 +7085,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?rev=dcf6a3a#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
+source = "git+https://github.com/compound-finance/substrate.git#dcf6a3ae9587bdf27a58eeff4bad8628c4763b38"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",

--- a/ethereum_client/Cargo.toml
+++ b/ethereum_client/Cargo.toml
@@ -12,10 +12,10 @@ ethabi = { version = "12.0.0", default-features = false }
 hex = { version = "0.4.2", default-features = false }
 serde = { version = "1.0.116", features = ["derive", "alloc"], default-features = false}
 serde_json = { version = "1.0.58", features=["alloc"], default-features = false}
-frame-support = { default-features = false, version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-io = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a', features = ["disable_oom", "disable_panic_handler"]}
-sp-runtime = { default-features = false, version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-std = { version = '2.0.0', default-features = false }
+frame-support = { default-features = false, version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+sp-io = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git', features = ["disable_oom", "disable_panic_handler"]}
+sp-runtime = { default-features = false, version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+sp-std = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
 
 [features]
 default = ['std']

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -15,7 +15,7 @@ name = 'compound-chain'
 targets = ['x86_64-unknown-linux-gnu']
 
 [build-dependencies]
-substrate-build-script-utils = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a'}
+substrate-build-script-utils = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git'}
 
 [dependencies]
 jsonrpc-core = '15.0.0'
@@ -27,46 +27,46 @@ serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0.41"
 
 # Substrate dependencies
-sc-chain-spec = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sc-client-api = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sc-cli = { version = '0.8.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a', features = ['wasmtime'] }
-sc-client-db = { version = "0.8.0", git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a', default-features = false }
-sp-core = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sc-consensus = { version = '0.8.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-consensus = { version = '0.8.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sc-consensus-babe = { version = '0.8.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sc-consensus-babe-rpc = { version = '0.8.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-consensus-babe = { version = '0.8.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sc-consensus-epochs = { version = '0.8.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sc-consensus-slots = { version = '0.8.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sc-finality-grandpa = { version = '0.8.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sc-finality-grandpa-rpc = { version = '0.8.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-finality-grandpa = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sc-executor = { version = '0.8.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a', features = ['wasmtime'] }
-sp-inherents = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sc-keystore = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-keystore = { version = '0.8.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sc-network = { version = '0.8.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-runtime = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sc-service = { version = '0.8.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a', default-features = false, features = [] }
-sc-transaction-pool = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-transaction-pool = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
+sc-chain-spec = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+sc-client-api = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+sc-cli = { version = '0.8.0', git = 'https://github.com/compound-finance/substrate.git', features = ['wasmtime'] }
+sc-client-db = { version = "0.8.0", git = 'https://github.com/compound-finance/substrate.git', default-features = false }
+sp-core = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+sc-consensus = { version = '0.8.0', git = 'https://github.com/compound-finance/substrate.git' }
+sp-consensus = { version = '0.8.0', git = 'https://github.com/compound-finance/substrate.git' }
+sc-consensus-babe = { version = '0.8.0', git = 'https://github.com/compound-finance/substrate.git' }
+sc-consensus-babe-rpc = { version = '0.8.0', git = 'https://github.com/compound-finance/substrate.git' }
+sp-consensus-babe = { version = '0.8.0', git = 'https://github.com/compound-finance/substrate.git' }
+sc-consensus-epochs = { version = '0.8.0', git = 'https://github.com/compound-finance/substrate.git' }
+sc-consensus-slots = { version = '0.8.0', git = 'https://github.com/compound-finance/substrate.git' }
+sc-finality-grandpa = { version = '0.8.0', git = 'https://github.com/compound-finance/substrate.git' }
+sc-finality-grandpa-rpc = { version = '0.8.0', git = 'https://github.com/compound-finance/substrate.git' }
+sp-finality-grandpa = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+sc-executor = { version = '0.8.0', git = 'https://github.com/compound-finance/substrate.git', features = ['wasmtime'] }
+sp-inherents = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+sc-keystore = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+sp-keystore = { version = '0.8.0', git = 'https://github.com/compound-finance/substrate.git' }
+sc-network = { version = '0.8.0', git = 'https://github.com/compound-finance/substrate.git' }
+sp-runtime = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+sc-service = { version = '0.8.0', git = 'https://github.com/compound-finance/substrate.git', default-features = false, features = [] }
+sc-transaction-pool = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+sp-transaction-pool = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
 
 # These dependencies are used for the node's RPCs
-sc-rpc = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-api = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sc-rpc-api = { version = '0.8.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-blockchain = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-chain-spec = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-block-builder = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sc-basic-authorship = { version = '0.8.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sc-sync-state-rpc = { version = '0.8.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-substrate-frame-rpc-system = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-pallet-transaction-payment-rpc = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
+sc-rpc = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+sp-api = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+sc-rpc-api = { version = '0.8.0', git = 'https://github.com/compound-finance/substrate.git' }
+sp-blockchain = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+sp-chain-spec = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+sp-block-builder = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+sc-basic-authorship = { version = '0.8.0', git = 'https://github.com/compound-finance/substrate.git' }
+sc-sync-state-rpc = { version = '0.8.0', git = 'https://github.com/compound-finance/substrate.git' }
+substrate-frame-rpc-system = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+pallet-transaction-payment-rpc = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
 
 # Used only for runtime benchmarking
-frame-benchmarking = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-frame-benchmarking-cli = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a', default-features = false, optional = true }
+frame-benchmarking = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+frame-benchmarking-cli = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git', default-features = false, optional = true }
 
 # Local dependencies
 compound-chain-runtime = { version = '1.0.0', path = '../runtime' }
@@ -75,14 +75,14 @@ runtime-interfaces = { path = '../pallets/runtime-interfaces', version = '1.0.0'
 [dev-dependencies]
 tempfile = "3.1.0"
 
-sc-consensus-babe = { version = '0.8.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a', features = ["test-helpers"] }
-sp-keyring = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sc-service-test = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a', default-features = false, features = [] }
-sp-timestamp = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a', default-features = false }
+sc-consensus-babe = { version = '0.8.0', git = 'https://github.com/compound-finance/substrate.git', features = ["test-helpers"] }
+sp-keyring = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+sc-service-test = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git', default-features = false, features = [] }
+sp-timestamp = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git', default-features = false }
 
-frame-system = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
+frame-system = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
 
-pallet-transaction-payment = { version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
+pallet-transaction-payment = { version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
 
 [features]
 default = ['with-parity-db']

--- a/pallets/cash/Cargo.toml
+++ b/pallets/cash/Cargo.toml
@@ -13,12 +13,12 @@ targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
 codec = { package = 'parity-scale-codec', version = '1.3.4', default-features = false, features = ['derive'] }
-frame-support = { default-features = false, version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-frame-system = { default-features = false, version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-core = { default-features = false, version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-io = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a', features = ["disable_oom", "disable_panic_handler"]}
-sp-runtime = { default-features = false, version = '2.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-std = { version = '2.0.0', default-features = false }
+frame-support = { default-features = false, version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+frame-system = { default-features = false, version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+sp-core = { default-features = false, version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+sp-io = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git', features = ["disable_oom", "disable_panic_handler"]}
+sp-runtime = { default-features = false, version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+sp-std = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
 
 runtime-interfaces = { path = '../runtime-interfaces', version = '1.0.0', default-features = false }
 ethereum-client = { path = "../../ethereum_client", version = '0.1.0', default-features = false}

--- a/pallets/runtime-interfaces/Cargo.toml
+++ b/pallets/runtime-interfaces/Cargo.toml
@@ -10,9 +10,9 @@ version = '1.0.0'
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sp-runtime-interface = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-externalities = { version='0.8.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-io = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
+sp-runtime-interface = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
+sp-externalities = { version='0.8.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
+sp-io = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
 codec = { package = 'parity-scale-codec', version = '1.3.4', default-features = false, features = ['derive'] }
 lazy_static = '1.4.0'
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,7 +10,7 @@ version = '1.0.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [build-dependencies]
-substrate-wasm-builder = { version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
+substrate-wasm-builder = { version = '3.0.0', git = 'https://github.com/compound-finance/substrate.git' }
 
 [dependencies]
 codec = { package = 'parity-scale-codec', version = '1.3.4', default-features = false, features = ['derive'] }
@@ -19,36 +19,36 @@ hex-literal = { optional = true, version = '0.3.1' }
 serde = { features = ['derive'], optional = true, version = '1.0.101' }
 
 # Substrate dependencies
-frame-executive = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-frame-support = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-frame-system = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-frame-system-rpc-runtime-api = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
+frame-executive = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
+frame-support = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
+frame-system = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
+frame-system-rpc-runtime-api = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
 
-sp-api = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-block-builder = { git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a', default-features = false, version = '2.0.0'}
-sp-consensus-babe = { version = '0.8.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-core = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-inherents = { git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a', default-features = false, version = '2.0.0'}
-sp-offchain = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-runtime = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-session = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-std = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-transaction-pool = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-sp-version = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
+sp-api = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
+sp-block-builder = { git = 'https://github.com/compound-finance/substrate.git', default-features = false, version = '2.0.0'}
+sp-consensus-babe = { version = '0.8.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
+sp-core = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
+sp-inherents = { git = 'https://github.com/compound-finance/substrate.git', default-features = false, version = '2.0.0'}
+sp-offchain = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
+sp-runtime = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
+sp-session = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
+sp-std = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
+sp-transaction-pool = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
+sp-version = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
 
 # Used only for runtime benchmarking
-frame-benchmarking = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a', optional = true }
-frame-system-benchmarking = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a', optional = true }
+frame-benchmarking = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git', optional = true }
+frame-system-benchmarking = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git', optional = true }
 
 # Other pallets
-pallet-babe = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-pallet-balances = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-pallet-grandpa = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-pallet-randomness-collective-flip = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-pallet-sudo = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-pallet-timestamp = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-pallet-transaction-payment = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
-pallet-transaction-payment-rpc-runtime-api = { version = '2.0.0', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'dcf6a3a' }
+pallet-babe = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
+pallet-balances = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
+pallet-grandpa = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
+pallet-randomness-collective-flip = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
+pallet-sudo = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
+pallet-timestamp = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
+pallet-transaction-payment = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
+pallet-transaction-payment-rpc-runtime-api = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git' }
 
 # Local dependencies
 pallet-cash = { path = '../pallets/cash', default-features = false, version = '1.0.0' }


### PR DESCRIPTION
This patch switches us to using the Compound Substrate Fork: https://github.com/compound-finance/substrate. This will allow us to have better control over the version of Substrate, and if we need, to make changes to the substrate core. Additionally, we fix an issue where `sp-std` was on the crates version instead of through our git dependency.