### PR TITLE
Run in Band

### DIFF
--- a/integration/package.json
+++ b/integration/package.json
@@ -14,6 +14,6 @@
     "jest-junit": "^12.0.0"
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest --runInBand"
   }
 }


### PR DESCRIPTION
This patch runs Jests tests serially. The hope is that this will improve CI runs' consistency until we can figure out why tests are non-isolated.