### PR TITLE
Add ExecTrxRequest to Starport

### DIFF
--- a/ethereum/contracts/Starport.sol
+++ b/ethereum/contracts/Starport.sol
@@ -23,6 +23,7 @@ contract Starport {
 
     event Lock(address asset, address holder, uint amount);
     event LockCash(address holder, uint amount, uint128 principal);
+    event ExecTrxRequest(address account, string trxRequest);
     event Unlock(address account, uint amount, address asset);
     event UnlockCash(address account, uint amount, uint128 principal);
     event ChangeAuthorities(address[] newAuthorities);
@@ -65,6 +66,15 @@ contract Starport {
     function lockEth() public payable {
         require(address(this).balance <= supplyCaps[ETH_ADDRESS], "Supply Cap Exceeded");
         emit Lock(ETH_ADDRESS, msg.sender, msg.value);
+    }
+
+    /*
+     * @notice Emits an event s.t. a given trx request will execute as if called by `msg.sender`
+     * @dev Externally-owned accounts may call `execTrxRequest` with a signed message to avoid Ethereum fees.
+     * @param trxRequest An ASCII-encoded transaction request
+     */
+    function execTrxRequest(string calldata trxRequest) public payable {
+        emit ExecTrxRequest(msg.sender, trxRequest);
     }
 
     /**

--- a/ethereum/tests/starport_test.js
+++ b/ethereum/tests/starport_test.js
@@ -299,6 +299,19 @@ describe('Starport', () => {
     });
   });
 
+  describe('#execTrxRequest', () => {
+    it('should emit ExecTrxRequest event', async () => {
+      let trxRequest = `(Extract 100 CASH Eth:${account1})`;
+      const tx = await send(starport, 'execTrxRequest', [trxRequest], { from: account1 });
+      console.log({tx: tx.events.ExecTrxRequest});
+      console.log({tx: tx.events.ExecTrxRequest.raw});
+      expect(tx.events.ExecTrxRequest.returnValues).toMatchObject({
+        account: account1,
+        trxRequest
+      });
+    });
+  });
+
   describe('#executeProposal', () => {
     it('should emit ExecuteProposal event', async () => {
       const extrinsics = ["0x010203", "0x040506"]

--- a/integration/__tests__/extract_scen.js
+++ b/integration/__tests__/extract_scen.js
@@ -28,6 +28,18 @@ buildScenarios('Extract Scenarios', extract_scen_info, { beforeEach: lockUSDC },
     }
   },
   {
+    name: "Extract via Starport Action",
+    scenario: async ({ ashley, zrx, chain, starport, log }) => {
+      await ashley.execTrxRequest(ashley.extractTrxReq(50, zrx));
+      let notice = await chain.waitForNotice();
+      let signatures = await chain.getNoticeSignatures(notice);
+      expect(await ashley.tokenBalance(zrx)).toEqual(900);
+      await starport.invoke(notice, signatures);
+      expect(await ashley.tokenBalance(zrx)).toEqual(950);
+      expect(await ashley.chainBalance(zrx)).toEqual(50);
+    }
+  },
+  {
     skip: true,
     name: "Extract Cash",
     scenario: async ({ ashley, zrx, chain, starport, cash }) => {

--- a/integration/util/scenario/actor.js
+++ b/integration/util/scenario/actor.js
@@ -115,12 +115,23 @@ class Actor {
       let token = this.ctx.tokens.get(asset);
       let weiAmount = token.toWeiAmount(amount);
 
-      let trxReq = this.ctx.generateTrxReq("Extract", weiAmount, token, recipient || this);
+      let trxReq = this.extractTrxReq(amount, asset, recipient);
 
       this.ctx.log(`Running Trx Request \`${trxReq}\` from ${this.name}`);
 
       return await this.runTrxRequest(trxReq);
     });
+  }
+
+  async execTrxRequest(trxRequest, awaitEvent = true) {
+    return await this.ctx.starport.execTrxRequest(this, trxRequest, awaitEvent);
+  }
+
+  extractTrxReq(amount, asset, recipient = null) {
+    let token = this.ctx.tokens.get(asset);
+    let weiAmount = token.toWeiAmount(amount);
+
+    return this.ctx.generateTrxReq("Extract", weiAmount, token, recipient || this)
   }
 }
 

--- a/integration/util/scenario/chain.js
+++ b/integration/util/scenario/chain.js
@@ -1,4 +1,4 @@
-const { sendAndWaitForEvents, waitForEvent } = require('../substrate');
+const { sendAndWaitForEvents, waitForEvent, getEventData } = require('../substrate');
 const { sleep, arrayEquals, keccak256 } = require('../util');
 const {
   getNoticeChainId,
@@ -28,6 +28,15 @@ class Chain {
 
   async waitForEthProcessFailure(onFinalize = true) {
     return this.waitForEvent('cash', 'FailedProcessingEthEvent', onFinalize);
+  }
+
+  async waitForChainProcessed(onFinalize = true, failureEvent = null) {
+    // TODO: Match transaction id?
+    return await waitForEvent(this.api(), 'cash', 'ProcessedChainEvent', onFinalize, failureEvent);
+  }
+
+  async waitForNotice(onFinalize = true, failureEvent = null) {
+    return getEventData(await waitForEvent(this.api(), 'cash', 'Notice', onFinalize, failureEvent));
   }
 
   async getNoticeChain(notice) {

--- a/integration/util/scenario/starport.js
+++ b/integration/util/scenario/starport.js
@@ -68,6 +68,21 @@ class Starport {
     return await this.starport.methods.isNoticeUsed(noticeHash).call();
   }
 
+  async execTrxRequest(actorLookup, trxReq, awaitEvent = true) {
+    let actor = this.ctx.actors.get(actorLookup);
+
+    let event;
+    let tx = this.starport.methods.execTrxRequest(trxReq).send({ from: actor.ethAddress() });
+    if (awaitEvent) {
+      // TODO: Pass in log id?
+      event = await this.ctx.chain.waitForChainProcessed();
+    }
+    return {
+      tx,
+      event
+    };
+  }
+
   async invoke(notice, signaturePairs) {
     let encoded = notice.EncodedNotice;
     let signatures = signaturePairs.map(([signer, sig]) => sig.toHex());

--- a/pallets/cash/src/internal/exec_trx_request.rs
+++ b/pallets/cash/src/internal/exec_trx_request.rs
@@ -1,0 +1,52 @@
+use crate::{
+    chains::{CashAsset, ChainAccount},
+    core::{extract_cash_internal, extract_internal, symbol},
+    reason,
+    reason::Reason,
+    require,
+    symbol::CASH,
+    types::{Nonce, Quantity},
+    Config, Nonces,
+};
+use either::Left;
+use frame_support::storage::StorageMap;
+
+pub fn exec_trx_request<T: Config>(
+    request_str: &str,
+    sender: ChainAccount,
+    nonce_opt: Option<Nonce>,
+) -> Result<(), Reason> {
+    // Match TrxReq against known Transaction Requests
+    let trx_request = trx_request::parse_request(request_str)
+        .map_err(|e| Reason::TrxRequestParseError(reason::to_parse_error(e)))?;
+
+    if let Some(nonce) = nonce_opt {
+        // Read Require Nonce=Nonce_Account+1
+        let current_nonce = Nonces::get(sender);
+        require!(
+            nonce == current_nonce,
+            Reason::IncorrectNonce(nonce, current_nonce)
+        );
+    }
+
+    match trx_request {
+        trx_request::TrxRequest::Extract(amount, asset, account) => match CashAsset::from(asset) {
+            CashAsset::Cash => {
+                extract_cash_internal::<T>(sender, account.into(), Left(Quantity(CASH, amount)))?;
+            }
+            CashAsset::Asset(chain_asset) => {
+                let symbol = symbol(&chain_asset).ok_or(Reason::AssetNotSupported)?;
+                let quantity = Quantity(symbol, amount.into());
+
+                extract_internal::<T>(chain_asset, sender, account.into(), quantity)?;
+            }
+        },
+    }
+
+    if let Some(nonce) = nonce_opt {
+        // Update user nonce
+        Nonces::insert(sender, nonce + 1);
+    }
+
+    Ok(())
+}

--- a/pallets/cash/src/internal/mod.rs
+++ b/pallets/cash/src/internal/mod.rs
@@ -1,1 +1,2 @@
+pub mod exec_trx_request;
 pub mod set_yield_next;


### PR DESCRIPTION
This patch allows any contract (EOA or smart contract) to call `ExecTrxRequest("(Extract ...")`-style transaction requests to the Starport, which will be executed on Compound Chain.

Note: we do not track nonces for these actions, as they would be hard to track in the smart contract and are not necessary to prevent replay (there is no replay of Starport run transaction requests, except in the wild world of re-organizations).