### PR TITLE
Add internals for set code next, support asset, and refactor

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -6,7 +6,7 @@ on: push
 jobs:
   cargo-format:
     name: Cargo Format Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -19,7 +19,7 @@ jobs:
 
   substrate-tests:
     name: Substrate Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/pallets/cash/src/events.rs
+++ b/pallets/cash/src/events.rs
@@ -57,8 +57,10 @@ pub enum EventError {
     ErrorDecodingHex,
 }
 
+// XXX does this belong here? all very eth specific...
+//  whats the separate with internal?
 /// Fetch all latest Starport events for the offchain worker.
-pub fn fetch_events(from_block: String) -> Result<EventInfo, EventError> {
+pub fn fetch_eth_events(from_block: String) -> Result<EventInfo, EventError> {
     // Get a validator config from runtime-interfaces pallet
     // Use config to get an address for interacting with Ethereum JSON RPC client
     let config = runtime_interfaces::config_interface::get();
@@ -157,7 +159,7 @@ pub mod tests {
 
         let (mut t, _pool_state, _offchain_state) = new_test_ext_with_http_calls(calls);
         t.execute_with(|| {
-            let events_candidate = events::fetch_events("earliest".to_string());
+            let events_candidate = events::fetch_eth_events("earliest".to_string());
             assert!(events_candidate.is_ok());
             let starport_info = events_candidate.unwrap();
             let latest_eth_block = starport_info.latest_eth_block;
@@ -208,7 +210,7 @@ pub mod tests {
 
         let (mut t, _pool_state, _offchain_state) = new_test_ext_with_http_calls(calls);
         t.execute_with(|| {
-            let events_candidate = events::fetch_events("earliest".to_string());
+            let events_candidate = events::fetch_eth_events("earliest".to_string());
             assert!(events_candidate.is_ok());
             let event_info = events_candidate.unwrap();
             let latest_eth_block = event_info.latest_eth_block;

--- a/pallets/cash/src/internal/assets.rs
+++ b/pallets/cash/src/internal/assets.rs
@@ -1,0 +1,46 @@
+use frame_support::storage::StorageMap;
+
+use crate::{
+    chains::ChainAsset,
+    core::get_asset,
+    rates::InterestRateModel,
+    reason::Reason,
+    types::{AssetInfo, LiquidityFactor},
+    Config, SupportedAssets,
+};
+
+pub fn set_liquidity_factor<T: Config>(
+    asset: ChainAsset,
+    factor: LiquidityFactor,
+) -> Result<(), Reason> {
+    let asset_info = get_asset::<T>(asset)?;
+    SupportedAssets::insert(
+        &asset,
+        AssetInfo {
+            liquidity_factor: factor,
+            ..asset_info
+        },
+    );
+    Ok(())
+}
+
+pub fn set_rate_model<T: Config>(
+    asset: ChainAsset,
+    model: InterestRateModel,
+) -> Result<(), Reason> {
+    let asset_info = get_asset::<T>(asset)?;
+    model.check_parameters()?;
+    SupportedAssets::insert(
+        &asset,
+        AssetInfo {
+            rate_model: model,
+            ..asset_info
+        },
+    );
+    Ok(())
+}
+
+pub fn support_asset<T: Config>(asset: ChainAsset, asset_info: AssetInfo) -> Result<(), Reason> {
+    SupportedAssets::insert(&asset, asset_info);
+    Ok(())
+}

--- a/pallets/cash/src/internal/change_validators.rs
+++ b/pallets/cash/src/internal/change_validators.rs
@@ -1,0 +1,14 @@
+use frame_support::storage::{IterableStorageMap, StorageMap};
+
+use crate::{reason::Reason, types::ValidatorKeys, Config, NextValidators};
+
+pub fn change_validators<T: Config>(validators: Vec<ValidatorKeys>) -> Result<(), Reason> {
+    for (id, _keys) in <NextValidators>::iter() {
+        <NextValidators>::take(&id);
+    }
+    for keys in &validators {
+        <NextValidators>::take(&keys.substrate_id);
+        <NextValidators>::insert(&keys.substrate_id, keys);
+    }
+    Ok(())
+}

--- a/pallets/cash/src/internal/events.rs
+++ b/pallets/cash/src/internal/events.rs
@@ -1,0 +1,181 @@
+use codec::Encode;
+use frame_support::storage::{IterableStorageMap, StorageMap};
+use frame_system::offchain::SubmitTransaction;
+use sp_runtime::offchain::{
+    storage::StorageValueRef,
+    storage_lock::{StorageLock, Time},
+};
+
+use crate::{
+    chains::{Chain, Ethereum},
+    core::{apply_chain_event_internal, passes_validation_threshold},
+    events::{encode_block_hex, fetch_eth_events, ChainLogEvent, ChainLogId, EventState},
+    log,
+    reason::Reason,
+    types::ValidatorSig,
+    Call, Config, Event as EventT, EventStates, Module, Validators,
+};
+
+// OCW storage constants
+const OCW_STORAGE_LOCK_ETHEREUM_EVENTS: &[u8; 34] = b"cash::storage_lock_ethereum_events";
+const OCW_LATEST_CACHED_ETHEREUM_BLOCK: &[u8; 34] = b"cash::latest_cached_ethereum_block";
+
+// XXX disambiguate whats for ethereum vs not
+pub fn fetch_events<T: Config>() -> Result<(), Reason> {
+    let s_info = StorageValueRef::persistent(OCW_LATEST_CACHED_ETHEREUM_BLOCK);
+
+    let from_block: String = if let Some(Some(cached_block_num)) = s_info.get::<u64>() {
+        // Ethereum block number has been cached, fetch events starting from the next after cached block
+        log!("Last cached block number: {:?}", cached_block_num);
+        encode_block_hex(cached_block_num + 1)
+    } else {
+        // Validator's cache is empty, fetch events from the earliest block with pending events
+        log!("Block number has not been cached yet");
+        // XXX TODO: Add back?
+        // let block_numbers: Vec<u32> = EthEventQueue::iter()
+        //     .filter_map(|((block_number, _log_index), status)| {
+        //         if match status {
+        //             EventStatus::<Ethereum>::Pending { .. } => true,
+        //             _ => false,
+        //         } {
+        //             Some(block_number)
+        //         } else {
+        //             None
+        //         }
+        //     })
+        //     .collect();
+        // let pending_events_block = block_numbers.iter().min();
+        // if pending_events_block.is_some() {
+        //     let events_block: u32 = *pending_events_block.unwrap();
+        //     from_block = format!("{:#X}", events_block);
+        // } else {
+        //}
+        String::from("earliest")
+    };
+
+    log!("Fetching events starting from block {:?}", from_block);
+
+    let mut lock = StorageLock::<Time>::new(OCW_STORAGE_LOCK_ETHEREUM_EVENTS);
+    if let Ok(_guard) = lock.try_lock() {
+        match fetch_eth_events(from_block) {
+            Ok(event_info) => {
+                log!("Result: {:?}", event_info);
+
+                // TODO: The failability here is bad, since we don't want to re-process events
+                // We need to make sure this is fully idempotent
+
+                // Send extrinsics for all events
+                submit_events::<T>(event_info.events)?;
+
+                // Save latest block in ocw storage
+                s_info.set(&event_info.latest_eth_block);
+            }
+            Err(err) => {
+                log!("Error while fetching events: {:?}", err);
+                return Err(Reason::FetchError);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn submit_events<T: Config>(events: Vec<(ChainLogId, ChainLogEvent)>) -> Result<(), Reason> {
+    for (event_id, event) in events.into_iter() {
+        log!(
+            "Processing event and sending extrinsic: {} {:?}",
+            event_id.show(),
+            event
+        );
+
+        // XXX why are we signing with eth?
+        //  bc eth is identity key...
+        let signature = <Ethereum as Chain>::sign_message(&event.encode()[..])?;
+        let call = Call::receive_event(event_id, event, signature);
+
+        // TODO: Do we want to short-circuit on an error here?
+        let res = SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into())
+            .map_err(|()| Reason::FailedToSubmitExtrinsic);
+
+        if res.is_err() {
+            log!("Error while sending event extrinsic");
+        }
+    }
+    Ok(())
+}
+
+pub fn receive_event<T: Config>(
+    event_id: ChainLogId,
+    event: ChainLogEvent,
+    signature: ValidatorSig,
+) -> Result<(), Reason> {
+    // XXX sig
+    // XXX do we want to store/check hash to allow replaying?
+    // TODO: use more generic function?
+    // XXX why is this using eth for validator sig though?
+    let signer: crate::types::ValidatorIdentity =
+        compound_crypto::eth_recover(&event.encode()[..], &signature, false)?;
+    let validators: Vec<_> = Validators::iter().map(|v| v.1.eth_address).collect();
+    if !validators.contains(&signer) {
+        log!(
+            "Signer of a log event is not a known validator {:?}, validators are {:?}",
+            signer,
+            validators
+        );
+        return Err(Reason::UnknownValidator)?;
+    }
+
+    match EventStates::get(event_id) {
+        EventState::Pending { signers } => {
+            // XXX sets?
+            if signers.contains(&signer) {
+                log!("process_chain_event_internal({}): Validator has already signed this payload {:?}", event_id.show(), signer);
+                return Err(Reason::EventAlreadySigned);
+            }
+
+            // Add new validator to the signers
+            let mut signers_new = signers.clone();
+            signers_new.push(signer.clone()); // XXX unique add to set?
+
+            if passes_validation_threshold(&signers_new, &validators) {
+                match apply_chain_event_internal::<T>(event) {
+                    Ok(()) => {
+                        EventStates::insert(event_id, EventState::Done);
+                        <Module<T>>::deposit_event(EventT::ProcessedChainEvent(event_id));
+                        Ok(())
+                    }
+
+                    Err(reason) => {
+                        log!(
+                            "process_chain_event_internal({}) apply failed: {:?}",
+                            event_id.show(),
+                            reason
+                        );
+                        EventStates::insert(event_id, EventState::Failed { reason });
+                        <Module<T>>::deposit_event(EventT::FailedProcessingChainEvent(
+                            event_id, reason,
+                        ));
+                        Ok(())
+                    }
+                }
+            } else {
+                log!(
+                    "process_chain_event_internal({}) signer_count={}",
+                    event_id.show(),
+                    signers_new.len()
+                );
+                EventStates::insert(
+                    event_id,
+                    EventState::Pending {
+                        signers: signers_new,
+                    },
+                );
+                Ok(())
+            }
+        }
+
+        EventState::Failed { .. } | EventState::Done => {
+            // TODO: Eventually we should be deleting or retrying here (based on monotonic ids and signing order)
+            Ok(())
+        }
+    }
+}

--- a/pallets/cash/src/internal/mod.rs
+++ b/pallets/cash/src/internal/mod.rs
@@ -1,3 +1,8 @@
+pub mod assets;
+pub mod change_validators;
+pub mod events;
 pub mod exec_trx_request;
+pub mod next_code;
 pub mod notices;
+pub mod oracle;
 pub mod set_yield_next;

--- a/pallets/cash/src/internal/next_code.rs
+++ b/pallets/cash/src/internal/next_code.rs
@@ -1,0 +1,26 @@
+use frame_support::storage::StorageValue;
+
+use crate::{
+    chains::{Chain, Ethereum},
+    reason::Reason,
+    require,
+    types::CodeHash,
+    AllowedNextCodeHash, Config,
+};
+
+pub fn allow_next_code_with_hash<T: Config>(hash: CodeHash) -> Result<(), Reason> {
+    AllowedNextCodeHash::put(hash);
+    Ok(())
+}
+
+pub fn set_next_code_via_hash<T: Config>(code: Vec<u8>) -> Result<(), Reason> {
+    // XXX what Hash type to use?
+    require!(
+        Some(<Ethereum as Chain>::hash_bytes(&code)) == AllowedNextCodeHash::get(),
+        Reason::InvalidCodeHash
+    );
+    AllowedNextCodeHash::kill();
+    // XXX
+    //System::Call::<T>::set_code(frame_system::RawOrigin::root(), code);
+    Ok(())
+}

--- a/pallets/cash/src/internal/notices.rs
+++ b/pallets/cash/src/internal/notices.rs
@@ -1,10 +1,13 @@
+use frame_support::storage::{IterableStorageDoubleMap, StorageDoubleMap, StorageMap};
+use frame_system::offchain::SubmitTransaction;
+
 use crate::{
-    chains::{ChainHash, ChainId},
-    notices::{NoticeId, NoticeState},
+    chains::{ChainAccount, ChainHash, ChainId, ChainSignature, ChainSignatureList},
+    log,
+    notices::{has_signer, EncodeNotice, NoticeId, NoticeState},
     reason::Reason,
-    require, Config, NoticeHashes, NoticeStates, Notices,
+    require, Call, Config, NoticeHashes, NoticeStates, Notices,
 };
-use frame_support::storage::{StorageDoubleMap, StorageMap};
 
 pub fn handle_notice_invoked<T: Config>(
     chain_id: ChainId,
@@ -14,11 +17,103 @@ pub fn handle_notice_invoked<T: Config>(
 ) -> Result<(), Reason> {
     require!(
         NoticeHashes::get(notice_hash) == Some(notice_id),
-        Reason::MismatchedNoticeHash
+        Reason::NoticeHashMismatch
     );
     Notices::take(chain_id, notice_id);
     NoticeStates::insert(chain_id, notice_id, NoticeState::Executed);
     Ok(())
+}
+
+pub fn process_notices<T: Config>(_block_number: T::BlockNumber) -> Result<(), Reason> {
+    // TODO: Do we want to return a failure here in any case, or collect them, etc?
+    for (chain_id, notice_id, notice_state) in NoticeStates::iter() {
+        match notice_state {
+            NoticeState::Pending { signature_pairs } => {
+                let signer = chain_id.signer_address()?;
+
+                if !has_signer(&signature_pairs, signer) {
+                    // find parent
+                    // id = notice.gen_id(parent)
+
+                    // XXX
+                    // submit onchain call for aggregating the price
+                    let notice = Notices::get(chain_id, notice_id)
+                        .ok_or(Reason::NoticeMissing(chain_id, notice_id))?;
+                    let signature: ChainSignature = notice.sign_notice()?;
+                    log!("Posting Signature for [{},{}]", notice_id.0, notice_id.1);
+                    let call = <Call<T>>::publish_signature(chain_id, notice_id, signature);
+
+                    // TODO: Do we want to short-circuit on an error here?
+                    let _res =
+                        SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into())
+                            .map_err(|()| Reason::FailedToSubmitExtrinsic);
+                }
+
+                ()
+            }
+            _ => (),
+        }
+    }
+    Ok(())
+}
+
+pub fn publish_signature(
+    chain_id: ChainId,
+    notice_id: NoticeId,
+    signature: ChainSignature,
+) -> Result<(), Reason> {
+    log!("Publishing Signature: [{},{}]", notice_id.0, notice_id.1);
+    let state = <NoticeStates>::get(chain_id, notice_id);
+
+    match state {
+        NoticeState::Missing => Ok(()),
+
+        NoticeState::Pending { signature_pairs } => {
+            let notice = Notices::get(chain_id, notice_id)
+                .ok_or(Reason::NoticeMissing(chain_id, notice_id))?;
+            let signer: ChainAccount = signature.recover(&notice.encode_notice())?; // XXX
+            let has_signer_v = has_signer(&signature_pairs, signer);
+
+            require!(!has_signer_v, Reason::NoticeAlreadySigned);
+
+            // TODO: Can this be easier?
+            let signature_pairs_next = match (signature_pairs, signer, signature) {
+                (
+                    ChainSignatureList::Eth(eth_signature_list),
+                    ChainAccount::Eth(eth_account),
+                    ChainSignature::Eth(eth_sig),
+                ) => {
+                    let mut eth_signature_list_mut = eth_signature_list.clone();
+                    eth_signature_list_mut.push((eth_account, eth_sig));
+                    Ok(ChainSignatureList::Eth(eth_signature_list_mut))
+                }
+                _ => Err(Reason::SignatureMismatch),
+            }?;
+
+            // require(signer == known validator); // XXX
+
+            // XXX sets?
+            // let signers_new = {signer | signers};
+            // let signatures_new = {signature | signatures };
+
+            // if len(signers_new & Validators) > 2/3 * len(Validators) {
+            // NoticeQueue::insert(notice_id, NoticeState::Done);
+            // Self::deposit_event(Event::SignedNotice(ChainId::Eth, notice_id, notice.encode_notice(), signatures)); // XXX generic
+            // Ok(())
+            // } else {
+            NoticeStates::insert(
+                chain_id,
+                notice_id,
+                NoticeState::Pending {
+                    signature_pairs: signature_pairs_next,
+                },
+            );
+            Ok(())
+            // }
+        }
+
+        NoticeState::Executed => Ok(()),
+    }
 }
 
 #[cfg(test)]
@@ -123,7 +218,7 @@ mod tests {
             let result =
                 handle_notice_invoked::<Test>(chain_id, NoticeId(66, 77), notice_hash, vec![]);
 
-            assert_eq!(result, Err(Reason::MismatchedNoticeHash));
+            assert_eq!(result, Err(Reason::NoticeHashMismatch));
 
             assert_eq!(NoticeHashes::get(notice_hash), Some(notice_id));
             assert_eq!(Notices::get(chain_id, notice_id), Some(notice));

--- a/pallets/cash/src/internal/oracle.rs
+++ b/pallets/cash/src/internal/oracle.rs
@@ -1,0 +1,123 @@
+use frame_support::storage::{StorageMap, StorageValue};
+use frame_system::offchain::SubmitTransaction;
+use sp_runtime::offchain::{
+    storage::StorageValueRef,
+    storage_lock::{StorageLock, Time},
+};
+
+use crate::{
+    chains::{Chain, Ethereum},
+    log,
+    oracle::{open_price_feed_request, parse_message},
+    params::OCW_OPEN_ORACLE_POLL_INTERVAL_BLOCKS,
+    reason::{OracleError, Reason},
+    symbol::Ticker,
+    types::{AssetPrice, Timestamp},
+    Call, Config, PriceReporters, PriceTimes, Prices,
+};
+use our_std::str::FromStr;
+
+// OCW storage constants
+const OCW_LATEST_PRICE_FEED_TIMESTAMP: &[u8; 33] = b"cash::latest_price_feed_timestamp";
+const OCW_LATEST_PRICE_FEED_POLL_BLOCK_NUMBER: &[u8; 41] =
+    b"cash::latest_price_feed_poll_block_number";
+const OCW_STORAGE_LOCK_OPEN_PRICE_FEED: &[u8; 34] = b"cash::storage_lock_open_price_feed";
+
+pub fn post_price<T: Config>(payload: Vec<u8>, signature: Vec<u8>) -> Result<(), Reason> {
+    // check signature
+    let parsed_sig: <Ethereum as Chain>::Signature =
+        compound_crypto::eth_signature_from_bytes(&signature)?;
+
+    // note that this is actually a double-hash situation but that is expected behavior
+    // the hashed message is hashed again in the eth convention inside eth_recover
+    let hashed = compound_crypto::keccak(&payload);
+    let recovered = compound_crypto::eth_recover(&hashed, &parsed_sig, true)?;
+    if !PriceReporters::get().contains(recovered) {
+        return Err(OracleError::NotAReporter.into());
+    }
+
+    // parse message and check it
+    let parsed = parse_message(&payload)?;
+    let ticker = Ticker::from_str(&parsed.key)?;
+
+    // XXX
+    log!(
+        "Parsed price from open price feed: {:?} is worth {:?}",
+        parsed.key,
+        (parsed.value as f64) / 1000000.0
+    );
+
+    // todo: more sanity checking on the value // XXX like what?
+    if let Some(last_updated) = PriceTimes::get(&ticker) {
+        if parsed.timestamp <= last_updated {
+            return Err(OracleError::StalePrice.into());
+        }
+    }
+
+    // * WARNING begin storage - all checks must happen above * //
+
+    Prices::insert(&ticker, parsed.value as AssetPrice);
+    PriceTimes::insert(&ticker, parsed.timestamp as Timestamp);
+    Ok(())
+}
+
+/// Procedure for offchain worker to processes messages coming out of the open price feed
+pub fn process_prices<T: Config>(block_number: T::BlockNumber) -> Result<(), Reason> {
+    let mut lock = StorageLock::<Time>::new(OCW_STORAGE_LOCK_OPEN_PRICE_FEED);
+    if lock.try_lock().is_err() {
+        // working in another thread, no big deal
+        return Ok(());
+    }
+
+    // get the URL to poll, just return if there is no URL set up
+    let url = runtime_interfaces::validator_config_interface::get_opf_url().unwrap_or(vec![]);
+    if url.len() == 0 {
+        return Ok(());
+    }
+
+    // check to see if it is time to poll or not
+    let latest_price_feed_poll_block_number_storage =
+        StorageValueRef::persistent(OCW_LATEST_PRICE_FEED_POLL_BLOCK_NUMBER);
+    if let Some(Some(latest_poll_block_number)) =
+        latest_price_feed_poll_block_number_storage.get::<T::BlockNumber>()
+    {
+        let poll_interval_blocks =
+            <T as frame_system::Config>::BlockNumber::from(OCW_OPEN_ORACLE_POLL_INTERVAL_BLOCKS);
+        if block_number - latest_poll_block_number < poll_interval_blocks {
+            return Ok(());
+        }
+    }
+    let url = String::from_utf8(url).map_err(|_| OracleError::InvalidApiEndpoint)?;
+
+    // poll
+    let (messages_and_signatures, timestamp) =
+        open_price_feed_request(&url)?.to_message_signature_pairs()?;
+
+    // Check to see if Coinbase api prices were updated or not
+    let latest_price_feed_timestamp_storage =
+        StorageValueRef::persistent(OCW_LATEST_PRICE_FEED_TIMESTAMP);
+    if let Some(Some(latest_price_feed_timestamp)) =
+        latest_price_feed_timestamp_storage.get::<String>()
+    {
+        if latest_price_feed_timestamp == timestamp {
+            log!(
+                "Open oracle prices for timestamp {:?} has been already posted",
+                timestamp
+            );
+            return Ok(());
+        }
+    }
+
+    for (msg, sig) in messages_and_signatures {
+        // adding some debug info in here, this will become very chatty
+        let call = <Call<T>>::post_price(msg, sig);
+        SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into())
+            .map_err(|_| OracleError::SubmitError)?;
+        // note - there is a log message in check_failure if this extrinsic fails but we should
+        // still try to update the other prices even if one extrinsic fails, thus the result
+        // is ignored and we continue in this loop
+    }
+    latest_price_feed_poll_block_number_storage.set(&block_number);
+    latest_price_feed_timestamp_storage.set(&timestamp);
+    Ok(())
+}

--- a/pallets/cash/src/lib.rs
+++ b/pallets/cash/src/lib.rs
@@ -12,8 +12,8 @@ extern crate ethereum_client;
 extern crate trx_request;
 
 use crate::chains::{
-    Chain, ChainAccount, ChainAccountSignature, ChainAsset, ChainHash, ChainId, ChainSignature,
-    ChainSignatureList, Ethereum,
+    ChainAccount, ChainAccountSignature, ChainAsset, ChainHash, ChainId, ChainSignature,
+    ChainSignatureList,
 };
 use crate::events::{ChainLogEvent, ChainLogId, EventState};
 use crate::notices::{Notice, NoticeId, NoticeState};
@@ -22,25 +22,16 @@ use crate::reason::Reason;
 use crate::symbol::Ticker;
 use crate::types::{
     AssetAmount, AssetBalance, AssetIndex, AssetInfo, AssetPrice, Bips, CashIndex, CashPrincipal,
-    EncodedNotice, LiquidityFactor, Nonce, ReporterSet, SessionIndex, Timestamp, ValidatorKeys,
-    ValidatorSig,
+    CodeHash, EncodedNotice, LiquidityFactor, Nonce, ReporterSet, SessionIndex, Timestamp,
+    ValidatorKeys, ValidatorSig,
 };
 use codec::alloc::string::String;
-use frame_support::{decl_error, decl_event, decl_module, decl_storage, dispatch, Parameter};
-use frame_system::{
-    ensure_none, ensure_root,
-    offchain::{CreateSignedTransaction, SubmitTransaction},
-};
+use frame_support::{decl_event, decl_module, decl_storage, dispatch, Parameter};
+use frame_system::{ensure_none, ensure_root, offchain::CreateSignedTransaction};
 use our_std::{str, vec::Vec};
 use sp_core::crypto::AccountId32;
-use sp_runtime::{
-    offchain::{
-        storage::StorageValueRef,
-        storage_lock::{StorageLock, Time},
-    },
-    transaction_validity::{
-        InvalidTransaction, TransactionSource, TransactionValidity, ValidTransaction,
-    },
+use sp_runtime::transaction_validity::{
+    InvalidTransaction, TransactionSource, TransactionValidity, ValidTransaction,
 };
 
 use frame_support::sp_runtime::traits::Convert;
@@ -81,14 +72,6 @@ mod testdata;
 /// Type for linking sessions to validators.
 pub type SubstrateId = AccountId32;
 
-// OCW storage constants
-pub const OCW_STORAGE_LOCK_ETHEREUM_EVENTS: &[u8; 34] = b"cash::storage_lock_ethereum_events";
-pub const OCW_LATEST_CACHED_ETHEREUM_BLOCK: &[u8; 34] = b"cash::latest_cached_ethereum_block";
-pub const OCW_LATEST_PRICE_FEED_TIMESTAMP: &[u8; 33] = b"cash::latest_price_feed_timestamp";
-pub const OCW_LATEST_PRICE_FEED_POLL_BLOCK_NUMBER: &[u8; 41] =
-    b"cash::latest_price_feed_poll_block_number";
-pub const OCW_STORAGE_LOCK_OPEN_PRICE_FEED: &[u8; 34] = b"cash::storage_lock_open_price_feed";
-
 /// Configure the pallet by specifying the parameters and types on which it depends.
 pub trait Config:
     frame_system::Config + CreateSignedTransaction<Call<Self>> + pallet_timestamp::Config
@@ -109,6 +92,9 @@ decl_storage! {
     trait Store for Module<T: Config> as Cash {
         /// The timestamp of the previous block (or initialized to yield start defined in genesis).
         LastYieldTimestamp get(fn last_yield_timestamp) config(): Timestamp;
+
+        /// A possible next code hash which is used to accept code provided to SetNextCodeViaHash.
+        AllowedNextCodeHash get(fn allowed_next_code_hash): Option<CodeHash>;
 
         /// The upcoming session at which to tell the sessions pallet to rotate the validators.
         NextSessionIndex get(fn next_session_index): SessionIndex;
@@ -186,10 +172,10 @@ decl_storage! {
         Nonces get(fn nonce): map hasher(blake2_128_concat) ChainAccount => Nonce;
 
         /// Mapping of latest prices for each price ticker.
-        Prices get(fn price): map hasher(blake2_128_concat) Ticker => AssetPrice;
+        Prices get(fn price): map hasher(blake2_128_concat) Ticker => Option<AssetPrice>;
 
         /// Mapping of assets to the last time their price was updated.
-        PriceTimes get(fn price_time): map hasher(blake2_128_concat) Ticker => Timestamp;
+        PriceTimes get(fn price_time): map hasher(blake2_128_concat) Ticker => Option<Timestamp>;
 
         /// Ethereum addresses of open oracle price reporters.
         PriceReporters get(fn reporters): ReporterSet; // XXX if > 1, how are we combining?
@@ -241,89 +227,12 @@ decl_event!(
 
 /* ::ERRORS:: */
 
-decl_error! {
-    pub enum Error for Module<T: Config> {
-        /// Error returned when fetching starport info
-        HttpFetchingError,
-
-        /// An error related to the oracle
-        OpenOracleError,
-
-        /// Open oracle cannot parse the signature
-        OpenOracleErrorInvalidSignature,
-
-        /// Open oracle cannot parse the signature
-        OpenOracleErrorInvalidReporter,
-
-        /// Open oracle cannot parse the message
-        OpenOracleErrorInvalidMessage,
-
-        /// Open oracle cannot parse the ticker
-        OpenOracleErrorInvalidTicker,
-
-        /// Open oracle cannot update price due to stale price
-        OpenOracleErrorStalePrice,
-
-        /// Open oracle cannot fetch price due to an http error
-        OpenOracleHttpFetchError,
-
-        /// Open oracle cannot fetch price due to an http error
-        OpenOracleBadUrl,
-
-        /// Open oracle cannot deserialize the messages and/or signatures from eth encoded hex to binary
-        OpenOracleApiResponseHexError,
-
-        /// Open oracle offchain worker made an attempt to update the price but failed in the extrinsic
-        OpenOraclePostPriceExtrinsicError,
-
-        /// An error related to the chain_spec file contents
-        GenesisConfigError,
-
-        /// Invalid parameters to a provided interest rate model
-        InterestRateModelInvalidParameters,
-
-        /// Asset is not supported
-        AssetNotSupported,
-
-        /// No interest rate model is provided for the given asset
-        InterestRateModelNotSet,
-
-        /// Could not get the borrow rate on the asset but there was a model to try
-        InterestRateModelGetBorrowRateFailed,
-
-        /// Could not get the utilization ratio
-        InterestRateModelGetUtilizationFailed,
-
-        /// Signature recovery errror
-        InvalidSignature,
-
-        /// Error signing notice in off-chain worker
-        ProcessNoticeFailure,
-
-        /// Failed to publish signatures
-        PublishSignatureFailure,
-
-        /// Error processing trx request
-        TrxRequestError,
-
-        /// Error when processing chain event
-        ErrorProcessingChainEvent,
-
-        /// Error when setting a future yield rate
-        SetYieldNextFailure
-    }
-}
-
-fn check_failure<El, T: Config>(
-    res: Result<El, Reason>,
-    new_err: Error<T>,
-) -> Result<El, Error<T>> {
+fn check_failure<T: Config>(res: Result<(), Reason>) -> Result<(), Reason> {
     if let Err(err) = res {
         <Module<T>>::deposit_event(Event::Failure(err));
         log!("Cash Failure {:#?}", err);
     }
-
-    res.map_err(|_| new_err)
+    res
 }
 
 impl<T: Config> pallet_session::SessionManager<SubstrateId> for Module<T> {
@@ -367,243 +276,124 @@ impl<T: Config> pallet_session::SessionManager<SubstrateId> for Module<T> {
 // Dispatchable functions must be annotated with a weight and must return a DispatchResult.
 decl_module! {
     pub struct Module<T: Config> for enum Call where origin: T::Origin {
-        // Errors must be initialized if they are used by the pallet.
-        type Error = Error<T>;
-
         // Events must be initialized if they are used by the pallet.
         fn deposit_event() = default;
 
+        /// Called by substrate on block initialization.
+        /// Our initialization function is fallible, but that's not allowed.
         fn on_initialize(block: T::BlockNumber) -> frame_support::weights::Weight {
-            Self::on_initialize_internal(block)
+            match core::on_initialize_core::<T>() {
+                Ok(weight) => weight,
+                Err(err) => {
+                    // This should never happen...
+                    error!("Could not initialize block!!! {:#?} {:#?}", block, err);
+                    0
+                }
+            }
         }
 
-        /// Set the price using the open price feed.
-        #[weight = 0]
-        pub fn post_price(origin, payload: Vec<u8>, signature: Vec<u8>) -> dispatch::DispatchResult {
+        /// Sets the keys for the next set of validators beginning at the next session. [Root]
+        #[weight = 0] // XXX
+        pub fn change_validators(origin, validators: Vec<ValidatorKeys>) -> dispatch::DispatchResult {
+            ensure_root(origin)?;
+            Ok(check_failure::<T>(internal::change_validators::change_validators::<T>(validators))?)
+        }
+
+        /// Sets the allowed next code hash to the given hash. [Root]
+        #[weight = 0] // XXX
+        pub fn allow_next_code_with_hash(origin, hash: CodeHash) -> dispatch::DispatchResult {
+            ensure_root(origin)?;
+            Ok(check_failure::<T>(internal::next_code::allow_next_code_with_hash::<T>(hash))?)
+        }
+
+        /// Sets the allowed next code hash to the given hash. [User] [Free]
+        #[weight = 0] // XXX
+        pub fn set_next_code_via_hash(origin, code: Vec<u8>) -> dispatch::DispatchResult {
             ensure_none(origin)?;
-            Self::post_price_internal(payload, signature)?;
-            Ok(())
+            Ok(check_failure::<T>(internal::next_code::set_next_code_via_hash::<T>(code))?)
         }
 
-
-        /// Set the price using the open price feed.
-        #[weight = 0]
+        /// Set the price using the open price feed. [Root]
+        #[weight = 0] // XXX
         pub fn set_liquidity_factor(origin, asset: ChainAsset, factor: LiquidityFactor) -> dispatch::DispatchResult {
             ensure_root(origin)?;
-            Self::set_liquidity_factor_internal(asset, factor)?;
-            Ok(())
+            Ok(check_failure::<T>(internal::assets::set_liquidity_factor::<T>(asset, factor))?)
         }
 
-        /// Update the interest rate model for a given asset. This is only called by governance
-        #[weight = 0]
+        /// Update the interest rate model for a given asset. [Root]
+        #[weight = 0] // XXX
         pub fn set_rate_model(origin, asset: ChainAsset, model: InterestRateModel) -> dispatch::DispatchResult {
             ensure_root(origin)?;
-            Self::set_rate_model_internal(asset, model)?;
-            Ok(())
+            Ok(check_failure::<T>(internal::assets::set_rate_model::<T>(asset, model))?)
         }
 
-        /// Set the cash yield rate at some point in the future
-        #[weight = 0]
+        /// Set the cash yield rate at some point in the future. [Root]
+        #[weight = 0] // XXX
         pub fn set_yield_next(origin, next_apr: APR, next_apr_start: Timestamp) -> dispatch::DispatchResult {
             ensure_root(origin)?;
-            check_failure(
-                crate::internal::set_yield_next::set_yield_next::<T>(next_apr, next_apr_start),
-                <Error<T>>::SetYieldNextFailure
-            )?;
-
-            Ok(())
+            Ok(check_failure::<T>(internal::set_yield_next::set_yield_next::<T>(next_apr, next_apr_start))?)
         }
 
-        #[weight = 0]
-        pub fn change_authorities(origin, keys: Vec<(AccountId32, ValidatorKeys)>) -> dispatch::DispatchResult {
+        /// Adds the asset to the runtime by defining it as a supported asset. [Root]
+        #[weight = 0] // XXX
+        pub fn support_asset(origin, asset: ChainAsset, asset_info: AssetInfo) -> dispatch::DispatchResult {
             ensure_root(origin)?;
-            Self::change_authorities_internal(keys);
-            Ok(())
+            Ok(check_failure::<T>(internal::assets::support_asset::<T>(asset, asset_info))?)
+        }
+
+        /// Set the price using the open price feed. [User] [Free]
+        #[weight = 0] // XXX
+        pub fn post_price(origin, payload: Vec<u8>, signature: Vec<u8>) -> dispatch::DispatchResult {
+            ensure_none(origin)?;
+            Ok(check_failure::<T>(internal::oracle::post_price::<T>(payload, signature))?)
+        }
+
+        // TODO: Do we need to sign the event id, too?
+        #[weight = 1] // XXX how are we doing weights?
+        pub fn receive_event(origin, event_id: ChainLogId, event: ChainLogEvent, signature: ValidatorSig) -> dispatch::DispatchResult { // XXX sig
+            log!("receive_event(origin,event_id,event,sig): {:?} {:?} {}", event_id, &event, hex::encode(&signature)); // XXX ?
+            ensure_none(origin)?;
+            Ok(check_failure::<T>(internal::events::receive_event::<T>(event_id, event, signature))?)
+        }
+
+        #[weight = 0] // XXX
+        pub fn publish_signature(origin, chain_id: ChainId, notice_id: NoticeId, signature: ChainSignature) -> dispatch::DispatchResult {
+            ensure_none(origin)?;
+            Ok(check_failure::<T>(internal::notices::publish_signature(chain_id, notice_id, signature))?)
+        }
+
+        /// Offchain Worker entry point.
+        fn offchain_worker(block_number: T::BlockNumber) {
+            if let Err(e) = internal::events::fetch_events::<T>() {
+                log!("offchain_worker error during fetch events: {:?}", e);
+            }
+
+            // XXX is this end times?
+           if let Err(e) = internal::notices::process_notices::<T>(block_number) {
+                log!("offchain_worker error during process notices: {:?}", e);
+            }
+
+            // XXX
+            // todo: do this less often perhaps once a minute?
+            // a really simple idea to do it once a minute on average is to just use probability
+            // and only update the feed every now and then. It is a function of how many validators
+            // are running.
+            if let Err(e) = internal::oracle::process_prices::<T>(block_number) {
+                log!("offchain_worker error during open price feed processing: {:?}", e);
+            }
         }
 
         /// Execute a transaction request on behalf of a user
         #[weight = 1]
         pub fn exec_trx_request(origin, request: Vec<u8>, signature: ChainAccountSignature, nonce: Nonce) -> dispatch::DispatchResult {
             ensure_none(origin)?;
-
-            check_failure(core::exec_trx_request_internal::<T>(request, signature, nonce), Error::<T>::TrxRequestError)?;
-            Ok(())
-        }
-
-        // TODO: Do we need to sign the event id, too?
-        #[weight = 1] // XXX how are we doing weights?
-        pub fn process_chain_event(origin, event_id: ChainLogId, event: ChainLogEvent, signature: ValidatorSig) -> dispatch::DispatchResult { // XXX sig
-            log!("process_chain_event(origin,event_id,event,sig): {:?} {:?} {}", event_id, &event, hex::encode(&signature));
-            ensure_none(origin)?;
-
-            check_failure(core::process_chain_event_internal::<T>(event_id, event, signature), Error::<T>::ErrorProcessingChainEvent)?;
-            Ok(())
-        }
-
-        #[weight = 0] // XXX
-        pub fn publish_signature(origin, chain_id: ChainId, notice_id: NoticeId, signature: ChainSignature) -> dispatch::DispatchResult {
-            ensure_none(origin)?;
-            check_failure(core::publish_signature_internal(chain_id, notice_id, signature), Error::<T>::PublishSignatureFailure)?;
-
-            Ok(())
-        }
-
-        /// Offchain Worker entry point.
-        fn offchain_worker(block_number: T::BlockNumber) {
-            let result = Self::fetch_events_with_lock();
-            if let Err(e) = result {
-                log!("offchain_worker error during fetch events: {:?}", e);
-            }
-
-            // TODO: What to do with res?
-            let _res = check_failure(core::process_notices::<T>(block_number), Error::<T>::ProcessNoticeFailure);
-
-            // todo: do this less often perhaps once a minute?
-            // a really simple idea to do it once a minute on average is to just use probability
-            // and only update the feed every now and then. It is a function of how many validators
-            // are running.
-            let result = Self::process_open_price_feed(block_number);
-            if let Err(e) = result {
-                log!("offchain_worker error during open price feed processing: {:?}", e);
-            }
+            Ok(check_failure::<T>(internal::exec_trx_request::exec::<T>(request, signature, nonce))?)
         }
     }
 }
 
 /// Reading error messages inside `decl_module!` can be difficult, so we move them here.
 impl<T: Config> Module<T> {
-    /// Called by substrate on block initialization. Note, this can fail under various scenarios
-    /// but the function signature does not allow us to express that to the substrate system.
-    /// This is our final stand
-    fn on_initialize_internal(block: T::BlockNumber) -> frame_support::weights::Weight {
-        match crate::core::on_initialize_core::<T>() {
-            Ok(weight) => weight,
-            Err(err) => {
-                // todo: something is going very wrong here..... we need to take some very serious
-                // action like invalidating the block if possible.
-                error!("Could not initialize block! {:#?} {:#?}", block, err);
-                0
-            }
-        }
-    }
-
-    /// Update the liquidity factor for an asset.
-    fn set_liquidity_factor_internal(
-        asset: ChainAsset,
-        factor: LiquidityFactor,
-    ) -> Result<(), Error<T>> {
-        let asset_info = check_failure(
-            SupportedAssets::get(asset).ok_or(Reason::AssetNotSupported),
-            <Error<T>>::AssetNotSupported,
-        )?;
-        SupportedAssets::insert(
-            &asset,
-            AssetInfo {
-                liquidity_factor: factor,
-                ..asset_info
-            },
-        );
-        Ok(())
-    }
-
-    /// Update the interest rate model for an asset.
-    fn set_rate_model_internal(
-        asset: ChainAsset,
-        model: InterestRateModel,
-    ) -> Result<(), Error<T>> {
-        let asset_info = check_failure(
-            SupportedAssets::get(asset).ok_or(Reason::AssetNotSupported),
-            <Error<T>>::AssetNotSupported,
-        )?;
-        check_failure(
-            model.check_parameters().map_err(Reason::RatesError),
-            <Error<T>>::InterestRateModelInvalidParameters,
-        )?;
-        SupportedAssets::insert(
-            &asset,
-            AssetInfo {
-                rate_model: model,
-                ..asset_info
-            },
-        );
-        Ok(())
-    }
-
-    fn change_authorities_internal(keys: Vec<(AccountId32, ValidatorKeys)>) {
-        for (id, _chain_keys) in <NextValidators>::iter() {
-            <NextValidators>::take(id);
-        }
-
-        for (id, chain_keys) in &keys {
-            <NextValidators>::take(id);
-            <NextValidators>::insert(&id, chain_keys);
-        }
-    }
-
-    /// Body of the post_price extrinsic
-    /// * checks signature of message
-    /// * parses message
-    /// * updates storage
-    ///
-    /// Gets us out of the decl_module! macro and helps with static code analysis to have the
-    /// body of this function here.
-    fn post_price_internal(payload: Vec<u8>, signature: Vec<u8>) -> Result<(), Error<T>> {
-        // check signature
-        let parsed_sig: <Ethereum as Chain>::Signature = check_failure(
-            compound_crypto::eth_signature_from_bytes(&signature).map_err(Reason::CryptoError),
-            <Error<T>>::OpenOracleErrorInvalidSignature,
-        )?;
-        // note that this is actually a double-hash situation but that is expected behavior
-        // the hashed message is hashed again in the eth convention inside eth_recover
-        let hashed = compound_crypto::keccak(&payload);
-        let recovered = check_failure(
-            compound_crypto::eth_recover(&hashed, &parsed_sig, true).map_err(Reason::CryptoError),
-            <Error<T>>::OpenOracleErrorInvalidSignature,
-        )?;
-        if !PriceReporters::get().contains(recovered) {
-            return Err(<Error<T>>::OpenOracleErrorInvalidReporter);
-        }
-
-        // parse message and check it
-        let parsed = check_failure(
-            oracle::parse_message(&payload).map_err(Reason::OracleError),
-            <Error<T>>::OpenOracleErrorInvalidMessage,
-        )?;
-
-        let ticker: Ticker = check_failure(
-            str::FromStr::from_str(&parsed.key),
-            <Error<T>>::OpenOracleErrorInvalidTicker,
-        )?;
-
-        log!(
-            "Parsed price from open price feed: {:?} is worth {:?}",
-            parsed.key,
-            (parsed.value as f64) / 1000000.0
-        );
-        // todo: more sanity checking on the value
-        // note - the API for GET does not return an Option but if the value is not present it
-        // returns Default::default(). Thus, we explicitly check if the key for the ticker is supported
-        // or not.
-
-        if PriceTimes::contains_key(&ticker) {
-            // it has been updated at some point, make sure we are updating to a more recent price
-            let last_updated = PriceTimes::get(&ticker);
-            if parsed.timestamp <= last_updated {
-                return Err(<Error<T>>::OpenOracleErrorStalePrice);
-            }
-        }
-
-        // WARNING begin storage - all checks must happen above
-
-        Prices::insert(&ticker, parsed.value as u128);
-        PriceTimes::insert(&ticker, parsed.timestamp as u128);
-
-        // todo: update storage
-        Ok(())
-    }
-
-    // XXX expose price(String) fn
-
     /// Initializes the set of supported assets from a config value.
     fn initialize_assets(assets: Vec<AssetInfo>) {
         for asset in assets {
@@ -636,148 +426,6 @@ impl<T: Config> Module<T> {
         );
         PriceReporters::put(reporters);
     }
-
-    /// Procedure for offchain worker to processes messages coming out of the open price feed
-    pub fn process_open_price_feed(block_number: T::BlockNumber) -> Result<(), Error<T>> {
-        let mut lock = StorageLock::<Time>::new(OCW_STORAGE_LOCK_OPEN_PRICE_FEED);
-        if lock.try_lock().is_err() {
-            // working in another thread, no big deal
-            return Ok(());
-        }
-
-        // get the URL to poll, just return if there is no URL set up
-        let url = runtime_interfaces::validator_config_interface::get_opf_url().unwrap_or(vec![]);
-        if url.len() == 0 {
-            return Ok(());
-        }
-
-        // check to see if it is time to poll or not
-        let latest_price_feed_poll_block_number_storage =
-            StorageValueRef::persistent(OCW_LATEST_PRICE_FEED_POLL_BLOCK_NUMBER);
-        if let Some(Some(latest_poll_block_number)) =
-            latest_price_feed_poll_block_number_storage.get::<T::BlockNumber>()
-        {
-            let poll_interval_blocks = <T as frame_system::Config>::BlockNumber::from(
-                params::OCW_OPEN_ORACLE_POLL_INTERVAL_BLOCKS,
-            );
-            if block_number - latest_poll_block_number < poll_interval_blocks {
-                return Ok(());
-            }
-        }
-        let url = check_failure(
-            String::from_utf8(url).map_err(|_| Reason::StringError),
-            <Error<T>>::OpenOracleBadUrl,
-        )?;
-
-        // poll
-        let api_response = check_failure(
-            crate::oracle::open_price_feed_request(&url).map_err(Reason::OracleError),
-            <Error<T>>::OpenOracleHttpFetchError,
-        )?;
-
-        let messages_and_signatures_and_timestamp = check_failure(
-            api_response
-                .to_message_signature_pairs()
-                .map_err(Reason::OracleError),
-            <Error<T>>::OpenOracleApiResponseHexError,
-        )?;
-        let (messages_and_signatures, timestamp) = messages_and_signatures_and_timestamp;
-
-        // Check to see if Coinbase api prices were updated or not
-        let latest_price_feed_timestamp_storage =
-            StorageValueRef::persistent(OCW_LATEST_PRICE_FEED_TIMESTAMP);
-        if let Some(Some(latest_price_feed_timestamp)) =
-            latest_price_feed_timestamp_storage.get::<String>()
-        {
-            if latest_price_feed_timestamp == timestamp {
-                log!(
-                    "Open oracle prices for timestamp {:?} has been already posted",
-                    timestamp
-                );
-                return Ok(());
-            }
-        }
-
-        for (msg, sig) in messages_and_signatures {
-            // adding some debug info in here, this will become very chatty
-            let call = <Call<T>>::post_price(msg, sig);
-            let _ = check_failure(
-                SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into())
-                    .map_err(|()| Reason::FailedToSubmitExtrinsic),
-                <Error<T>>::OpenOraclePostPriceExtrinsicError,
-            );
-            // note - there is a log message in check_failure if this extrinsic fails but we should
-            // still try to update the other prices even if one extrinsic fails, thus the result
-            // is ignored and we continue in this loop
-        }
-        latest_price_feed_poll_block_number_storage.set(&block_number);
-        latest_price_feed_timestamp_storage.set(&timestamp);
-        Ok(())
-    }
-
-    // XXX disambiguate whats for ethereum vs not
-    fn fetch_events_with_lock() -> Result<(), Error<T>> {
-        let s_info = StorageValueRef::persistent(OCW_LATEST_CACHED_ETHEREUM_BLOCK);
-
-        let from_block: String = if let Some(Some(cached_block_num)) = s_info.get::<u64>() {
-            // Ethereum block number has been cached, fetch events starting from the next after cached block
-            log!("Last cached block number: {:?}", cached_block_num);
-
-            events::encode_block_hex(cached_block_num + 1)
-        } else {
-            // Validator's cache is empty, fetch events from the earliest block with pending events
-            log!("Block number has not been cached yet");
-            // XXX TODO: Add back?
-            // let block_numbers: Vec<u32> = EthEventQueue::iter()
-            //     .filter_map(|((block_number, _log_index), status)| {
-            //         if match status {
-            //             EventStatus::<Ethereum>::Pending { .. } => true,
-            //             _ => false,
-            //         } {
-            //             Some(block_number)
-            //         } else {
-            //             None
-            //         }
-            //     })
-            //     .collect();
-            // let pending_events_block = block_numbers.iter().min();
-            // if pending_events_block.is_some() {
-            //     let events_block: u32 = *pending_events_block.unwrap();
-            //     from_block = format!("{:#X}", events_block);
-            // } else {
-            //}
-            String::from("earliest")
-        };
-
-        log!("Fetching events starting from block {:?}", from_block);
-
-        let mut lock = StorageLock::<Time>::new(OCW_STORAGE_LOCK_ETHEREUM_EVENTS);
-
-        if let Ok(_guard) = lock.try_lock() {
-            match events::fetch_events(from_block) {
-                Ok(event_info) => {
-                    log!("Result: {:?}", event_info);
-
-                    // TODO: The failability here is bad, since we don't want to re-process events
-                    // We need to make sure this is fully idempotent
-
-                    // Send extrinsics for all events
-                    check_failure(
-                        core::process_events_internal::<T>(event_info.events),
-                        Error::<T>::ErrorProcessingChainEvent,
-                    )?;
-
-                    // Save latest block in ocw storage
-                    s_info.set(&event_info.latest_eth_block);
-                }
-                Err(err) => {
-                    log!("Error while fetching events: {:?}", err);
-                    return Err(Error::<T>::HttpFetchingError);
-                }
-            }
-        }
-        Ok(())
-    }
 }
 
 impl<T: Config> frame_support::unsigned::ValidateUnsigned for Module<T> {
@@ -790,7 +438,7 @@ impl<T: Config> frame_support::unsigned::ValidateUnsigned for Module<T> {
     /// are being whitelisted and marked as valid.
     fn validate_unsigned(_source: TransactionSource, call: &Self::Call) -> TransactionValidity {
         match call {
-            Call::process_chain_event(_event_id, _event, signature) => {
+            Call::receive_event(_event_id, _event, signature) => {
                 ValidTransaction::with_tag_prefix("CashPallet")
                     .longevity(10)
                     .and_provides(signature)
@@ -798,8 +446,9 @@ impl<T: Config> frame_support::unsigned::ValidateUnsigned for Module<T> {
                     .build()
             }
             Call::exec_trx_request(request, signature, nonce) => {
-                let signer_res =
-                    signature.recover_account(&core::prepend_nonce(request, *nonce)[..]);
+                let signer_res = signature.recover_account(
+                    &internal::exec_trx_request::prepend_nonce(request, *nonce)[..],
+                );
 
                 log!("signer_res={:?}", signer_res);
 

--- a/pallets/cash/src/portfolio.rs
+++ b/pallets/cash/src/portfolio.rs
@@ -63,9 +63,9 @@ impl Portfolio {
 
     /// Get the hypothetical liquidity value.
     pub fn get_liquidity<T: Config>(&self) -> Result<Balance, Reason> {
-        let mut liquidity = self.cash.mul_price(get_price::<T>(CASH))?;
+        let mut liquidity = self.cash.mul_price(get_price::<T>(CASH)?)?;
         for (info, balance) in &self.positions {
-            let price = get_price::<T>(balance.units);
+            let price = get_price::<T>(balance.units)?;
             let worth = (*balance).mul_price(price)?;
             if worth.value >= 0 {
                 liquidity = liquidity.add(worth.mul_factor(info.liquidity_factor)?)?

--- a/pallets/cash/src/primitives.rs
+++ b/pallets/cash/src/primitives.rs
@@ -1,0 +1,86 @@
+use codec::{Decode, Encode};
+use num_bigint::BigUint;
+use our_std::{
+    convert::TryFrom,
+    ops::{Add, Div, Mul, Sub},
+    RuntimeDebug,
+};
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, RuntimeDebug)]
+pub struct Uint(pub BigUint);
+
+impl Encode for Uint {
+    fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
+        self.0.to_bytes_le().using_encoded(f)
+    }
+}
+
+impl codec::EncodeLike for Uint {}
+
+impl Decode for Uint {
+    fn decode<I: codec::Input>(encoded: &mut I) -> Result<Self, codec::Error> {
+        let raw: Vec<u8> = Decode::decode(encoded)?;
+        Ok(Uint(BigUint::from_bytes_le(&raw)))
+    }
+}
+
+impl<T> From<T> for Uint
+where
+    T: Into<BigUint>,
+{
+    fn from(raw: T) -> Self {
+        Uint(raw.into())
+    }
+}
+
+impl TryFrom<Uint> for u128 {
+    type Error = num_bigint::TryFromBigIntError<BigUint>;
+
+    fn try_from(from: Uint) -> Result<u128, Self::Error> {
+        TryFrom::try_from(from.0)
+    }
+}
+
+impl<T> Add<T> for Uint
+where
+    T: Into<Uint>,
+{
+    type Output = Self;
+
+    fn add(self, rhs: T) -> Self::Output {
+        Uint(self.0 + rhs.into().0)
+    }
+}
+
+impl<T> Sub<T> for Uint
+where
+    T: Into<Uint>,
+{
+    type Output = Self;
+
+    fn sub(self, rhs: T) -> Self::Output {
+        Uint(self.0 - rhs.into().0)
+    }
+}
+
+impl<T> Mul<T> for Uint
+where
+    T: Into<Uint>,
+{
+    type Output = Self;
+
+    fn mul(self, rhs: T) -> Self::Output {
+        Uint(self.0 * rhs.into().0)
+    }
+}
+
+impl<T> Div<T> for Uint
+where
+    T: Into<Uint>,
+{
+    type Output = Self;
+
+    fn div(self, rhs: T) -> Self::Output {
+        Uint(self.0 / rhs.into().0)
+    }
+}

--- a/pallets/cash/src/reason.rs
+++ b/pallets/cash/src/reason.rs
@@ -1,7 +1,6 @@
 use crate::chains::ChainId;
 use crate::internal::set_yield_next::SetYieldNextError;
 use crate::notices::NoticeId;
-use crate::oracle::OracleError;
 use crate::rates::RatesError;
 use crate::types::Nonce;
 use codec::{Decode, Encode};
@@ -22,44 +21,98 @@ pub enum Reason {
     BadUnits,
     ChainMismatch,
     CryptoError(compound_crypto::CryptoError),
+    EventAlreadySigned,
     FailedToSubmitExtrinsic,
-    HttpError,
+    FetchError,
     IncorrectNonce(Nonce, Nonce),
     InKindLiquidation,
     InsufficientChainCash,
     InsufficientLiquidity,
     InsufficientTotalFunds,
     InvalidAPR,
+    InvalidCodeHash,
     InvalidLiquidityFactor,
-    InvalidSignature,
     InvalidUTF8,
     KeyNotFound,
     MathError(MathError),
+    MaxForNonCashAsset,
     MinTxValueNotMet,
-    MissingEvent,
-    NegativePrincipalExtraction,
-    NegativePrincipalExtrction,
     None,
+    NoPrice,
     NoSuchAsset,
     NoticeAlreadySigned,
+    NoticeHashMismatch,
     NoticeMissing(ChainId, NoticeId),
     NotImplemented,
     OracleError(OracleError),
-    ParseIntError,
     RatesError(RatesError),
     RepayTooMuch,
     SelfTransfer,
     SignatureAccountMismatch,
     SignatureMismatch,
-    StringError,
     TimeTravelNotAllowed,
     TrxRequestParseError(TrxReqParseError),
     UnknownValidator,
-    ValidatorAlreadySigned,
     SetYieldNextError(SetYieldNextError),
-    MaxForNonCashAsset,
-    MaxWithNegativeCashPrincipal,
-    MismatchedNoticeHash,
+}
+
+impl From<Reason> for frame_support::dispatch::DispatchError {
+    fn from(reason: Reason) -> frame_support::dispatch::DispatchError {
+        // XXX better way to assign codes?
+        let (index, error, message) = match reason {
+            Reason::AssetExtractionNotSupported => {
+                (0, 99, "asset extraction not supported XXX temporary")
+            }
+            Reason::AssetNotSupported => (0, 0, "asset not supported"),
+            Reason::BadAccount => (1, 0, "bad account"),
+            Reason::BadAddress => (1, 1, "bad address"),
+            Reason::BadAsset => (1, 2, "bad asset"),
+            Reason::BadChainId => (1, 3, "bad chain id"),
+            Reason::BadSymbol => (1, 4, "bad symbol"),
+            Reason::BadTicker => (1, 5, "bad ticker"),
+            Reason::BadUnits => (1, 6, "bad units"),
+            Reason::ChainMismatch => (2, 0, "chain mismatch"),
+            Reason::CryptoError(_) => (3, 0, "crypto error"),
+            Reason::EventAlreadySigned => (4, 0, "event already signed"),
+            Reason::FailedToSubmitExtrinsic => (5, 0, "failed to submit extrinsic"),
+            Reason::FetchError => (6, 0, "fetch error"),
+            Reason::IncorrectNonce(_, _) => (6, 0, "incorrect nonce"),
+            Reason::InKindLiquidation => (6, 0, "in kind liquidation"),
+            Reason::InsufficientChainCash => (6, 0, "insufficient chain cash"),
+            Reason::InsufficientLiquidity => (6, 1, "insufficient liquidity"),
+            Reason::InsufficientTotalFunds => (6, 2, "insufficient total funds"),
+            Reason::InvalidAPR => (7, 0, "invalid apr"),
+            Reason::InvalidCodeHash => (7, 1, "invalid code hash"),
+            Reason::InvalidLiquidityFactor => (7, 2, "invalid liquidity factor"),
+            Reason::InvalidUTF8 => (7, 4, "invalid utf8"),
+            Reason::KeyNotFound => (8, 0, "key not found"),
+            Reason::MathError(_) => (9, 0, "math error"),
+            Reason::MaxForNonCashAsset => (10, 0, "max for non cash asset"),
+            Reason::MinTxValueNotMet => (11, 0, "min tx value not met"),
+            Reason::None => (12, 0, "none"),
+            Reason::NoPrice => (13, 0, "no price"),
+            Reason::NoSuchAsset => (13, 1, "no such asset"),
+            Reason::NoticeAlreadySigned => (14, 0, "notice already signed"),
+            Reason::NoticeHashMismatch => (14, 1, "notice hash mismatch"),
+            Reason::NoticeMissing(_, _) => (14, 2, "notice missing"),
+            Reason::NotImplemented => (15, 0, "not implemented"),
+            Reason::OracleError(_) => (16, 0, "oracle error"),
+            Reason::RatesError(_) => (17, 0, "rates error"),
+            Reason::RepayTooMuch => (18, 0, "repay too much"),
+            Reason::SelfTransfer => (19, 0, "self transfer"),
+            Reason::SignatureAccountMismatch => (20, 0, "signature account mismatch"),
+            Reason::SignatureMismatch => (20, 1, "signature mismatch"),
+            Reason::TimeTravelNotAllowed => (21, 0, "time travel not allowed"),
+            Reason::TrxRequestParseError(_) => (22, 0, "trx request parse error"),
+            Reason::UnknownValidator => (23, 0, "unknown validator"),
+            Reason::SetYieldNextError(_) => (24, 0, "set yield next error"),
+        };
+        frame_support::dispatch::DispatchError::Module {
+            index,
+            error,
+            message: Some(message),
+        }
+    }
 }
 
 impl From<MathError> for Reason {
@@ -71,6 +124,12 @@ impl From<MathError> for Reason {
 impl From<compound_crypto::CryptoError> for Reason {
     fn from(err: compound_crypto::CryptoError) -> Self {
         Reason::CryptoError(err)
+    }
+}
+
+impl From<OracleError> for Reason {
+    fn from(err: OracleError) -> Self {
+        Reason::OracleError(err)
     }
 }
 
@@ -110,6 +169,24 @@ pub enum MathError {
     UnitsMismatch,
 }
 
+/// Errors coming from the price oracle.
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+pub enum OracleError {
+    EthAbiParseError,
+    InvalidApiEndpoint,
+    InvalidApiResponse,
+    InvalidKind,
+    InvalidSymbol,
+    InvalidTicker,
+    JsonParseError,
+    HexParseError,
+    HttpError,
+    NotAReporter,
+    StalePrice,
+    SubmitError,
+}
+
+/// Error from parsing trx requests.
 #[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
 pub enum TrxReqParseError {
     NotImplemented,

--- a/pallets/cash/src/types.rs
+++ b/pallets/cash/src/types.rs
@@ -58,6 +58,9 @@ pub type CashQuantity = Quantity; // ideally Quantity<{ CASH }>
 /// Type for representing an amount of USD.
 pub type USDQuantity = Quantity; // ideally Quantity<{ USD }>
 
+/// Type for a code hash.
+pub type CodeHash = <Ethereum as Chain>::Hash; // XXX what to use?
+
 /// Type for an open price feed reporter.
 pub type Reporter = <Ethereum as Chain>::Address;
 


### PR DESCRIPTION
I started to add the error replacing strategy `Reason => dispatch::DispatchResult`, which I think we *can* convert to static str errors w/ two u8 codes at least 🤷 