### PR TITLE
Remove Lib

### DIFF
--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,3 +1,0 @@
-pub mod chain_spec;
-pub mod rpc;
-pub mod service;


### PR DESCRIPTION
This patch removes `lib.rs` which means the node can't be used as a lib. Alternatively, it also means we don't compile our node twice, which could mean a significant boost in compilation time since this is the highest-level and thus slowest component.