### PR TITLE
Add Notice Execution Handler

### DIFF
--- a/ethereum-client/src/events.rs
+++ b/ethereum-client/src/events.rs
@@ -22,6 +22,12 @@ pub enum EthereumEvent {
         title: String,
         extrinsics: Vec<Vec<u8>>,
     },
+    NoticeInvoked {
+        era_id: u32,
+        era_index: u32,
+        notice_hash: [u8; 32],
+        result: Vec<u8>,
+    },
 }
 
 lazy_static! {
@@ -105,6 +111,33 @@ lazy_static! {
         anonymous: false
     };
     static ref EXECUTE_PROPOSAL_EVENT_TOPIC: ethabi::Hash = EXECUTE_PROPOSAL_EVENT.signature();
+    static ref NOTICE_INVOKED_EVENT: ethabi::Event = ethabi::Event {
+        name: String::from("NoticeInvoked"),
+        inputs: vec![
+            ethabi::EventParam {
+                name: String::from("eraId"),
+                kind: ethabi::param_type::ParamType::Uint(32),
+                indexed: false
+            },
+            ethabi::EventParam {
+                name: String::from("eraIndex"),
+                kind: ethabi::param_type::ParamType::Uint(32),
+                indexed: false
+            },
+            ethabi::EventParam {
+                name: String::from("noticeHash"),
+                kind: ethabi::param_type::ParamType::FixedBytes(32),
+                indexed: false
+            },
+            ethabi::EventParam {
+                name: String::from("result"),
+                kind: ethabi::param_type::ParamType::Bytes,
+                indexed: false
+            },
+        ],
+        anonymous: false
+    };
+    static ref NOTICE_INVOKED_EVENT_TOPIC: ethabi::Hash = NOTICE_INVOKED_EVENT.signature();
 }
 
 fn parse_lock_log(log: ethabi::Log) -> Result<EthereumEvent, EventError> {
@@ -189,6 +222,32 @@ fn parse_execute_proposal_log(log: ethabi::Log) -> Result<EthereumEvent, EventEr
     }
 }
 
+fn parse_notice_invoked_log(log: ethabi::Log) -> Result<EthereumEvent, EventError> {
+    match &log.params[..] {
+        [ethabi::LogParam {
+            value: ethabi::token::Token::Uint(era_id),
+            ..
+        }, ethabi::LogParam {
+            value: ethabi::token::Token::Uint(era_index),
+            ..
+        }, ethabi::LogParam {
+            value: ethabi::token::Token::FixedBytes(notice_hash),
+            ..
+        }, ethabi::LogParam {
+            value: ethabi::token::Token::Bytes(result),
+            ..
+        }] => Ok(EthereumEvent::NoticeInvoked {
+            era_id: (*era_id).try_into().map_err(|_| EventError::Overflow)?,
+            era_index: (*era_index).try_into().map_err(|_| EventError::Overflow)?,
+            notice_hash: notice_hash[..]
+                .try_into()
+                .map_err(|_| EventError::InvalidHash)?,
+            result: result.clone(), // TODO: Why the clones?
+        }),
+        _ => Err(EventError::InvalidLogParams),
+    }
+}
+
 #[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
 pub enum EventError {
     UnknownEventTopic,
@@ -196,6 +255,7 @@ pub enum EventError {
     InvalidHex,
     InvalidTopic,
     Overflow,
+    InvalidHash,
     InvalidLogParams,
 }
 
@@ -255,6 +315,15 @@ pub fn decode_event(topics: Vec<String>, data: String) -> Result<EthereumEvent, 
             .map_err(|_| EventError::ErrorParsingLog)?;
 
         parse_execute_proposal_log(log)
+    } else if *topic_hash == *NOTICE_INVOKED_EVENT_TOPIC {
+        let log: ethabi::Log = NOTICE_INVOKED_EVENT
+            .parse_log(ethabi::RawLog {
+                topics: topic_hashes,
+                data: decode_hex(&data)?,
+            })
+            .map_err(|_| EventError::ErrorParsingLog)?;
+
+        parse_notice_invoked_log(log)
     } else {
         Err(EventError::UnknownEventTopic)
     }
