### PR TITLE
Check Failures

### DIFF
--- a/pallets/cash/src/oracle.rs
+++ b/pallets/cash/src/oracle.rs
@@ -1,10 +1,11 @@
 use crate::Timestamp;
+use codec::{Decode, Encode};
 use our_std::{collections::btree_map::BTreeMap, vec::Vec, Debuggable};
 use serde::Deserialize;
 use sp_runtime::offchain::{http, Duration};
 
 /// Errors coming from the price oracle
-#[derive(Debuggable)]
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, Debuggable)]
 pub enum OracleError {
     HexParseError,
     EthAbiParseError,
@@ -13,6 +14,7 @@ pub enum OracleError {
     JsonParseError,
     HttpError,
     InvalidOpenOracleApiResponse,
+    InvalidSymbol,
 }
 
 /// A single decoded message from the price oracle

--- a/pallets/cash/src/reason.rs
+++ b/pallets/cash/src/reason.rs
@@ -1,6 +1,7 @@
 use crate::chains::ChainId;
 use crate::internal::set_yield_next::SetYieldNextError;
 use crate::notices::NoticeId;
+use crate::oracle::OracleError;
 use crate::rates::RatesError;
 use crate::types::Nonce;
 use codec::{Decode, Encode};
@@ -42,12 +43,14 @@ pub enum Reason {
     NoticeAlreadySigned,
     NoticeMissing(ChainId, NoticeId),
     NotImplemented,
+    OracleError(OracleError),
     ParseIntError,
     RatesError(RatesError),
     RepayTooMuch,
     SelfTransfer,
     SignatureAccountMismatch,
     SignatureMismatch,
+    StringError,
     TimeTravelNotAllowed,
     TrxRequestParseError(TrxReqParseError),
     UnknownValidator,

--- a/types.json
+++ b/types.json
@@ -313,7 +313,7 @@
       "SetYieldNextError": "SetYieldNextError",
       "MaxForNonCashAsset": "",
       "MaxWithNegativeCashPrincipal": "",
-      "MismatchedNoticeHash": "",
+      "MismatchedNoticeHash": ""
     }
   },
   "MathError": {


### PR DESCRIPTION
This patch is an attempt to improve the failure system overall of Compound Chain. Specifically, we emit events on failure that should make it easy for clients to understand failures. Additionally, as we've solidified around `Reason` as the core error type, we no longer need a macro for error handling. Finally, we fix our event watching system to make it where our clients will be able to get consistent errors without repeats.