### PR TITLE
Fix cash index and add logging

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -205,7 +205,6 @@ fn testnet_genesis(
         }),
 
         pallet_cash: Some(CashConfig {
-            initial_yield: None,
             last_block_timestamp: wasm_timer::SystemTime::now()
                 .duration_since(wasm_timer::UNIX_EPOCH)
                 .expect("cannot get system time for genesis")
@@ -248,6 +247,9 @@ fn testnet_genesis(
                     eth_address: v.1,
                 })
                 .collect::<Vec<_>>(),
+
+
+            initial_yield: 8000,
         }),
     }
 }

--- a/pallets/cash/src/lib.rs
+++ b/pallets/cash/src/lib.rs
@@ -201,8 +201,8 @@ decl_storage! {
     }
     add_extra_genesis {
         config(assets): Vec<AssetInfo>;
-        config(initial_yield): Option<(APR, Timestamp)>;
         config(reporters): ReporterSet;
+        config(initial_yield): u128;
         config(validators): Vec<ValidatorKeys>;
         build(|config| {
             Module::<T>::initialize_assets(config.assets.clone());
@@ -632,11 +632,8 @@ impl<T: Config> Module<T> {
     }
 
     /// Set the initial cash yield, if provided
-    fn initialize_yield(initial_yield_config: Option<(APR, Timestamp)>) {
-        if let Some((initial_yield, initial_yield_start)) = initial_yield_config {
-            CashYield::put(initial_yield);
-            LastBlockTimestamp::put(initial_yield_start);
-        }
+    fn initialize_yield(initial_yield_config: u128) {
+        CashYield::put(APR(initial_yield_config));
     }
 
     /// Procedure for offchain worker to processes messages coming out of the open price feed

--- a/pallets/cash/src/types.rs
+++ b/pallets/cash/src/types.rs
@@ -425,7 +425,7 @@ impl CashPrincipal {
 pub struct CashIndex(pub Uint);
 
 impl CashIndex {
-    pub const DECIMALS: Decimals = 4;
+    pub const DECIMALS: Decimals = 18;
     pub const ONE: CashIndex = CashIndex(static_pow10(Self::DECIMALS));
 
     /// Get a CASH index from a string.


### PR DESCRIPTION
The problem here was that the interest index was not being incremented because
the level of precision was too low on CashIndex for a single period of interest.

This PR fixes that. There is probably some math we could do to figure out what
level of precision we need to support the minimum cash interest and block time combination

There really is no reason that we shouldn't have a high number of decimals on
cashIndex because it will be fairly close to 1 for a long time.