### PR TITLE
Give Miner Rewards via Inherents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4409,6 +4409,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
+ "sp-inherents",
  "sp-io",
  "sp-runtime",
  "tiny-keccak 2.0.2",

--- a/integration/util/scenario/validator.js
+++ b/integration/util/scenario/validator.js
@@ -52,7 +52,7 @@ let validatorInfoMap = {
 };
 
 class Validator {
-  constructor(ctx, name, info, rpcPort, p2pPort, wsPort, nodeKey, peerId, logLevel, spawnOpts, extraArgs, validatorArgs, ethPrivateKey, chainSpecFile) {
+  constructor(ctx, name, info, rpcPort, p2pPort, wsPort, nodeKey, peerId, logLevel, spawnOpts, extraArgs, validatorArgs, ethPrivateKey, ethAccount, chainSpecFile) {
     this.ctx = ctx;
     this.name = name;
     this.info = info;
@@ -66,6 +66,7 @@ class Validator {
     this.extraArgs = extraArgs;
     this.validatorArgs = validatorArgs;
     this.ethPrivateKey = ethPrivateKey;
+    this.ethAccount = ethAccount;
     this.chainSpecFile = chainSpecFile;
     this.wsProvider = null;
     this.api = null;
@@ -108,7 +109,8 @@ class Validator {
         ...this.spawnOpts,
         ETH_RPC_URL: this.ctx.eth.web3Url,
         ETH_KEY: this.ethPrivateKey,
-        ETH_KEY_ID: "my_eth_key_id"
+        ETH_KEY_ID: "my_eth_key_id",
+        MINER: `Eth:${this.ethAccount}`
       }
     });
 
@@ -236,13 +238,14 @@ function buildValidator(validatorName, validatorInfo, ctx) {
   let validatorArgs = validatorInfo.spawn_args || [];
 
   let ethPrivateKey = getInfoKey(validatorInfo, 'eth_private_key', `validator ${validatorName}`);
+  let ethAccount = getInfoKey(validatorInfo, 'eth_account', `validator ${validatorName}`);
   if (!ctx.chainSpec) {
     throw new Error(`Must initialize chain spec before starting validator`);
   }
 
   let chainSpecFile = ctx.chainSpec.file();
 
-  return new Validator(ctx, validatorName, validatorInfo, rpcPort, p2pPort, wsPort, nodeKey, peerId, logLevel, spawnOpts, extraArgs, validatorArgs, ethPrivateKey, chainSpecFile);
+  return new Validator(ctx, validatorName, validatorInfo, rpcPort, p2pPort, wsPort, nodeKey, peerId, logLevel, spawnOpts, extraArgs, validatorArgs, ethPrivateKey, ethAccount, chainSpecFile);
 }
 
 async function getValidatorsInfo(validatorsInfoHash, ctx) {

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -7,6 +7,7 @@ use sc_executor::native_executor_instance;
 use sc_service::{config::Configuration, error::Error as ServiceError, TaskManager};
 use std::sync::Arc;
 use std::time::Duration;
+use pallet_cash;
 
 type FullClient = sc_service::TFullClient<Block, RuntimeApi, Executor>;
 type FullBackend = sc_service::TFullBackend<Block>;
@@ -63,6 +64,9 @@ pub fn new_partial(
         )));
     }
     let inherent_data_providers = sp_inherents::InherentDataProviders::new();
+        inherent_data_providers
+            .register_provider(pallet_cash::internal::miner::InherentDataProvider)
+            .expect("Failed to register miner data provider");
 
     let (client, backend, keystore_container, task_manager) =
         sc_service::new_full_parts::<Block, RuntimeApi, Executor>(&config)?;

