### PR TITLE
Make Notices Idempotent and Add Events

### DIFF
--- a/ethereum/contracts/test/StarportHarness.sol
+++ b/ethereum/contracts/test/StarportHarness.sol
@@ -17,11 +17,11 @@ contract StarportHarness is Starport {
 
 	/// Harness to call `checkNoticeSignerAuthorized`
 	function checkNoticeSignerAuthorized_(
-        bytes calldata notice,
+        bytes32 noticeHash,
         address[] memory authorities_,
         bytes[] calldata signatures
-    ) external view {
-		return checkNoticeSignerAuthorized(notice, authorities_, signatures);
+    ) external pure {
+		return checkNoticeSignerAuthorized(noticeHash, authorities_, signatures);
 	}
 
 	/// Harness to call `mint` on Cash Token


### PR DESCRIPTION
This patch makes it where we short-circuit as opposed to revert in the event that a notice is replayed. This is to handle this issue that certain notices are blockers and thus may be submitted to the chain by multiple parties to unblock their own notices. But if these are run _after_ another user plays that notice, you'd end up reverting for a large gas loss (and smart contract revert). As such, we'll simply emit an event and return when a notice is being replayed.

Additionally, we start to add events to notices. These will be useful to users and to Compound Chain which can know that a notice was used and no longer needs runtime information.

Finally, we save some gas by passing around the notice hash, as opposed to computing it twice.