### PR TITLE
Fix Symbol in types.json

### DIFF
--- a/types.json
+++ b/types.json
@@ -78,7 +78,7 @@
   "AssetIndex": ["Uint"],
 
   "Source1": "SymbolRS",
-  "Symbol": "[u32; 12]",
+  "Symbol": ["[u8; 12]", "u8"],
 
   "Source2": "ChainsRS",
   "ChainId": {


### PR DESCRIPTION
This isn't exactly correct but should get us unblocked.. I wasn't sure about support for `char` in `types.json` but I knew it would support `u8`. 