### PR TITLE
Add Account Nonces

### DIFF
--- a/pallets/cash/src/chains.rs
+++ b/pallets/cash/src/chains.rs
@@ -146,6 +146,42 @@ pub enum ChainAssetAccount {
     Tez(<Tezos as Chain>::Address, <Tezos as Chain>::Address),
 }
 
+/// Type for a signature and account tied to a chain.
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+pub enum ChainAccountSignature {
+    Comp(<Compound as Chain>::Address, <Compound as Chain>::Signature),
+    Eth(<Ethereum as Chain>::Address, <Ethereum as Chain>::Signature),
+    Dot(<Polkadot as Chain>::Address, <Polkadot as Chain>::Signature),
+    Sol(<Solana as Chain>::Address, <Solana as Chain>::Signature),
+    Tez(<Tezos as Chain>::Address, <Tezos as Chain>::Signature),
+}
+
+impl ChainAccountSignature {
+    pub fn to_chain_signature(self) -> ChainSignature {
+        match self {
+            ChainAccountSignature::Comp(_, sig) => ChainSignature::Comp(sig),
+            ChainAccountSignature::Eth(_, sig) => ChainSignature::Eth(sig),
+            ChainAccountSignature::Dot(_, sig) => ChainSignature::Dot(sig),
+            ChainAccountSignature::Sol(_, sig) => ChainSignature::Sol(sig),
+            ChainAccountSignature::Tez(_, sig) => ChainSignature::Tez(sig),
+        }
+    }
+
+    pub fn recover_account(self, message: &[u8]) -> Result<ChainAccount, Reason> {
+        match self {
+            ChainAccountSignature::Eth(eth_account, eth_sig) => {
+                let recovered = <Ethereum as Chain>::recover_address(message, eth_sig)?;
+                if eth_account == recovered {
+                    Ok(ChainAccount::Eth(recovered))
+                } else {
+                    Err(Reason::SignatureAccountMismatch)
+                }
+            }
+            _ => panic!("XXX not implemented"),
+        }
+    }
+}
+
 /// Type for a signature tied to a chain.
 #[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
 pub enum ChainSignature {

--- a/pallets/cash/src/lib.rs
+++ b/pallets/cash/src/lib.rs
@@ -11,7 +11,8 @@ extern crate ethereum_client;
 extern crate trx_request;
 
 use crate::chains::{
-    Chain, ChainAccount, ChainAsset, ChainId, ChainSignature, ChainSignatureList, Ethereum,
+    Chain, ChainAccount, ChainAccountSignature, ChainAsset, ChainId, ChainSignature,
+    ChainSignatureList, Ethereum,
 };
 use crate::notices::{Notice, NoticeId, NoticeStatus};
 use crate::rates::{InterestRateModel, APR};
@@ -19,8 +20,8 @@ use crate::reason::Reason;
 use crate::symbol::Symbol;
 use crate::types::{
     AssetAmount, AssetBalance, AssetIndex, AssetPrice, Bips, CashIndex, CashPrincipal, ChainKeys,
-    ConfigAsset, ConfigSetString, EncodedNotice, EthAddress, EventStatus, Nonce, Quantity,
-    ReporterSet, SessionIndex, SignedPayload, Timestamp, ValidatorSet, ValidatorSig,
+    ConfigAsset, ConfigSetString, EncodedNotice, EthAddress, EventStatus, Nonce, ReporterSet,
+    SessionIndex, SignedPayload, Timestamp, ValidatorSet, ValidatorSig,
 };
 use codec::{alloc::string::String, Decode};
 use frame_support::{decl_error, decl_event, decl_module, decl_storage, dispatch};
@@ -257,9 +258,6 @@ decl_error! {
         /// An error related to the chain_spec file contents
         GenesisConfigError,
 
-        /// Trx request parsing error
-        TrxRequestParseError,
-
         /// Invalid parameters to a provided interest rate model
         InterestRateModelInvalidParameters,
 
@@ -364,32 +362,13 @@ decl_module! {
             Ok(())
         }
 
-        // TODO
+        /// Execute a transaction request on behalf of a user
         #[weight = 1]
-        pub fn exec_trx_request(origin, request: Vec<u8>, signature: ChainSignature) -> dispatch::DispatchResult {
+        pub fn exec_trx_request(origin, request: Vec<u8>, signature: ChainAccountSignature, nonce: Nonce) -> dispatch::DispatchResult {
             ensure_none(origin)?;
 
-            // // TODO: Add more error information here
-            let request_str: &str = str::from_utf8(&request[..]).map_err(|_| <Error<T>>::TrxRequestParseError)?;
-
-            // // TODO: Add more error information here
-            let sender = cash_err!(signature.recover(&request), <Error<T>>::InvalidSignature)?; // XXX error from reason?
-            let trx_request = cash_err!(trx_request::parse_request(request_str), <Error<T>>::TrxRequestParseError)?;
-
-            match trx_request {
-                trx_request::TrxRequest::Extract(amount, asset, account) => {
-                    let chain_asset: ChainAsset = asset.into();
-                    let symbol = core::symbol::<T>(chain_asset).ok_or(<Error<T>>::AssetNotSupported)?; // TODO: Correct error? cash_err?
-                    let quantity = Quantity(symbol, amount.into());
-                    match core::extract_internal::<T>(chain_asset, sender, account.into(), quantity) {
-                        Ok(()) => Ok(()),
-                        Err(err) => {
-                            log!("TrxExtract Error: {:?}", err);
-                            Err(Error::<T>::TrxRequestError)?
-                        }
-                    }
-                }
-            }
+            cash_err!(core::exec_trx_request_internal::<T>(request, signature, nonce), Error::<T>::TrxRequestError)?;
+            Ok(())
         }
 
         #[weight = 1] // XXX how are we doing weights?
@@ -895,12 +874,26 @@ impl<T: Config> frame_support::unsigned::ValidateUnsigned for Module<T> {
                     .propagate(true)
                     .build()
             }
-            Call::exec_trx_request(request, _signature) => {
-                ValidTransaction::with_tag_prefix("CashPallet")
-                    .longevity(10)
-                    .and_provides(request)
-                    .propagate(true)
-                    .build()
+            Call::exec_trx_request(request, signature, nonce) => {
+                let signer_res =
+                    signature.recover_account(&core::prepend_nonce(request, *nonce)[..]);
+
+                log!("signer_res={:?}", signer_res);
+
+                match (signer_res, nonce) {
+                    (Err(_e), _) => InvalidTransaction::Call.into(),
+                    (Ok(sender), 0) => ValidTransaction::with_tag_prefix("CashPallet")
+                        .longevity(10)
+                        .and_provides((sender, nonce))
+                        .propagate(true)
+                        .build(),
+                    (Ok(sender), _) => ValidTransaction::with_tag_prefix("CashPallet")
+                        .longevity(10)
+                        .and_requires((sender, nonce - 1))
+                        .and_provides((sender, nonce))
+                        .propagate(true)
+                        .build(),
+                }
             }
             Call::post_price(_, sig) => ValidTransaction::with_tag_prefix("CashPallet")
                 .longevity(10)

--- a/pallets/cash/src/reason.rs
+++ b/pallets/cash/src/reason.rs
@@ -1,5 +1,7 @@
+use crate::types::Nonce;
 use codec::{Decode, Encode};
 use our_std::{Debuggable, RuntimeDebug};
+use trx_request;
 
 /// Type for reporting failures for reasons outside of our control.
 #[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, Debuggable)]
@@ -28,6 +30,11 @@ pub enum Reason {
     ParseIntError,
     RepayTooMuch,
     SignatureMismatch,
+    AssetNotSupported,
+    TrxRequestParseError(TrxReqParseError),
+    InvalidUTF8,
+    SignatureAccountMismatch,
+    IncorrectNonce(Nonce, Nonce),
 }
 
 impl From<MathError> for Reason {
@@ -57,4 +64,31 @@ pub enum MathError {
     SymbolMismatch,
     PriceNotUSD,
     DivisionByZero,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, Debuggable)]
+pub enum TrxReqParseError {
+    NotImplemented,
+    LexError,
+    InvalidAmount,
+    InvalidAddress,
+    InvalidArgs,
+    UnknownFunction,
+    InvalidExpression,
+    InvalidChain,
+    InvalidChainAccount,
+}
+
+pub fn to_parse_error(err: trx_request::ParseError) -> TrxReqParseError {
+    match err {
+        trx_request::ParseError::NotImplemented => TrxReqParseError::NotImplemented,
+        trx_request::ParseError::LexError(_) => TrxReqParseError::LexError,
+        trx_request::ParseError::InvalidAmount => TrxReqParseError::InvalidAmount,
+        trx_request::ParseError::InvalidAddress => TrxReqParseError::InvalidAddress,
+        trx_request::ParseError::InvalidArgs(_, _, _) => TrxReqParseError::InvalidArgs,
+        trx_request::ParseError::UnknownFunction(_) => TrxReqParseError::UnknownFunction,
+        trx_request::ParseError::InvalidExpression => TrxReqParseError::InvalidExpression,
+        trx_request::ParseError::InvalidChain(_) => TrxReqParseError::InvalidChain,
+        trx_request::ParseError::InvalidChainAccount(_) => TrxReqParseError::InvalidChainAccount,
+    }
 }

--- a/pallets/cash/src/tests.rs
+++ b/pallets/cash/src/tests.rs
@@ -18,7 +18,8 @@ fn it_fails_exec_trx_request_signed() {
             CashModule::exec_trx_request(
                 Origin::signed(Default::default()),
                 vec![],
-                ChainSignature::Eth([0; 65])
+                ChainAccountSignature::Eth([0; 20], [0; 65]),
+                0
             ),
             DispatchError::BadOrigin
         );

--- a/types.json
+++ b/types.json
@@ -76,6 +76,15 @@
       "Tez": "([u8; 20], [u8; 20])"
     }
   },
+  "ChainAccountSignature": {
+    "_enum": {
+      "Comp": "([u8; 20], [u8; 65])",
+      "Eth": "([u8; 20], [u8; 65])",
+      "Dot": "([u8; 20], [u8; 65])",
+      "Sol": "([u8; 20], [u8; 65])",
+      "Tez": "([u8; 20], [u8; 65])"
+    }
+  },
   "ChainSignature": {
     "_enum": {
       "Comp": ["[u8; 65]"],
@@ -231,6 +240,19 @@
   },
 
   "Source6": "ReasonRS",
+  "TrxReqParseError": {
+    "_enum": [
+      "NotImplemented",
+      "LexError",
+      "InvalidAmount",
+      "InvalidAddress",
+      "InvalidArgs",
+      "UnknownFunction",
+      "InvalidExpression",
+      "InvalidChain",
+      "InvalidChainAccount"
+    ]
+  },
   "Reason": {
     "_enum": {
       "AssetExtractionNotSupported": "",
@@ -256,7 +278,12 @@
       "NotImplemented": "",
       "ParseIntError": "",
       "RepayTooMuch": "",
-      "SignatureMismatch": ""
+      "SignatureMismatch": "",
+      "AssetNotSupported": "",
+      "TrxRequestParseError": "TrxReqParseError",
+      "InvalidUTF8": "",
+      "SignatureAccountMismatch": "",
+      "IncorrectNonce": "(Nonce, Nonce)"
     }
   },
   "MathError": {


### PR DESCRIPTION
This patch adds account nonces to Compound Chain, specifically used when a user submits a trx request. The user will sign a message `5:(my-trx request)` which would indicate that the user's account nonce should be 5 when processing the trx request. We do not play fast-and-loose with the recovery values and instead require the user calls `exec_trx_request("(my-trx-request)", { Eth: [0xACCT, 0xSIG] }, 5)` to indicate the trx request, the account that signed it, the signature and the nonce. The reason for not side-stepping these additional input values is that we can easily reject invalid transactions at the `validate_unsigned` level without pulling data from storage (e.g. if a user submits a trx that he says is signed by John Hancock but is actually signed by Joe Exotic, we _know that_ and can reject it immediately). This is different from Ethereum where you have to always pay a gas cost on transactions as a spam prevention that would end up rejecting these invalid signatures there (e.g. it doesn't matter who purports to sign it, so long as the purported signer has Eth to pay for the trx, it's good. We aren't as obviously lucky there in a screening mechanism).

Finally, we refactor `exec_trx_request` into `core.rs` as is our current policy. We, additionally, add nonce ordering to `validate_unsigned` to properly process a given user's trx requests in order.