### PR TITLE
Add Price for USD Assets

### DIFF
--- a/integration/util/scenario/chain_spec.js
+++ b/integration/util/scenario/chain_spec.js
@@ -38,7 +38,7 @@ async function baseChainSpec(validatorsInfoHash, tokensInfoHash, ctx) {
     asset: `Eth:${token.ethAddress()}`,
     decimals: token.decimals,
     symbol: token.symbol.toUpperCase(),
-    ticker: token.symbol.toUpperCase(), // XXX how to set price ticker in integration tests?
+    ticker: token.priceTicker,
     liquidity_factor: 6543,
     rate_model: {
       Kink: {

--- a/integration/util/substrate.js
+++ b/integration/util/substrate.js
@@ -189,9 +189,14 @@ function decodeCall(api, callData) {
   return call.toHuman();
 }
 
+function descale(val, decimals) {
+  return Number(`${val}e-${decimals}`);
+}
+
 module.exports = {
   decodeCall,
   encodeCall,
+  descale,
   findEvent,
   getEventData,
   sendAndWaitForEvents,

--- a/pallets/cash/src/symbol.rs
+++ b/pallets/cash/src/symbol.rs
@@ -42,6 +42,8 @@ impl From<Symbol> for String {
 #[derive(Copy, Clone, Eq, Encode, Decode, PartialEq, Ord, PartialOrd, RuntimeDebug)]
 pub struct Ticker(pub [u8; WIDTH]);
 
+pub const USD_TICKER: Ticker = Ticker([b'U', b'S', b'D', 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+
 impl Ticker {
     pub const fn new(ticker_str: &str) -> Self {
         Ticker(str_to_label(ticker_str))


### PR DESCRIPTION
This patch adds a price for assets with a ticker of "USD" that can be used for USDC, USDT, etc. Open for discussion if this is the exact right approach.