### PR TITLE
Upgrade the calculation of asset interest and increase some precision (WIP)

### DIFF
--- a/pallets/cash/src/symbol.rs
+++ b/pallets/cash/src/symbol.rs
@@ -13,7 +13,7 @@ pub struct Symbol(pub [u8; WIDTH], pub u8);
 // Define symbols used directly by the chain itself
 
 /// Symbol for CASH.
-pub const CASH: Symbol = Symbol::new("CASH", 6);
+pub const CASH: Symbol = Symbol::new("CASH", 18);
 
 /// Symbol for USD.
 pub const USD: Symbol = Symbol::new("USD", 6);


### PR DESCRIPTION
Warning - this increased precision may lead to overflow in some undesirable scenarios especially when we need to compute interest over longer time horizons for example in the case of a chain halt.

This is to demonstrate that this really is the root of the problem and that there is a way to patch it for now and see asset interest accumulate.

Some possibly interesting logs 

```
{ cash0: 0, cash1: 0, cash2: -1.204234471e+33 }
```

```
stderr: 2021-02-17 12:44:30.011   INFO tokio-runtime-worker pallet_cash::core:compute_cash_principal_per_internal(312, 5998, 313242, 4629309255404082740)=401255392
stderr: 2021-02-17 12:44:30.011   INFO tokio-runtime-worker pallet_cash::core:compute_cash_principal_per_internal(156, 5998, 313242, 4629309255404082740)=200627696
```