### PR TITLE
Fix Cash Token

### DIFF
--- a/integration/util/scenario/cash_token.js
+++ b/integration/util/scenario/cash_token.js
@@ -18,7 +18,7 @@ class CashToken {
       'CASH',
       'Cash Token',
       18,
-      this.ethAddress(),
+      this.cashToken,
       this.owner,
       this.ctx
     );


### PR DESCRIPTION
When building a `Token` from `CashToken` in our integration tests, we were passing the EthAddress to super when it was supposed to be the token contract itself. This manifests itself downstream as an invalid configuration for the Elm app.