### PR TITLE
Minor Integration Patches

### DIFF
--- a/integration/util/scenario/actor.js
+++ b/integration/util/scenario/actor.js
@@ -5,7 +5,6 @@ const { sendAndWaitForEvents } = require('../substrate');
 const { lookupBy } = require('../util');
 const { CashToken } = require('./cash_token');
 
-
 class Actor {
   constructor(name, ethAddress, chainKey, ctx) {
     this.name = name;

--- a/integration/util/substrate.js
+++ b/integration/util/substrate.js
@@ -1,5 +1,5 @@
 const { debug, log } = require('./log');
-const { arrayToHex, concatArray } = require('./util');
+const { arrayToHex, concatArray, sleep } = require('./util');
 const types = require('@polkadot/types');
 
 // TODO: Consider moving these vars into ctx
@@ -14,12 +14,17 @@ let callbacks = [];
 // TODO: Refactor here?
 function subscribeEvents(api) {
   api.query.system.events((events) => {
-    events.forEach(({ event }) => {
-      debug(`Found event: ${event.section}:${event.method}`);
+    events.forEach(({ event, phase }) => {
+      debug(`Found event: ${event.section}:${event.method} [${phase.toString()}]`);
     });
+    // TODO: Clean this up
+    sleep(5000).then(() => {
+      // let finalizedEvents = events.filter(({phase}) => phase.Finalization);
+      // debug(`Found ${finalizedEvents.length } finalized event(s)`);
 
-    allEvents = [...allEvents, ...events];
-    callbacks.forEach((callback) => callback(allEvents));
+      allEvents = [...allEvents, ...events];
+      callbacks.forEach((callback) => callback(allEvents));
+    });
   });
 }
 

--- a/pallets/cash/src/core.rs
+++ b/pallets/cash/src/core.rs
@@ -402,6 +402,7 @@ fn set_asset_balance_internal(asset: ChainAsset, account: ChainAccount, balance:
     } else {
         AssetsWithNonZeroBalance::insert(account, asset, ());
     }
+
     AssetBalances::insert(asset, account, balance);
 }
 

--- a/types.json
+++ b/types.json
@@ -381,6 +381,12 @@
       "ExecuteProposal": {
         "title": "String",
         "extrinsics": "Vec<Vec<u8>>"
+      },
+      "NoticeInvoked": {
+        "era_id": "u32",
+        "era_index": "u32",
+        "notice_hash": "[u8; 32]",
+        "result": "Vec<u8>"
       }
     }
   },


### PR DESCRIPTION
This patch is to help integration tests pass more frequently. There's honestly a lot of work to do as tests get significantly more complex. We now have session changeover, etc, so it's not... not easy to make these consistently pass.

The core hack here is to give events some time when we see them to when we pass them back to the caller s.t. they can be incorporated in a new block. We need a better event polling system or to pair an event polling system with a block polling system to check finality better.

We also add an improvement to print out `types.json` errors since they come up so often.