### PR TITLE
Add `log!` Macro

### DIFF
--- a/pallets/cash/src/core.rs
+++ b/pallets/cash/src/core.rs
@@ -12,7 +12,7 @@ use crate::{
     chains::{
         eth, ChainAccount, ChainAsset, ChainAssetAccount, ChainSignature, ChainSignatureList,
     },
-    notices,
+    log, notices,
     notices::{EncodeNotice, ExtractionNotice, Notice, NoticeId, NoticeStatus},
     params::MIN_TX_VALUE,
     reason::{MathError, Reason},
@@ -26,8 +26,6 @@ use crate::{
     TotalCashPrincipal, TotalSupplyAssets,
 };
 use frame_support::storage::{IterableStorageMap, StorageDoubleMap, StorageMap, StorageValue};
-
-use sp_runtime::print;
 
 macro_rules! require {
     ($expr:expr, $reason:expr) => {
@@ -470,9 +468,7 @@ pub fn process_notices<T: Config>(_block_number: T::BlockNumber) -> Result<(), R
                     // submit onchain call for aggregating the price
                     let signature: ChainSignature = notices::sign_notice_chain(&notice)?;
 
-                    print(
-                        format!("Posting Signature for [{},{}]", notice_id.0, notice_id.1).as_str(),
-                    );
+                    log!("Posting Signature for [{},{}]", notice_id.0, notice_id.1);
 
                     let call = <Call<T>>::publish_signature(notice_id, signature);
 
@@ -495,7 +491,7 @@ pub fn publish_signature_internal(
     notice_id: NoticeId,
     signature: ChainSignature,
 ) -> Result<(), Reason> {
-    print(format!("Publishing Signature: [{},{}]", notice_id.0, notice_id.1).as_str());
+    log!("Publishing Signature: [{},{}]", notice_id.0, notice_id.1);
     let status = <NoticeQueue>::get(notice_id).unwrap_or(NoticeStatus::Missing);
 
     match status {

--- a/pallets/cash/src/log.rs
+++ b/pallets/cash/src/log.rs
@@ -1,0 +1,91 @@
+#![macro_use]
+
+#[cfg(feature = "std")]
+use frame_support;
+
+#[cfg(not(feature = "std"))]
+use sp_runtime;
+
+// This file includes macros to make it easy to log from either an
+// std or no_std environment. Just use log!("My Log: {}", 5); and
+// things should just magically work.
+
+#[cfg(feature = "std")]
+#[macro_export]
+macro_rules! log {
+    ($($arg:tt)*) => {{
+        frame_support::debug::native::info!($($arg)*);
+    }}
+}
+
+#[cfg(not(feature = "std"))]
+#[macro_export]
+macro_rules! log {
+    ($($arg:tt)*) => {{
+        sp_runtime::print(format!($($arg)*).as_str());
+    }}
+}
+
+#[cfg(feature = "std")]
+#[macro_export]
+macro_rules! debug {
+    ($($arg:tt)*) => {{
+        frame_support::debug::native::debug!($($arg)*);
+    }}
+}
+
+#[cfg(not(feature = "std"))]
+#[macro_export]
+macro_rules! debug {
+    ($($arg:tt)*) => {{
+        log!($($arg)*);
+    }}
+}
+
+#[cfg(feature = "std")]
+#[macro_export]
+macro_rules! info {
+    ($($arg:tt)*) => {{
+        frame_support::debug::native::info!($($arg)*);
+    }}
+}
+
+#[cfg(not(feature = "std"))]
+#[macro_export]
+macro_rules! info {
+    ($($arg:tt)*) => {{
+        log!($($arg)*);
+    }}
+}
+
+#[cfg(feature = "std")]
+#[macro_export]
+macro_rules! warn {
+    ($($arg:tt)*) => {{
+        frame_support::debug::native::warn!($($arg)*);
+    }}
+}
+
+#[cfg(not(feature = "std"))]
+#[macro_export]
+macro_rules! warn {
+    ($($arg:tt)*) => {{
+        log!($($arg)*);
+    }}
+}
+
+#[cfg(feature = "std")]
+#[macro_export]
+macro_rules! error {
+    ($($arg:tt)*) => {{
+        frame_support::debug::native::error!($($arg)*);
+    }}
+}
+
+#[cfg(not(feature = "std"))]
+#[macro_export]
+macro_rules! error {
+    ($($arg:tt)*) => {{
+        log!($($arg)*);
+    }}
+}


### PR DESCRIPTION
This patch adds a `log!("My log {}", 5);` macro that should (hopefully) work correctly in both std and no_std environments. We've historically used a variety of log-styles and the goal here is to consolidate into a single macro that can capture any important log information we need, esp. during the development phase and to debug test-net nodes.