### PR TITLE
Make interest rates actually apply over time to assets and cash

### DIFF
--- a/integration/util/scenario/chain_spec.js
+++ b/integration/util/scenario/chain_spec.js
@@ -55,7 +55,8 @@ async function baseChainSpec(validatorsInfoHash, tokensInfoHash, ctx) {
   let initialYieldConfig = {};
   if (ctx.__initialYield() > 0) {
     initialYieldConfig = {
-      initialYield: [ctx.__initialYield(), ctx.__initialYieldStart()]
+      cashYield: ctx.__initialYield(),
+      lastYieldTimestamp: ctx.__initialYieldStart()
     };
   }
 

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -205,8 +205,8 @@ fn testnet_genesis(
         }),
 
         pallet_cash: Some(CashConfig {
-            initial_yield: None,
-            last_block_timestamp: wasm_timer::SystemTime::now()
+            cash_yield: FromStr::from_str("0").unwrap(),
+            last_yield_timestamp: wasm_timer::SystemTime::now()
                 .duration_since(wasm_timer::UNIX_EPOCH)
                 .expect("cannot get system time for genesis")
                 .as_millis(),

--- a/pallets/cash/src/internal/set_yield_next.rs
+++ b/pallets/cash/src/internal/set_yield_next.rs
@@ -138,7 +138,7 @@ mod tests {
                 id: expected_notice_id,
                 parent: [0u8; 32],
                 next_cash_yield: 100,
-                next_cash_index: 10000,
+                next_cash_index: 1000000000000000000,
                 next_cash_yield_start: 86400500,
             });
 

--- a/pallets/cash/src/params.rs
+++ b/pallets/cash/src/params.rs
@@ -7,7 +7,7 @@ use crate::types::{Quantity, Timestamp};
 pub const ETH_FINALIZATION_BLOCKS: u32 = 30; // XXX
 
 /// Number of milliseconds in a year.
-pub const MILLISECONDS_PER_YEAR: Timestamp = 31557600000; // todo: xxx finalize this number
+pub const MILLISECONDS_PER_YEAR: Timestamp = 365 * 24 * 60 * 60 * 1000; // todo: xxx finalize this number
 
 /// Minimum amount of time (milliseconds) into the future that a synchronized change may be scheduled for.
 /// Must be sufficient time to propagate changes to L1s before they occur.

--- a/pallets/cash/src/rates.rs
+++ b/pallets/cash/src/rates.rs
@@ -4,9 +4,11 @@ use our_std::{Deserialize, RuntimeDebug, Serialize};
 
 use crate::{
     params::MILLISECONDS_PER_YEAR,
-    reason::MathError,
+    reason::{MathError, Reason},
     types::{uint_from_string_with_decimals, AssetAmount, CashIndex, Timestamp, Uint},
 };
+use num_bigint::BigInt;
+use num_traits::ToPrimitive;
 
 /// Error enum for interest rates
 #[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
@@ -36,35 +38,50 @@ impl From<Uint> for APR {
 impl APR {
     pub const DECIMALS: u8 = 4;
     pub const ZERO: APR = APR::from_nominal("0");
+    pub const ONE: APR = APR::from_nominal("1");
     pub const MAX: APR = APR::from_nominal("0.35"); // 35%
 
     pub const fn from_nominal(s: &'static str) -> Self {
         APR(uint_from_string_with_decimals(Self::DECIMALS, s))
     }
 
-    fn as_f64(self) -> f64 {
-        (self.0 as f64) / 10f64.powf(Self::DECIMALS as f64)
-    }
-
     /// exp{r * dt} where dt is change in time in seconds
     // XXX why is this an index, should it be a CashIndexDelta or something?
     pub fn over_time(self, dt: Timestamp) -> Result<CashIndex, MathError> {
-        let increment = (self.as_f64() * (dt as f64) / (MILLISECONDS_PER_YEAR as f64)).exp()
-            * 10f64.powf(CashIndex::DECIMALS as f64);
-        if !increment.is_normal() {
-            // this can happen when increment is + infinity for example
-            return Err(MathError::AbnormalFloatingPointResult);
+        let index_scale = &BigInt::from(CashIndex::ONE.0);
+        let scaled_rate: &BigInt =
+            &(index_scale * self.0 * dt / MILLISECONDS_PER_YEAR / APR::ONE.0);
+        let t1 = index_scale * index_scale * index_scale; //     1
+        let t2 = scaled_rate * index_scale * index_scale; //     x
+        let t3 = scaled_rate * scaled_rate * index_scale / 2; // x^2 / 2
+        let t4 = scaled_rate * scaled_rate * scaled_rate / 6; // x^3 / 6
+        let unscaled = t1 + t2 + t3 + t4;
+        let scaled: BigInt = unscaled / index_scale / index_scale;
+        if let Some(raw) = scaled.to_u128() {
+            Ok(CashIndex(raw))
+        } else {
+            Err(MathError::Overflow)
         }
-        if increment > (Uint::max_value() as f64) {
-            return Err(MathError::Overflow);
-        }
-        Ok(CashIndex(increment as Uint))
     }
 }
 
 impl Default for APR {
     fn default() -> Self {
         APR(0)
+    }
+}
+
+impl our_std::str::FromStr for APR {
+    type Err = Reason;
+
+    fn from_str(string: &str) -> Result<Self, Self::Err> {
+        Ok(APR(u128::from_str(string).map_err(|_| Reason::InvalidAPR)?))
+    }
+}
+
+impl From<APR> for String {
+    fn from(string: APR) -> Self {
+        format!("{}", string.0)
     }
 }
 
@@ -641,10 +658,57 @@ mod test {
 
     #[test]
     fn test_over_time() {
-        let r = APR::from_nominal("0.2"); // 20% per year
-        let dt = MILLISECONDS_PER_YEAR / 2; // for 6 months
-        let actual = r.over_time(dt).unwrap(); // compounded continuously
-        let expected = CashIndex::from_nominal("1.1051"); // from google sheets
-        assert_eq!(actual, expected);
+        let mut rates = vec!["0", "0.0001", "0.03", "0.1", "0.2"];
+        // XXX should positively assert some failures here instead of commenting these out?
+        // let months_per_year = 12;
+        // let weeks_per_year = 52;
+        let days_per_year = 365;
+        let hours_per_year = days_per_year * 24;
+        let minutes_per_year = hours_per_year * 60;
+        let seconds_per_year = minutes_per_year * 60;
+
+        let year_fractions = vec![
+            // months_per_year,
+            // weeks_per_year,
+            // days_per_year,
+            hours_per_year,
+            minutes_per_year,
+            seconds_per_year,
+        ];
+
+        for rate in rates.drain(..) {
+            for year_frac in year_fractions.iter() {
+                let r = APR::from_nominal(rate);
+                let dt = MILLISECONDS_PER_YEAR / year_frac;
+                let actual = match r.over_time(dt) {
+                    Ok(actual) => actual,
+                    Err(e) => panic!(
+                        "Math error during over_time  r = {}, year_frac = {}, error = {:?}",
+                        rate, year_frac, e
+                    ),
+                };
+
+                let float_rate = (r.0 as f64) / 10f64.powf(APR::DECIMALS as f64);
+                let float_rate_over_time =
+                    float_rate * (dt as f64) / (MILLISECONDS_PER_YEAR as f64);
+                let float_exact_reference = float_rate_over_time.exp();
+                let float_exact_as_uint =
+                    (float_exact_reference * (CashIndex::ONE.0 as f64)) as u128;
+                let error_wei = if float_exact_as_uint > actual.0 {
+                    float_exact_as_uint - actual.0
+                } else {
+                    actual.0 - float_exact_as_uint
+                };
+
+                assert!(error_wei < 1000, "exp test case out of range");
+                // println!(
+                //     "{}, {}, {}, {}",
+                //     rate,
+                //     year_frac,
+                //     actual.0,
+                //     float_exact_reference * (CashIndex::ONE.0 as f64)
+                // );
+            }
+        }
     }
 }

--- a/pallets/cash/src/reason.rs
+++ b/pallets/cash/src/reason.rs
@@ -5,11 +5,11 @@ use crate::oracle::OracleError;
 use crate::rates::RatesError;
 use crate::types::Nonce;
 use codec::{Decode, Encode};
-use our_std::{Debuggable, RuntimeDebug};
+use our_std::RuntimeDebug;
 use trx_request;
 
 /// Type for reporting failures for reasons outside of our control.
-#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, Debuggable)]
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
 pub enum Reason {
     AssetExtractionNotSupported, // XXX temporary?
     AssetNotSupported,
@@ -29,6 +29,7 @@ pub enum Reason {
     InsufficientChainCash,
     InsufficientLiquidity,
     InsufficientTotalFunds,
+    InvalidAPR,
     InvalidLiquidityFactor,
     InvalidSignature,
     InvalidUTF8,
@@ -109,7 +110,7 @@ pub enum MathError {
     UnitsMismatch,
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, Debuggable)]
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
 pub enum TrxReqParseError {
     NotImplemented,
     LexError,

--- a/pallets/cash/src/symbol.rs
+++ b/pallets/cash/src/symbol.rs
@@ -77,7 +77,7 @@ pub struct Units {
 // Define units used directly by the chain itself
 
 /// Units for CASH.
-pub const CASH: Units = Units::from_ticker_str("CASH", 6);
+pub const CASH: Units = Units::from_ticker_str("CASH", 18);
 
 /// Units for USD.
 pub const USD: Units = Units::from_ticker_str("USD", 6);


### PR DESCRIPTION
problem

Interest rates were not working correctly due to underflows in cash index precision and asset index precision.

solution

* implements asset index with increased precision by calculating with bigint rather than u128
* add price_cash as per spec to asset index calculation
* implement exp in a way compatible with L1s - use increased precision via biguint 
* increase asset index decimals
* increase cash index decimals
* no worries about overflows now thanks to bigint