--- a/pallets/cash/Cargo.toml
+++ b/pallets/cash/Cargo.toml
@@ -21,6 +21,7 @@ frame-system = { default-features = false, version = '2.0.0', git = 'https://git
 sp-core = { default-features = false, version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
 sp-io = { version = '2.0.0', default-features = false, git = 'https://github.com/compound-finance/substrate.git', features = ["disable_oom", "disable_panic_handler"]}
 sp-runtime = { default-features = false, version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
+sp-inherents = { default-features = false, version = '2.0.0', git = 'https://github.com/compound-finance/substrate.git' }
 ethabi = { version = "12.0.0", default-features = false }
 ethereum-types = { version = "0.11.0", default-features = false }
 hex = { version = "0.4.2", default-features = false }

--- a/pallets/cash/src/core.rs
+++ b/pallets/cash/src/core.rs
@@ -38,7 +38,7 @@ use crate::{
     AccountNotices, AssetBalances, AssetsWithNonZeroBalance, BorrowIndices, CashPrincipals,
     CashYield, ChainCashPrincipals, Config, Event, GlobalCashIndex, LastIndices,
     LastYieldTimestamp, LatestNotice, Module, NoticeHashes, NoticeStates, Notices, Prices,
-    SupplyIndices, SupportedAssets, TotalBorrowAssets, TotalCashPrincipal, TotalSupplyAssets,
+    SupplyIndices, SupportedAssets, TotalBorrowAssets, TotalCashPrincipal, TotalSupplyAssets, Miner, LastMinerSpreadPrincipal,
 };
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
@@ -60,6 +60,13 @@ macro_rules! require_min_tx_value {
 }
 
 // Public helper functions //
+
+// Miner might not be set (e.g. in the first block mined), but for accouting
+// purposes, we want some address to make sure all numbers tie out. As such,
+// let's just give the initial rewards to some burn account.
+pub fn get_some_miner<T: Config>() -> ChainAccount {
+    Miner::get().unwrap_or(ChainAccount::Eth([0; 20]))
+}
 
 pub fn try_chain_asset_account(
     asset: ChainAsset,
@@ -646,7 +653,7 @@ pub fn transfer_internal<T: Config>(
     recipient: ChainAccount,
     amount: AssetQuantity,
 ) -> Result<(), Reason> {
-    let miner = ChainAccount::Eth([0; 20]); // todo: xxx how to get the current miner chain account
+    let miner = get_some_miner::<T>();
     let index = GlobalCashIndex::get();
 
     // XXX check asset matches amount asset?
@@ -729,7 +736,7 @@ pub fn transfer_cash_principal_internal<T: Config>(
     recipient: ChainAccount,
     principal: CashPrincipal,
 ) -> Result<(), Reason> {
-    let miner = ChainAccount::Eth([0; 20]); // todo: xxx how to get the current miner chain account
+    let miner = get_some_miner::<T>();
     let index: CashIndex = GlobalCashIndex::get();
     let amount = index.as_hold_amount(principal)?;
 
@@ -1334,11 +1341,16 @@ pub fn on_initialize<T: Config>(
     let total_cash_principal_new = total_cash_principal.add(cash_principal_borrow_increase)?;
     let miner_spread_principal =
         cash_principal_borrow_increase.sub(cash_principal_supply_increase)?;
-    let miner = ChainAccount::Eth([0; 20]); // todo: xxx how to get the current miner chain account
-    let miner_cash_principal_old: CashPrincipal = CashPrincipals::get(&miner);
-    let miner_cash_principal_new = miner_cash_principal_old.add(miner_spread_principal)?;
 
     // * WARNING - BEGIN STORAGE ALL CHECKS AND FAILURES MUST HAPPEN ABOVE * //
+
+    let last_miner = get_some_miner::<T>(); // Miner not yet set for this block, so this is "last miner"
+    let last_miner_spread_principal = LastMinerSpreadPrincipal::get();
+
+    let miner_cash_principal_old: CashPrincipal = CashPrincipals::get(&last_miner);
+    let miner_cash_principal_new = miner_cash_principal_old.add(last_miner_spread_principal)?;
+    CashPrincipals::insert(last_miner, miner_cash_principal_new);
+    log!("Miner={:?} received {:?} principal for mining last block", last_miner, last_miner_spread_principal);
 
     for (asset, new_supply_index, new_borrow_index) in asset_updates.drain(..) {
         SupplyIndices::insert(asset.clone(), new_supply_index);
@@ -1347,7 +1359,7 @@ pub fn on_initialize<T: Config>(
 
     GlobalCashIndex::put(cash_index_new);
     TotalCashPrincipal::put(total_cash_principal_new);
-    CashPrincipals::insert(miner, miner_cash_principal_new);
+    LastMinerSpreadPrincipal::put(miner_spread_principal);
 
     // todo: xxx support changing cash APRs
     /*
@@ -1844,6 +1856,12 @@ mod tests {
                 TotalCashPrincipal::get(),
                 CashPrincipal::from_nominal("462104.853072128227960800")
             );
+            assert_eq!(
+                CashPrincipals::get(&miner),
+                CashPrincipal::from_nominal("1.000000000000000000")
+            );
+            // Run again to set miner true principal
+            assert_eq!(on_initialize::<Test>(change_in_time), Ok(0));
             assert_eq!(
                 CashPrincipals::get(&miner),
                 CashPrincipal::from_nominal("243.097061442564559300")

--- a/pallets/cash/src/internal/miner.rs
+++ b/pallets/cash/src/internal/miner.rs
@@ -1,0 +1,124 @@
+#[cfg(feature = "std")]
+use codec::Decode;
+use codec::Encode;
+#[cfg(feature = "std")]
+use sp_inherents::ProvideInherentData;
+use sp_inherents::{InherentData, InherentIdentifier, IsFatalError, ProvideInherent};
+use sp_runtime::RuntimeString;
+use crate::{
+    chains::ChainAccount,
+    Module,
+    Config,
+    Call,
+};
+
+/// The identifier for the miner inherent.
+pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"miner000";
+/// The type of the inherent.
+pub type InherentType = ChainAccount;
+
+/// Errors that can occur while checking the miner inherent.
+#[derive(Encode, sp_runtime::RuntimeDebug)]
+#[cfg_attr(feature = "std", derive(Decode))]
+pub enum InherentError {
+    /// Some other error.
+    Other(RuntimeString),
+}
+
+impl IsFatalError for InherentError {
+    fn is_fatal_error(&self) -> bool {
+        match self {
+            InherentError::Other(_) => true,
+        }
+    }
+}
+
+impl InherentError {
+    /// Try to create an instance ouf of the given identifier and data.
+    #[cfg(feature = "std")]
+    pub fn try_from(id: &InherentIdentifier, data: &[u8]) -> Option<Self> {
+        if id == &INHERENT_IDENTIFIER {
+            <InherentError as codec::Decode>::decode(&mut &data[..]).ok()
+        } else {
+            None
+        }
+    }
+}
+
+/// Auxiliary trait to extract miner inherent data.
+pub trait MinerInherentData {
+    /// Get miner inherent data.
+    fn miner_inherent_data(&self) -> Result<InherentType, sp_inherents::Error>;
+}
+
+impl MinerInherentData for InherentData {
+    fn miner_inherent_data(&self) -> Result<InherentType, sp_inherents::Error> {
+        self.get_data(&INHERENT_IDENTIFIER) // TODO: Do we need to convert or anything?
+            .and_then(|r| r.ok_or_else(|| "Miner inherent data not found".into()))
+    }
+}
+
+/// Provide duration since unix epoch in millisecond for timestamp inherent.
+#[cfg(feature = "std")]
+pub struct InherentDataProvider;
+
+#[cfg(feature = "std")]
+impl ProvideInherentData for InherentDataProvider {
+    fn inherent_identifier(&self) -> &'static InherentIdentifier {
+        &INHERENT_IDENTIFIER
+    }
+
+    fn provide_inherent_data(
+        &self,
+        inherent_data: &mut InherentData,
+    ) -> Result<(), sp_inherents::Error> {
+        let miner_address_str =
+            runtime_interfaces::validator_config_interface::get_miner_address()
+            .ok_or("no miner address")?;
+
+        let miner_address =
+            our_std::str::from_utf8(&miner_address_str).map_err(|_| "invalid miner address bytes")?;
+
+        let chain_account: ChainAccount = our_std::str::FromStr::from_str(miner_address)
+            .map_err(|_| "invalid miner address")?;
+
+        inherent_data.put_data(INHERENT_IDENTIFIER, &chain_account)
+    }
+
+    fn error_to_string(&self, error: &[u8]) -> Option<String> {
+        InherentError::try_from(&INHERENT_IDENTIFIER, error).map(|e| format!("{:?}", e))
+    }
+}
+
+fn extract_inherent_data(data: &InherentData) -> Result<InherentType, RuntimeString> {
+    data.get_data::<InherentType>(&INHERENT_IDENTIFIER)
+        .map_err(|_| RuntimeString::from("Invalid miner inherent data encoding."))?
+        .ok_or_else(|| "Miner inherent data is not provided.".into())
+}
+
+impl<T: Config> ProvideInherent for Module<T> {
+    type Call = Call<T>;
+    type Error = InherentError;
+    const INHERENT_IDENTIFIER: InherentIdentifier = INHERENT_IDENTIFIER;
+
+    fn create_inherent(data: &InherentData) -> Option<Self::Call> {
+        match extract_inherent_data(data) {
+            Ok(miner) =>
+                Some(Call::set_miner(miner)),
+            Err(_err) =>
+                None,
+        }
+    }
+
+    fn check_inherent(call: &Self::Call, data: &InherentData) -> Result<(), Self::Error> {
+        let _t: ChainAccount = match call {
+            Call::set_miner(ref t) => t.clone(),
+            _ => return Ok(()),
+        };
+
+        let _data = extract_inherent_data(data).map_err(|e| InherentError::Other(e))?;
+
+        // We don't actually have any qualms with the miner's choice, so long as it decodes
+        Ok(())
+    }
+}

--- a/pallets/cash/src/internal/mod.rs
+++ b/pallets/cash/src/internal/mod.rs
@@ -6,3 +6,4 @@ pub mod next_code;
 pub mod notices;
 pub mod oracle;
 pub mod set_yield_next;
+pub mod miner;

--- a/pallets/runtime-interfaces/src/lib.rs
+++ b/pallets/runtime-interfaces/src/lib.rs
@@ -23,7 +23,7 @@ impl Config {
 
 pub fn new_config(eth_starport_address: Vec<u8>) -> Config {
     return Config {
-        eth_starport_address: eth_starport_address,
+        eth_starport_address,
     };
 }
 
@@ -58,6 +58,7 @@ const ETH_KEY_ID_ENV_VAR_DEV_DEFAULT: &str = compound_crypto::ETH_KEY_ID_ENV_VAR
 const ETH_RPC_URL_ENV_VAR: &str = "ETH_RPC_URL";
 const ETH_RPC_URL_ENV_VAR_DEV_DEFAULT: &str =
     "https://goerli.infura.io/v3/975c0c48e2ca4649b7b332f310050e27";
+const MINER_ENV_VAR: &str = "MINER";
 const OPF_URL_ENV_VAR: &str = "OPF_URL";
 const OPF_URL_ENV_VAR_DEFAULT: &str = "";
 
@@ -89,6 +90,11 @@ pub trait ValidatorConfigInterface {
     /// Get the open price feed URLs
     fn get_opf_url() -> Option<Vec<u8>> {
         std::env::var(OPF_URL_ENV_VAR).ok().map(Into::into)
+    }
+
+    /// Get the Miner address
+    fn get_miner_address() -> Option<Vec<u8>> {
+        std::env::var(MINER_ENV_VAR).ok().map(Into::into)
     }
 }
 
@@ -146,6 +152,7 @@ pub fn set_validator_config_dev_defaults() {
     set_validator_config_dev_default(ETH_KEY_ID_ENV_VAR, ETH_KEY_ID_ENV_VAR_DEV_DEFAULT);
     set_validator_config_dev_default(ETH_RPC_URL_ENV_VAR, ETH_RPC_URL_ENV_VAR_DEV_DEFAULT);
     set_validator_config_dev_default(OPF_URL_ENV_VAR, OPF_URL_ENV_VAR_DEFAULT);
+    set_validator_config_dev_default(MINER_ENV_VAR, "");
 }
 
 #[cfg(test)]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -373,7 +373,7 @@ construct_runtime!(
         Sudo: pallet_sudo::{Module, Call, Config<T>, Storage, Event<T>},
 
         // Include the custom logic from the CASH pallet in the runtime.
-        Cash: pallet_cash::{Module, Call, Config, Storage, Event, ValidateUnsigned},
+        Cash: pallet_cash::{Module, Call, Config, Storage, Event, ValidateUnsigned, Inherent},
 
         // comes after CASH pallet bc it asks CASH for validators during initialization
         Session: pallet_session::{Module, Call, Storage, Event, Config<T>},


### PR DESCRIPTION
This patch adds a `Miner` storage value that is set by an Inherent. This means that on each block, the block author will set his/her Ethereum address (or potentially any account in the future) that will be used to give block rewards. Note: the address is set _after_ the `on_initialize` code runs, so we actually now store the given rewards for the miner (in re: spreads) and give it to the miner at the start of the next block.