### PR TITLE
Add Transfer Trx Request

### DIFF
--- a/integration/__tests__/transfer_scen.js
+++ b/integration/__tests__/transfer_scen.js
@@ -1,0 +1,41 @@
+const {
+  years,
+  buildScenarios,
+} = require('../util/scenario');
+const { getNotice } = require('../util/substrate');
+
+let transfer_scen_info = {
+  tokens: [
+    { token: "zrx", balances: { ashley: 1000 } }
+  ],
+};
+
+async function lockUSDC({ ashley, bert, zrx }) {
+  await ashley.lock(100, zrx);
+  expect(await ashley.tokenBalance(zrx)).toEqual(900);
+  expect(await ashley.chainBalance(zrx)).toEqual(100);
+  expect(await bert.chainBalance(zrx)).toEqual(0);
+}
+
+buildScenarios('Transfer Scenarios', transfer_scen_info, { beforeEach: lockUSDC }, [
+  {
+    name: "Transfer Collateral",
+    scenario: async ({ ashley, bert, zrx, chain, starport, log }) => {
+      await ashley.transfer(50, zrx, bert);
+      expect(await ashley.tokenBalance(zrx)).toEqual(900);
+      expect(await ashley.chainBalance(zrx)).toEqual(50);
+      expect(await bert.chainBalance(zrx)).toEqual(50);
+    }
+  },
+  {
+    skip: true,
+    name: "Transfer Cash",
+    scenario: async ({ ashley, bert, zrx, chain, starport, cash }) => {
+      let notice = await ashley.extract(50, cash);
+      expect(await cash.getCashPrincipal(ashley)).toEqual(5000); // ??
+      expect(await ashley.tokenBalance(cash)).toEqual(50);
+      expect(await ashley.chainBalance(cash)).toEqual(-50);
+      expect(await bert.chainBalance(cash)).toEqual(50);
+    }
+  }
+]);

--- a/integration/util/scenario/actor.js
+++ b/integration/util/scenario/actor.js
@@ -133,6 +133,19 @@ class Actor {
 
     return this.ctx.generateTrxReq("Extract", weiAmount, token, recipient || this)
   }
+
+  async transfer(amount, asset, recipient) {
+    return await this.declare("transfer", [amount, asset, "to", recipient], async () => {
+      let token = this.ctx.tokens.get(asset);
+      let weiAmount = token.toWeiAmount(amount);
+
+      let trxReq = this.ctx.generateTrxReq("Transfer", weiAmount, token, recipient);
+
+      this.ctx.log(`Running Trx Request \`${trxReq}\` from ${this.name}`);
+
+      return await this.runTrxRequest(trxReq);
+    });
+  }
 }
 
 class Actors {


### PR DESCRIPTION
This patch adds a `(Transfer ...)` trx request and hooks it up to the transfer internal functions. Overall, the code is pretty simple and follows the standard foundation we've built.