### PR TITLE
Add Extract Max Trx Request

### DIFF
--- a/integration/__tests__/extract_scen.js
+++ b/integration/__tests__/extract_scen.js
@@ -52,5 +52,20 @@ buildScenarios('Extract Scenarios', extract_scen_info, { beforeEach: lockUSDC },
       expect(await ashley.tokenBalance(cash)).toEqual(50);
       expect(await ashley.chainBalance(cash)).toEqual(-50);
     }
+  },
+  {
+    skip: true,
+    name: "Extract Cash Max",
+    scenario: async ({ ashley, zrx, chain, starport, cash }) => {
+      // TODO: Make sure user has Cash to begin scenario
+      let notice = getNotice(await ashley.extract('Max', cash));
+      let signatures = await chain.getNoticeSignatures(notice);
+      expect(await cash.getCashPrincipal(ashley)).toEqual(0);
+      expect(await ashley.tokenBalance(cash)).toEqual(0);
+      await starport.invoke(notice, signatures);
+      expect(await cash.getCashPrincipal(ashley)).toEqual(5000);
+      expect(await ashley.tokenBalance(cash)).toEqual(50);
+      expect(await ashley.chainBalance(cash)).toEqual(-50);
+    }
   }
 ]);

--- a/integration/__tests__/transfer_scen.js
+++ b/integration/__tests__/transfer_scen.js
@@ -31,7 +31,18 @@ buildScenarios('Transfer Scenarios', transfer_scen_info, { beforeEach: lockUSDC 
     skip: true,
     name: "Transfer Cash",
     scenario: async ({ ashley, bert, zrx, chain, starport, cash }) => {
-      let notice = await ashley.extract(50, cash);
+      let notice = await ashley.transfer(50, cash);
+      expect(await cash.getCashPrincipal(ashley)).toEqual(5000); // ??
+      expect(await ashley.tokenBalance(cash)).toEqual(50);
+      expect(await ashley.chainBalance(cash)).toEqual(-50);
+      expect(await bert.chainBalance(cash)).toEqual(50);
+    }
+  },
+  {
+    skip: true,
+    name: "Transfer Cash Max",
+    scenario: async ({ ashley, bert, zrx, chain, starport, cash }) => {
+      let notice = await ashley.transfer('Max', cash);
       expect(await cash.getCashPrincipal(ashley)).toEqual(5000); // ??
       expect(await ashley.tokenBalance(cash)).toEqual(50);
       expect(await ashley.chainBalance(cash)).toEqual(-50);

--- a/integration/util/scenario/cash_token.js
+++ b/integration/util/scenario/cash_token.js
@@ -12,6 +12,14 @@ class CashToken extends Token {
     return `CASH`;
   }
 
+  toWeiAmount(tokenAmount) {
+    if (tokenAmount === 'Max' || tokenAmount === 'MAX') {
+      return tokenAmount;
+    } else {
+      super.toWeiAmount(tokenAmount)
+    }
+  }
+
   async cashIndex() {
     return this.cashToken.methods.getCashIndex().call();
   }

--- a/pallets/cash/src/internal/exec_trx_request.rs
+++ b/pallets/cash/src/internal/exec_trx_request.rs
@@ -6,10 +6,10 @@ use crate::{
     reason::Reason,
     require,
     symbol::CASH,
-    types::{Nonce, Quantity},
-    Config, GlobalCashIndex, Nonces,
+    types::{CashPrincipal, Nonce, Quantity},
+    CashPrincipals, Config, GlobalCashIndex, Nonces,
 };
-use either::Left;
+use either::{Left, Right};
 use frame_support::storage::{StorageMap, StorageValue};
 
 pub fn exec_trx_request<T: Config>(
@@ -31,34 +31,78 @@ pub fn exec_trx_request<T: Config>(
     }
 
     match trx_request {
-        trx_request::TrxRequest::Extract(amount, asset, account) => match CashAsset::from(asset) {
-            CashAsset::Cash => {
-                core::extract_cash_internal::<T>(
-                    sender,
-                    account.into(),
-                    Left(Quantity(CASH, amount)),
-                )?;
-            }
-            CashAsset::Asset(chain_asset) => {
-                let symbol = symbol(&chain_asset).ok_or(Reason::AssetNotSupported)?;
-                let quantity = Quantity(symbol, amount.into());
+        trx_request::TrxRequest::Extract(max_amount, asset, account) => {
+            match CashAsset::from(asset) {
+                CashAsset::Cash => {
+                    let quantity = match max_amount {
+                        trx_request::MaxAmount::Max => {
+                            // Read Principal=CashPrincipal_Signer assuming CashPrincipal_Signer ≥ 0 or fail
+                            let cash_principal_signer = CashPrincipals::get(sender);
+                            require!(
+                                cash_principal_signer >= CashPrincipal::ZERO,
+                                Reason::MaxWithNegativeCashPrincipal
+                            );
 
-                core::extract_internal::<T>(chain_asset, sender, account.into(), quantity)?;
-            }
-        },
-        trx_request::TrxRequest::Transfer(amount, asset, account) => match CashAsset::from(asset) {
-            CashAsset::Cash => {
-                let index = GlobalCashIndex::get(); // XXX This is re-loaded in `transfer_cash_principal_internal`
-                let principal = index.as_hold_principal(Quantity(CASH, amount))?; // XXX We later re-calcuate the amount
-                core::transfer_cash_principal_internal::<T>(sender, account.into(), principal)?;
-            }
-            CashAsset::Asset(chain_asset) => {
-                let symbol = symbol(&chain_asset).ok_or(Reason::AssetNotSupported)?;
-                let quantity = Quantity(symbol, amount.into());
+                            Right(cash_principal_signer)
+                        }
 
-                core::transfer_internal::<T>(chain_asset, sender, account.into(), quantity)?;
+                        // XXX Should we check for negative amounts / principals?
+                        trx_request::MaxAmount::Amount(amount) => Left(Quantity(CASH, amount)),
+                    };
+
+                    core::extract_cash_internal::<T>(sender, account.into(), quantity)?;
+                }
+                CashAsset::Asset(chain_asset) => match max_amount {
+                    trx_request::MaxAmount::Max => {
+                        return Err(Reason::MaxForNonCashAsset);
+                    }
+                    trx_request::MaxAmount::Amount(amount) => {
+                        let symbol = symbol(&chain_asset).ok_or(Reason::AssetNotSupported)?;
+                        let quantity = Quantity(symbol, amount.into());
+
+                        core::extract_internal::<T>(chain_asset, sender, account.into(), quantity)?;
+                    }
+                },
             }
-        },
+        }
+        trx_request::TrxRequest::Transfer(max_amount, asset, account) => {
+            match CashAsset::from(asset) {
+                CashAsset::Cash => {
+                    let index = GlobalCashIndex::get(); // XXX This is re-loaded in `transfer_cash_principal_internal`
+
+                    let principal = match max_amount {
+                        trx_request::MaxAmount::Max => CashPrincipals::get(sender),
+                        trx_request::MaxAmount::Amount(amount) => {
+                            index.as_hold_principal(Quantity(CASH, amount))? // XXX We later re-calcuate the amount
+                        }
+                    };
+
+                    // XXX Where should we do this check
+                    require!(
+                        principal >= CashPrincipal::ZERO,
+                        Reason::MaxWithNegativeCashPrincipal
+                    );
+
+                    core::transfer_cash_principal_internal::<T>(sender, account.into(), principal)?;
+                }
+                CashAsset::Asset(chain_asset) => match max_amount {
+                    trx_request::MaxAmount::Max => {
+                        return Err(Reason::MaxForNonCashAsset);
+                    }
+                    trx_request::MaxAmount::Amount(amount) => {
+                        let symbol = symbol(&chain_asset).ok_or(Reason::AssetNotSupported)?;
+                        let quantity = Quantity(symbol, amount.into());
+
+                        core::transfer_internal::<T>(
+                            chain_asset,
+                            sender,
+                            account.into(),
+                            quantity,
+                        )?;
+                    }
+                },
+            }
+        }
     }
 
     if let Some(nonce) = nonce_opt {

--- a/pallets/cash/src/reason.rs
+++ b/pallets/cash/src/reason.rs
@@ -53,6 +53,8 @@ pub enum Reason {
     UnknownValidator,
     ValidatorAlreadySigned,
     SetYieldNextError(SetYieldNextError),
+    MaxForNonCashAsset,
+    MaxWithNegativeCashPrincipal,
 }
 
 impl From<MathError> for Reason {

--- a/types.json
+++ b/types.json
@@ -299,7 +299,9 @@
       "TrxRequestParseError": "TrxReqParseError",
       "UnknownValidator": "",
       "ValidatorAlreadySigned": "",
-      "SetYieldNextError": "SetYieldNextError"
+      "SetYieldNextError": "SetYieldNextError",
+      "MaxForNonCashAsset": "",
+      "MaxWithNegativeCashPrincipal": ""
     }
   },
   "MathError": {


### PR DESCRIPTION
This patch adds support for `(Extract Max Cash ...)` transation requests. We follow the spec here on how this functionality works. Note: we currently don't allow `(Extract Max Eth:0x... ...)` for asset extraction, but we could add such a feature in the future.