### PR TITLE
Add Simple Actor Declarations

### DIFF
--- a/integration/__tests__/extract_scen.js
+++ b/integration/__tests__/extract_scen.js
@@ -1,5 +1,4 @@
 const {
-  years,
   buildScenarios,
 } = require('../util/scenario');
 const { getNotice } = require('../util/substrate');

--- a/integration/package.json
+++ b/integration/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "dependencies": {
     "@polkadot/api": "^3.4.1",
+    "chalk": "^4.1.0",
     "ganache-core": "^2.13.1",
     "web3": "^1.3.1"
   },

--- a/integration/util/scenario.js
+++ b/integration/util/scenario.js
@@ -1,5 +1,5 @@
 const { buildCtx } = require('./scenario/ctx');
-const { merge } = require('./util');
+const { merge, sleep } = require('./util');
 
 async function expectRevert(fn, reason) {
   // TODO: Expectation
@@ -72,4 +72,5 @@ module.exports = {
   merge,
   expectRevert,
   buildScenarios,
+  sleep,
 };

--- a/integration/util/scenario/ctx.js
+++ b/integration/util/scenario/ctx.js
@@ -1,6 +1,7 @@
 const { debug, log, error } = require('../log');
 const { merge, sleep } = require('../util');
 const path = require('path');
+const { declare } = require('./declare');
 
 const { baseScenInfo } = require('./scen_info');
 const { buildEth } = require('./eth');
@@ -84,6 +85,10 @@ class Ctx {
 
   api() {
     return this.validators.api();
+  }
+
+  declare(declareInfo, ...args) {
+    return declare(this, declareInfo, ...args);
   }
 
   getTestObject() {

--- a/integration/util/scenario/declare.js
+++ b/integration/util/scenario/declare.js
@@ -1,0 +1,64 @@
+const chalk = require('chalk');
+
+const colors = [
+  chalk.green,
+  chalk.yellow,
+  chalk.blue,
+  chalk.magenta,
+  chalk.cyan,
+  chalk.redBright,
+  chalk.greenBright,
+  chalk.yellowBright,
+  chalk.blueBright,
+  chalk.magentaBright,
+  chalk.cyanBright,
+];
+
+function colorize(id, msg) {
+  let colorFn = colors[id % colors.length];
+  return colorFn(msg);
+}
+
+async function declare(ctx, declareInfo, verb, info, fn) {
+  let {
+    name,
+    id,
+    colorId,
+    active,
+    past,
+    failed,
+  } = declareInfo;
+
+  let preamble = `[${name}]{action=${id}}: `;
+
+  let log = (x) => {
+    ctx.log(colorize(colorId, preamble + x));
+  }
+
+  let partsRaw = Array.isArray(info) ? info : [ info ];
+  let parts = partsRaw.map((part) => {
+    return typeof(part.show) === 'function' ? part.show() : part;
+  }).join(' ');
+
+  let showMsg = (tense) => {
+    let showVerb = tense === failed ? chalk.red(verb) : verb;
+    log(`${tense} ${showVerb} ${parts}`);
+  };
+
+  showMsg(active);
+
+  try {
+    let res = await fn();
+
+    showMsg(past);
+
+    return res;
+  } catch(e) {
+    showMsg(failed);
+    throw e;
+  }
+}
+
+module.exports = {
+  declare
+};

--- a/integration/util/scenario/scen_info.js
+++ b/integration/util/scenario/scen_info.js
@@ -24,6 +24,7 @@ const baseScenInfo = {
     use_temp: true,
     props: {}
   },
+  declare_opts: {},
   starport: {},
   cash_token: {
     initial_yield_index: '10000'

--- a/integration/util/scenario/token.js
+++ b/integration/util/scenario/token.js
@@ -42,6 +42,14 @@ class Token {
     return undec(weiAmount, this.decimals);
   }
 
+  show() {
+    return this.symbol;
+  }
+
+  showAmount(weiAmount) {
+    return `${this.toTokenAmount(weiAmount)} ${this.symbol}`;
+  }
+
   async getBalance(actorLookup) {
     let actor = this.ctx.actors.get(actorLookup);
     let balanceWei = await this.token.methods.balanceOf(actor.ethAddress()).call();

--- a/integration/yarn.lock
+++ b/integration/yarn.lock
@@ -2251,7 +2251,7 @@ chalk@^2.0.0, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==


### PR DESCRIPTION
This patch just adds a simple process for actors to "state" they are doing something, which is logged to the command line, and subsequently logs when it succeeds or fails. This is in preparation for more complex integration tests where it starts to get _very hard_ to understand the state of user actions when debugging a test ("wait, did Alice's lock go through before Bob tried to borrow?"). This is part of a larger PR that's being broken up to make it easier to merge.