@@ -287,7 +356,7 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_gov_event() {
+    fn test_decode_execute_proposal_event() {
         let topics = vec![String::from(
             "0x97b9e105962881d0aea472b7f0335a84c21cce09bc7917f3db0ea5e4b23116e8",
         )];
@@ -298,6 +367,30 @@ mod tests {
             Ok(EthereumEvent::ExecuteProposal {
                 title: String::from("My Action"),
                 extrinsics: vec![vec![1, 2, 3], vec![4, 5, 6]]
+            })
+        )
+    }
+
+    #[test]
+    fn test_decode_notice_invoked_event() {
+        let topics = vec![String::from(
+            "0xedd00d39b017eafbdd1eb7463087942ca834c96b1aa19e2a5ae97afef538c1a3",
+        )];
+        let data =
+            String::from("0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000349cdbb0243b4c762c76bb3e56d84c8d6b0d6d256f6a47088902018bf89048979000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001");
+        assert_eq!(
+            decode_event(topics, data),
+            Ok(EthereumEvent::NoticeInvoked {
+                era_id: 0,
+                era_index: 3,
+                notice_hash: [
+                    73, 205, 187, 2, 67, 180, 199, 98, 199, 107, 179, 229, 109, 132, 200, 214, 176,
+                    214, 210, 86, 246, 164, 112, 136, 144, 32, 24, 191, 137, 4, 137, 121
+                ],
+                result: vec![
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 1
+                ],
             })
         )
     }

--- a/ethereum/contracts/Starport.sol
+++ b/ethereum/contracts/Starport.sol
@@ -21,7 +21,7 @@ contract Starport {
     uint public eraId; // TODO: could bitpack here and use uint32
     mapping(bytes32 => bool) public isNoticeInvoked;
 
-    event NoticeInvoked(uint eraId, uint eraIndex, bytes32 noticeHash, bytes result);
+    event NoticeInvoked(uint32 eraId, uint32 eraIndex, bytes32 noticeHash, bytes result);
     event NoticeReplay(bytes32 noticeHash);
 
     event Lock(address asset, address holder, uint amount);
@@ -233,7 +233,7 @@ contract Starport {
             require(false, _getRevertMsg(callResult));
         }
 
-        emit NoticeInvoked(noticeEraId, noticeEraIndex, noticeHash, callResult);
+        emit NoticeInvoked(uint32(noticeEraId), uint32(noticeEraIndex), noticeHash, callResult);
 
         return callResult;
     }

--- a/pallets/cash/src/core.rs
+++ b/pallets/cash/src/core.rs
@@ -360,6 +360,8 @@ pub fn apply_chain_event_internal<T: Config>(event: ChainLogEvent) -> Result<(),
 
                 ethereum_client::events::EthereumEvent::ExecTrxRequest { account, trx_request } =>
                     internal::exec_trx_request::exec_trx_request::<T>(&trx_request[..], ChainAccount::Eth(account), None),
+
+                ethereum_client::events::EthereumEvent::NoticeInvoked { era_id, era_index, notice_hash, result } => internal::notices::handle_notice_invoked::<T>(ChainId::Eth, NoticeId(era_id, era_index), ChainHash::Eth(notice_hash), result),
             }
         }
     }

--- a/pallets/cash/src/internal/mod.rs
+++ b/pallets/cash/src/internal/mod.rs
@@ -1,2 +1,3 @@
 pub mod exec_trx_request;
+pub mod notices;
 pub mod set_yield_next;

