### PR TITLE
Implement exp in a way that L1s can replicate

### DIFF
--- a/pallets/cash/src/params.rs
+++ b/pallets/cash/src/params.rs
@@ -7,7 +7,7 @@ use crate::types::{Quantity, Timestamp};
 pub const ETH_FINALIZATION_BLOCKS: u32 = 30; // XXX
 
 /// Number of milliseconds in a year.
-pub const MILLISECONDS_PER_YEAR: Timestamp = 31557600000; // todo: xxx finalize this number
+pub const MILLISECONDS_PER_YEAR: Timestamp = 365 * 24 * 60 * 60 * 1000; // todo: xxx finalize this number
 
 /// Minimum amount of time (milliseconds) into the future that a synchronized change may be scheduled for.
 /// Must be sufficient time to propagate changes to L1s before they occur.

--- a/pallets/cash/src/reason.rs
+++ b/pallets/cash/src/reason.rs
@@ -94,7 +94,7 @@ impl our_std::fmt::Display for Reason {
 }
 
 /// Type for reporting failures from calculations.
-#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, Debuggable)]
 pub enum MathError {
     AbnormalFloatingPointResult,
     DivisionByZero,

--- a/pallets/cash/src/types.rs
+++ b/pallets/cash/src/types.rs
@@ -425,7 +425,7 @@ impl CashPrincipal {
 pub struct CashIndex(pub Uint);
 
 impl CashIndex {
-    pub const DECIMALS: Decimals = 4;
+    pub const DECIMALS: Decimals = 18;
     pub const ONE: CashIndex = CashIndex(static_pow10(Self::DECIMALS));
 
     /// Get a CASH index from a string.


### PR DESCRIPTION
* implements exp using a 3rd degree mclaurin polynomial
* upgraded to bigint to support more accurate calculations and avoid overflow scenarios
* upgrade index decimals to 18 to track interest over the short horizons expected

todo:
* identify minimum measurable interest rate
* consider a taylor polynomial with a slightly better center, currently a = 0
  - this may actually be quite good in our situation, we expect to calculate interest over short time horizons in the usual case