### PR TITLE
Remove `and_requires`

### DIFF
--- a/pallets/cash/src/core.rs
+++ b/pallets/cash/src/core.rs
@@ -779,6 +779,8 @@ pub fn exec_trx_request_internal<T: Config>(
     signature: ChainAccountSignature,
     nonce: Nonce,
 ) -> Result<(), Reason> {
+    log!("exec_trx_request_internal: {}", nonce);
+
     let request_str: &str = str::from_utf8(&request[..]).map_err(|_| Reason::InvalidUTF8)?;
 
     // Build Account=(Chain, Recover(Chain, Signature, NoncedRequest))

--- a/pallets/cash/src/lib.rs
+++ b/pallets/cash/src/lib.rs
@@ -931,12 +931,11 @@ impl<T: Config> frame_support::unsigned::ValidateUnsigned for Module<T> {
                     (Err(_e), _) => InvalidTransaction::Call.into(),
                     (Ok(sender), 0) => ValidTransaction::with_tag_prefix("CashPallet")
                         .longevity(10)
-                        .and_provides((sender, nonce))
+                        .and_provides((sender, 0))
                         .propagate(true)
                         .build(),
                     (Ok(sender), _) => ValidTransaction::with_tag_prefix("CashPallet")
                         .longevity(10)
-                        .and_requires((sender, nonce - 1))
                         .and_provides((sender, nonce))
                         .propagate(true)
                         .build(),


### PR DESCRIPTION
For some reason, the `and_requires` check is causing the extrinsic to get dropped or queued in the pool. As such, we're removing it since it will simply be checked later on.