--- a/pallets/cash/src/internal/notices.rs
+++ b/pallets/cash/src/internal/notices.rs
@@ -1,0 +1,138 @@
+use crate::{
+    chains::{ChainHash, ChainId},
+    notices::{NoticeId, NoticeState},
+    reason::Reason,
+    require, Config, NoticeHashes, NoticeStates, Notices,
+};
+use frame_support::storage::{StorageDoubleMap, StorageMap};
+
+pub fn handle_notice_invoked<T: Config>(
+    chain_id: ChainId,
+    notice_id: NoticeId,
+    notice_hash: ChainHash,
+    _result: Vec<u8>,
+) -> Result<(), Reason> {
+    require!(
+        NoticeHashes::get(notice_hash) == Some(notice_id),
+        Reason::MismatchedNoticeHash
+    );
+    Notices::take(chain_id, notice_id);
+    NoticeStates::insert(chain_id, notice_id, NoticeState::Executed);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        chains::ChainSignatureList,
+        mock::*,
+        notices::{ExtractionNotice, Notice},
+    };
+
+    #[test]
+    fn test_handle_proper_notice() {
+        new_test_ext().execute_with(|| {
+            let chain_id = ChainId::Eth;
+            let notice_id = NoticeId(5, 6);
+            let notice_hash = ChainHash::Eth([1; 32]);
+            let notice = Notice::ExtractionNotice(ExtractionNotice::Eth {
+                id: NoticeId(80, 1),
+                parent: [3u8; 32],
+                asset: [1; 20],
+                amount: 100,
+                account: [2; 20],
+            });
+
+            NoticeHashes::insert(notice_hash, notice_id);
+            Notices::insert(chain_id, notice_id, notice);
+            NoticeStates::insert(
+                chain_id,
+                notice_id,
+                NoticeState::Pending {
+                    signature_pairs: ChainSignatureList::Eth(vec![]),
+                },
+            );
+
+            let result = handle_notice_invoked::<Test>(chain_id, notice_id, notice_hash, vec![]);
+
+            assert_eq!(result, Ok(()));
+
+            assert_eq!(NoticeHashes::get(notice_hash), Some(notice_id));
+            assert_eq!(Notices::get(chain_id, notice_id), None);
+            assert_eq!(
+                NoticeStates::get(chain_id, notice_id),
+                NoticeState::Executed
+            );
+        });
+    }
+
+    #[test]
+    fn test_when_notice_missing() {
+        new_test_ext().execute_with(|| {
+            let chain_id = ChainId::Eth;
+            let notice_id = NoticeId(5, 6);
+            let notice_hash = ChainHash::Eth([1; 32]);
+            let notice = Notice::ExtractionNotice(ExtractionNotice::Eth {
+                id: NoticeId(80, 1),
+                parent: [3u8; 32],
+                asset: [1; 20],
+                amount: 100,
+                account: [2; 20],
+            });
+
+            NoticeHashes::insert(notice_hash, notice_id);
+
+            let result = handle_notice_invoked::<Test>(chain_id, notice_id, notice_hash, vec![]);
+
+            assert_eq!(result, Ok(()));
+
+            assert_eq!(NoticeHashes::get(notice_hash), Some(notice_id));
+            assert_eq!(Notices::get(chain_id, notice_id), None);
+            assert_eq!(
+                NoticeStates::get(chain_id, notice_id),
+                NoticeState::Executed
+            );
+        });
+    }
+
+    #[test]
+    fn test_handle_mismatched_notice() {
+        new_test_ext().execute_with(|| {
+            let chain_id = ChainId::Eth;
+            let notice_id = NoticeId(5, 6);
+            let notice_hash = ChainHash::Eth([1; 32]);
+            let notice = Notice::ExtractionNotice(ExtractionNotice::Eth {
+                id: NoticeId(80, 1),
+                parent: [3u8; 32],
+                asset: [1; 20],
+                amount: 100,
+                account: [2; 20],
+            });
+
+            NoticeHashes::insert(notice_hash, notice_id);
+            Notices::insert(chain_id, notice_id, notice.clone());
+            NoticeStates::insert(
+                chain_id,
+                notice_id,
+                NoticeState::Pending {
+                    signature_pairs: ChainSignatureList::Eth(vec![]),
+                },
+            );
+
+            let result =
+                handle_notice_invoked::<Test>(chain_id, NoticeId(66, 77), notice_hash, vec![]);
+
+            assert_eq!(result, Err(Reason::MismatchedNoticeHash));
+
+            assert_eq!(NoticeHashes::get(notice_hash), Some(notice_id));
+            assert_eq!(Notices::get(chain_id, notice_id), Some(notice));
+            assert_eq!(
+                NoticeStates::get(chain_id, notice_id),
+                NoticeState::Pending {
+                    signature_pairs: ChainSignatureList::Eth(vec![]),
+                }
+            );
+        });
+    }
+}

--- a/pallets/cash/src/reason.rs
+++ b/pallets/cash/src/reason.rs
@@ -55,6 +55,7 @@ pub enum Reason {
     SetYieldNextError(SetYieldNextError),
     MaxForNonCashAsset,
     MaxWithNegativeCashPrincipal,
+    MismatchedNoticeHash,
 }
 
 impl From<MathError> for Reason {

--- a/types.json
+++ b/types.json
@@ -312,7 +312,8 @@
       "ValidatorAlreadySigned": "",
       "SetYieldNextError": "SetYieldNextError",
       "MaxForNonCashAsset": "",
-      "MaxWithNegativeCashPrincipal": ""
+      "MaxWithNegativeCashPrincipal": "",
+      "MismatchedNoticeHash": "",
     }
   },
   "MathError": {


### PR DESCRIPTION
This patch handles `NoticeInvoked` and clears related storage on Compound Chain. This is part of a general strategy on long-term scalability and is a clear and obvious win in that category.