### PR TITLE
Add Lock To

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,6 +1724,7 @@ dependencies = [
  "lazy_static",
  "our-std",
  "parity-scale-codec 2.0.0",
+ "primitive-types 0.7.3",
  "serde",
  "serde_json",
  "sp-io",
@@ -1866,6 +1867,18 @@ name = "fixed-hash"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3367952ceb191f4ab95dd5685dc163ac539e36202f9fcfd0cb22f9f9c542fefc"
+dependencies = [
+ "byteorder",
+ "rand 0.7.3",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
 dependencies = [
  "byteorder",
  "rand 0.7.3",
@@ -5105,6 +5118,17 @@ dependencies = [
  "impl-codec 0.4.2",
  "impl-rlp",
  "impl-serde 0.3.1",
+ "uint 0.8.5",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd39dcacf71411ba488570da7bbc89b717225e46478b30ba99b92db6b149809"
+dependencies = [
+ "fixed-hash 0.6.1",
+ "impl-codec 0.4.2",
  "uint 0.8.5",
 ]
 

--- a/ethereum-client/Cargo.toml
+++ b/ethereum-client/Cargo.toml
@@ -21,6 +21,9 @@ sp-std = { default-features = false, git = 'https://github.com/compound-finance/
 
 our-std = { path = '../our-std', default-features = false }
 
+[dev-dependencies]
+primitive-types = "0.7.3"
+
 [features]
 default = ['std']
 std = [

--- a/ethereum-client/src/hex.rs
+++ b/ethereum-client/src/hex.rs
@@ -1,0 +1,182 @@
+use our_std::convert::TryInto;
+
+pub fn decode_hex(data: &String) -> Option<Vec<u8>> {
+    if data.len() < 2 || &data[0..2] != "0x" {
+        None
+    } else {
+        hex::decode(&data[2..]).ok()
+    }
+}
+
+pub fn decode_topic(topic: &String) -> Option<ethabi::Hash> {
+    let res = decode_hex(topic)?;
+    let addr: &[u8; 32] = &res[..].try_into().ok()?;
+    Some(addr.into())
+}
+
+pub fn parse_word(val_opt: Option<String>) -> Option<[u8; 32]> {
+    let v = decode_hex(&val_opt?)?;
+    let tokens = ethabi::decode(&[ethabi::ParamType::FixedBytes(32)], &v[..]).ok()?;
+    match &tokens[..] {
+        [ethabi::token::Token::FixedBytes(bytes)] => bytes[..].try_into().ok(),
+        _ => None,
+    }
+}
+
+// Note: our hex library won't even _parse_ hex with an odd-number of digits
+//       so we need to pad before we parse with ethabi, as opposed to decoding
+//       and then padding.
+// Note: this is an internal function and does not parse the hex digits themselves
+fn pad(val: String) -> Option<String> {
+    if val.len() > 66 || val.len() < 2 || &val[0..2] != "0x" {
+        None
+    } else {
+        let mut s = String::with_capacity(64);
+        let padding = 66 - val.len();
+        for _ in 0..padding {
+            s.push('0');
+        }
+        s.push_str(&val[2..]);
+        Some(s)
+    }
+}
+
+pub fn parse_u64(val_opt: Option<String>) -> Option<u64> {
+    let padded = hex::decode(&pad(val_opt?)?).ok()?;
+    let tokens = ethabi::decode(&[ethabi::ParamType::Uint(256)], &padded[..]).ok()?;
+    match tokens[..] {
+        [ethabi::token::Token::Uint(uint)] => uint.try_into().ok(),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use primitive_types::H256;
+
+    #[test]
+    fn test_decode_hex() {
+        assert_eq!(decode_hex(&String::from("0x")), Some(vec![]));
+        assert_eq!(decode_hex(&String::from("0x01")), Some(vec![1]));
+        assert_eq!(decode_hex(&String::from("0x0102")), Some(vec![1, 2]));
+        assert_eq!(decode_hex(&String::from("0x3")), None);
+        assert_eq!(decode_hex(&String::from("0b01")), None);
+        assert_eq!(decode_hex(&String::from("")), None);
+        assert_eq!(decode_hex(&String::from("0")), None);
+        assert_eq!(decode_hex(&String::from("0xr")), None);
+        assert_eq!(decode_hex(&String::from("0x💙")), None);
+        assert_eq!(decode_hex(&String::from("0x💙💙")), None);
+        assert_eq!(decode_hex(&String::from("0xṰ̺̺̕o͞ ̷i̲̬͇̪͙n̝̗͕v̟̜̘̦͟o̶̙̰̠k")), None);
+    }
+
+    #[test]
+    fn test_decode_topic() {
+        assert_eq!(decode_topic(&String::from("0x01")), None);
+        assert_eq!(
+            decode_topic(&String::from(
+                "0x000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f"
+            )),
+            Some(H256([
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                10, 11, 12, 13, 14, 15
+            ]))
+        );
+
+        assert_eq!(
+            decode_topic(&String::from(
+                "0x000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f00"
+            )),
+            None
+        );
+    }
+
+    #[test]
+    fn test_parse_word() {
+        assert_eq!(parse_word(None), None);
+        assert_eq!(parse_word(Some(String::from("0x01"))), None);
+        assert_eq!(
+            parse_word(Some(String::from(
+                "0x000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f"
+            ))),
+            Some([
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                10, 11, 12, 13, 14, 15
+            ])
+        );
+
+        assert_eq!(
+            parse_word(Some(String::from(
+                "0x000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f00"
+            ))),
+            None
+        );
+    }
+
+    #[test]
+    fn test_pad() {
+        assert_eq!(pad(String::from("")), None);
+        assert_eq!(pad(String::from("0")), None);
+        assert_eq!(
+            pad(String::from("0x")),
+            Some(String::from(
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            ))
+        );
+        assert_eq!(
+            pad(String::from("0x1")),
+            Some(String::from(
+                "0000000000000000000000000000000000000000000000000000000000000001"
+            ))
+        );
+        // Note: we do not parse the data at all, so this is valid
+        assert_eq!(
+            pad(String::from("0xr")),
+            Some(String::from(
+                "000000000000000000000000000000000000000000000000000000000000000r"
+            ))
+        );
+        assert_eq!(
+            pad(String::from("0x11")),
+            Some(String::from(
+                "0000000000000000000000000000000000000000000000000000000000000011"
+            ))
+        );
+        assert_eq!(
+            pad(String::from("0x111")),
+            Some(String::from(
+                "0000000000000000000000000000000000000000000000000000000000000111"
+            ))
+        );
+        assert_eq!(
+            pad(String::from(
+                "0x1111111111111111111111111111111111111111111111111111111111111111"
+            )),
+            Some(String::from(
+                "1111111111111111111111111111111111111111111111111111111111111111"
+            ))
+        );
+        assert_eq!(
+            pad(String::from(
+                "0x001111111111111111111111111111111111111111111111111111111111111111"
+            )),
+            None
+        );
+    }
+
+    #[test]
+    fn test_parse_u64() {
+        assert_eq!(parse_u64(Some(String::from(""))), None);
+        assert_eq!(parse_u64(Some(String::from("0"))), None);
+        assert_eq!(parse_u64(Some(String::from("0x"))), Some(0u64));
+        assert_eq!(parse_u64(Some(String::from("0x0"))), Some(0u64));
+        assert_eq!(parse_u64(Some(String::from("0x1"))), Some(1u64));
+        assert_eq!(parse_u64(Some(String::from("0x11"))), Some(17u64));
+        assert_eq!(parse_u64(Some(String::from("0x111"))), Some(273u64));
+        assert_eq!(
+            parse_u64(Some(String::from("0xffffffffffffffff"))),
+            Some(0xffffffffffffffff)
+        );
+        assert_eq!(parse_u64(Some(String::from("0x11ffffffffffffffff"))), None);
+    }
+}

--- a/integration/util/scenario.js
+++ b/integration/util/scenario.js
@@ -46,10 +46,10 @@ function buildScenariosInternal(name, baseScenInfo, opts, scenarios, testFn) {
         let ctx = await buildCtx(scenInfo);
         ctx.ctx = ctx; // Self reference to make ctx pattern-matchable for scenario fns
         try {
-          let beforeEach = scenario.hasOwnProperty('beforeEach') ? scenario.beforeEach : opts.beforeEach;
+          let beforeFn = scenario.hasOwnProperty('before') ? scenario.before : opts.beforeEach;
 
-          if (beforeEach) {
-            await beforeEach(ctx);
+          if (beforeFn) {
+            await beforeFn(ctx);
           }
           await scenario.scenario(ctx);
         } finally {

--- a/integration/util/scenario/actor.js
+++ b/integration/util/scenario/actor.js
@@ -80,17 +80,22 @@ class Actor {
     return await token.getBalance(this);
   }
 
-  async chainCashPrincipal() {
+  async chainCashPrincipal_() {
     return await this.ctx.api().query.cash.cashPrincipals(this.toChainAccount());
   }
 
+  async chainCashPrincipal() {
+    return descale(await this.chainCashPrincipal_(), 6);
+  }
+
+  async chainCashBalance_() {
+    let chainCashPrincipal = await this.chainCashPrincipal_();
+    let cashIndex = await this.ctx.chain.cashIndex();
+    return chainCashPrincipal.toBigInt() * cashIndex.toBigInt();
+  }
+
   async chainCashBalance() {
-    return
-        descale(
-          await this.chainCashPrincipal().toBigNumber()
-          * await this.ctx.chain.cashIndex().toBigNumber(),
-          18
-        );
+    return descale(await this.chainCashBalance_(), 18 + 6);
   }
 
   async chainBalance(tokenLookup) {
@@ -123,8 +128,9 @@ class Actor {
   async cash() {
     // TODO: Use non-zero balances
     let cashForTokens = await Promise.all(this.ctx.tokens.all().map((token) => this.cashForToken(token)));
-    console.log({cashForTokens});
-    return await this.chainCashPrincipal() + cashForTokens.reduce((acc, el) => acc + el, 0);
+    let chainCashBalance = await this.chainCashBalance();
+    console.log({cashForTokens, chainCashBalance});
+    return chainCashBalance + cashForTokens.reduce((acc, el) => acc + el, 0);
   }
 
   async liquidityForToken(token) {
@@ -155,7 +161,17 @@ class Actor {
     return await this.declare("lock", [amount, asset], async () => {
       let lockRes = await this.ctx.starport.lock(this, amount, asset);
       if (awaitEvent) {
-        await this.ctx.chain.waitForEthProcessEvent('cash', 'GoldieLocks'); // Replace with real event
+        await this.ctx.chain.waitForEthProcessEvent('cash', asset.lockEventName()); // Replace with real event
+      }
+      return lockRes;
+    });
+  }
+
+  async lockTo(amount, asset, recipient, awaitEvent = true) {
+    return await this.declare("lock", [amount, asset, "to", recipient], async () => {
+      let lockRes = await this.ctx.starport.lockTo(this, amount, asset, recipient);
+      if (awaitEvent) {
+        await this.ctx.chain.waitForEthProcessEvent('cash', asset.lockEventName()); // Replace with real event
       }
       return lockRes;
     });

--- a/integration/util/scenario/cash_token.js
+++ b/integration/util/scenario/cash_token.js
@@ -20,6 +20,10 @@ class CashToken extends Token {
     }
   }
 
+  lockEventName() {
+    return 'GoldieLocksCash';
+  }
+
   async cashIndex() {
     return this.cashToken.methods.getCashIndex().call();
   }

--- a/integration/util/scenario/token.js
+++ b/integration/util/scenario/token.js
@@ -53,6 +53,10 @@ class Token {
     return `${this.toTokenAmount(weiAmount)} ${this.symbol}`;
   }
 
+  lockEventName() {
+    return 'GoldieLocks';
+  }
+
   async getBalance(actorLookup) {
     let actor = this.ctx.actors.get(actorLookup);
     let balanceWei = await this.token.methods.balanceOf(actor.ethAddress()).call();

--- a/pallets/cash/src/core.rs
+++ b/pallets/cash/src/core.rs
@@ -282,20 +282,21 @@ pub fn apply_chain_event_internal<T: Config>(event: ChainLogEvent) -> Result<(),
         ChainLogEvent::Eth(eth_event) => match eth_event.event {
             ethereum_client::events::EthereumEvent::Lock {
                 asset,
-                holder,
+                recipient,
                 amount,
+                ..
             } => lock_internal::<T>(
                 get_asset::<T>(ChainAsset::Eth(asset))?,
-                ChainAccount::Eth(holder),
+                ChainAccount::Eth(recipient),
                 get_quantity::<T>(ChainAsset::Eth(asset), amount)?,
             ),
 
             ethereum_client::events::EthereumEvent::LockCash {
-                holder,
-                amount: _amount,
+                recipient,
                 principal,
+                ..
             } => lock_cash_principal_internal::<T>(
-                ChainAccount::Eth(holder),
+                ChainAccount::Eth(recipient),
                 CashPrincipalAmount(principal),
             ),
 
@@ -467,6 +468,8 @@ pub fn lock_cash_principal_internal<T: Config>(
     ChainCashPrincipals::insert(chain_id, chain_cash_principal_new);
     CashPrincipals::insert(holder, holder_cash_principal_new);
     TotalCashPrincipal::put(total_cash_principal_new);
+
+    <Module<T>>::deposit_event(Event::GoldieLocksCash(holder, principal)); // XXX -> raw amount?
 
     Ok(()) // XXX should we return events to be deposited?
 }

--- a/pallets/cash/src/testdata.rs
+++ b/pallets/cash/src/testdata.rs
@@ -1,5 +1,5 @@
 pub mod json_responses {
-    pub const EVENTS_RESPONSE: &[u8; 2390] = br#"{
+    pub const EVENTS_RESPONSE: &[u8] = br#"{
         "jsonrpc":"2.0",
         "id":1,
         "result": [
@@ -7,10 +7,15 @@ pub mod json_responses {
                 "address":"0xbbde1662bc3ed16aa8c618c9833c801f3543b587",
                 "blockHash":"0xc1c0eb37b56923ad9e20fdb31ca882988d5217f7ca24b6297ca6ed700811cf23",
                 "blockNumber":"0x3adf2f",
-                "data":"0x000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee000000000000000000000000513c1ff435eccedd0fda5edd2ad5e5461f0e87260000000000000000000000000000000000000000000000000011c37937e08000",
+                "data":"0x0000000000000000000000000000000000000000000000000011c37937e08000",
                 "logIndex":"0x0",
                 "removed":false,
-                "topics":["0xec36c0364d931187a76cf66d7eee08fad0ec2e8b7458a8d8b26b36769d4d13f3"],
+                "topics":[
+                    "0xd6aba49fa5adb7dbc18ab12d057e77c75e5d4b345cf473c7514afbbd6f5fc626",
+                    "0x000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                    "0x000000000000000000000000feb1ea27f888c384f1b0dc14fd6b387d5ff47031",
+                    "0x000000000000000000000000513c1ff435eccedd0fda5edd2ad5e5461f0e8726"
+                ],
                 "transactionHash":"0x680e1e81385151f5d791fab0a3c06b03d29b46df08a312d0304cd6a4fc5a7370",
                 "transactionIndex":"0x0"
             },
@@ -18,10 +23,15 @@ pub mod json_responses {
                 "address":"0xbbde1662bc3ed16aa8c618c9833c801f3543b587",
                 "blockHash":"0xa5c8024e699a5c30eb965e47b5157c06c76f3b726bff377a0a5333a561f25648",
                 "blockNumber":"0x3c02e1",
-                "data":"0x000000000000000000000000d87ba7a50b2e7e660f678a895e4b72e7cb4ccd9c000000000000000000000000feb1ea27f888c384f1b0dc14fd6b387d5ff470310000000000000000000000000000000000000000000000000000000005f5e100",
+                "data":"0x0000000000000000000000000000000000000000000000000000000005f5e100",
                 "logIndex":"0x1",
                 "removed":false,
-                "topics":["0xec36c0364d931187a76cf66d7eee08fad0ec2e8b7458a8d8b26b36769d4d13f3"],
+                "topics":[
+                    "0xd6aba49fa5adb7dbc18ab12d057e77c75e5d4b345cf473c7514afbbd6f5fc626",
+                    "0x000000000000000000000000d87ba7a50b2e7e660f678a895e4b72e7cb4ccd9c",
+                    "0x000000000000000000000000feb1ea27f888c384f1b0dc14fd6b387d5ff47031",
+                    "0x000000000000000000000000feb1ea27f888c384f1b0dc14fd6b387d5ff47031"
+                ],
                 "transactionHash":"0x7357859bd05b4429dac758df67f93adb54caad72dd992317811927232c592d4a",
                 "transactionIndex":"0x0"
             },
@@ -29,23 +39,28 @@ pub mod json_responses {
                 "address":"0xbbde1662bc3ed16aa8c618c9833c801f3543b587",
                 "blockHash":"0xa4a96e957718e3a30b77a667f93978d8f438bdcd56ff03545f08c833d9a26687",
                 "blockNumber":"0x3c030b",
-                "data":"0x000000000000000000000000e4e81fa6b16327d4b78cfeb83aade04ba7075165000000000000000000000000feb1ea27f888c384f1b0dc14fd6b387d5ff470310000000000000000000000000000000000000000000000056bc75e2d63100000",
+                "data":"0x0000000000000000000000000000000000000000000000056bc75e2d63100000",
                 "logIndex":"0xe",
                 "removed":false,
-                "topics":["0xec36c0364d931187a76cf66d7eee08fad0ec2e8b7458a8d8b26b36769d4d13f3"],
+                "topics":[
+                    "0xd6aba49fa5adb7dbc18ab12d057e77c75e5d4b345cf473c7514afbbd6f5fc626",
+                    "0x000000000000000000000000e4e81fa6b16327d4b78cfeb83aade04ba7075165",
+                    "0x000000000000000000000000feb1ea27f888c384f1b0dc14fd6b387d5ff47031",
+                    "0x000000000000000000000000feb1ea27f888c384f1b0dc14fd6b387d5ff47031"
+                ],
                 "transactionHash":"0xad28d82aa1f55e5f965c1da2d84cce29bdb75a134b8f7857c897736c4e562300",
                 "transactionIndex":"0x4"
             }
         ]
     }"#;
 
-    pub const NO_EVENTS_RESPONSE: &[u8; 69] = br#"{
+    pub const NO_EVENTS_RESPONSE: &[u8] = br#"{
         "jsonrpc":"2.0",
         "id":1,
         "result": []
     }"#;
 
-    pub const BLOCK_NUMBER_RESPONSE: &[u8; 79] = br#"{
+    pub const BLOCK_NUMBER_RESPONSE: &[u8] = br#"{
         "jsonrpc": "2.0",
         "id": 1,
         "result": "0xb27467"

--- a/pallets/cash/src/tests/mod.rs
+++ b/pallets/cash/src/tests/mod.rs
@@ -137,7 +137,8 @@ fn process_eth_event_happy_path() {
             log_index: 0,
             event: ethereum_client::EthereumEvent::Lock {
                 asset: [1; 20],
-                holder: [2; 20],
+                sender: [3; 20],
+                recipient: [2; 20],
                 amount: 10,
             },
         });
@@ -177,7 +178,8 @@ fn process_eth_event_fails_for_bad_signature() {
             log_index: 0,
             event: ethereum_client::EthereumEvent::Lock {
                 asset: [1; 20],
-                holder: [2; 20],
+                sender: [3; 20],
+                recipient: [2; 20],
                 amount: 10,
             },
         });
@@ -201,7 +203,8 @@ fn process_eth_event_fails_if_not_validator() {
             log_index: 0,
             event: ethereum_client::EthereumEvent::Lock {
                 asset: [1; 20],
-                holder: [2; 20],
+                sender: [3; 20],
+                recipient: [2; 20],
                 amount: 10,
             },
         });
@@ -422,7 +425,8 @@ fn offchain_worker_test() {
                 log_index: 14,
                 event: ethereum_client::EthereumEvent::Lock {
                     asset: [228, 232, 31, 166, 177, 99, 39, 212, 183, 140, 254, 184, 58, 173, 224, 75, 167, 7, 81, 101],
-                    holder: [254, 177, 234, 39, 248, 136, 195, 132, 241, 176, 220, 20, 253, 107, 56, 125, 95, 244, 112, 49],
+                    sender: [254, 177, 234, 39, 248, 136, 195, 132, 241, 176, 220, 20, 253, 107, 56, 125, 95, 244, 112, 49],
+                    recipient: [254, 177, 234, 39, 248, 136, 195, 132, 241, 176, 220, 20, 253, 107, 56, 125, 95, 244, 112, 49],
                     amount: 100000000000000000000,
                 },
             }));
@@ -439,7 +443,8 @@ fn offchain_worker_test() {
                 log_index: 1,
                 event: ethereum_client::EthereumEvent::Lock {
                     asset: [216, 123, 167, 165, 11, 46, 126, 102, 15, 103, 138, 137, 94, 75, 114, 231, 203, 76, 205, 156],
-                    holder: [254, 177, 234, 39, 248, 136, 195, 132, 241, 176, 220, 20, 253, 107, 56, 125, 95, 244, 112, 49],
+                    sender: [254, 177, 234, 39, 248, 136, 195, 132, 241, 176, 220, 20, 253, 107, 56, 125, 95, 244, 112, 49],
+                    recipient: [254, 177, 234, 39, 248, 136, 195, 132, 241, 176, 220, 20, 253, 107, 56, 125, 95, 244, 112, 49],
                     amount: 100000000,
                 },
             }));
@@ -456,7 +461,8 @@ fn offchain_worker_test() {
                 log_index: 0,
                 event: ethereum_client::EthereumEvent::Lock {
                     asset: [238, 238, 238, 238, 238, 238, 238, 238, 238, 238, 238, 238, 238, 238, 238, 238, 238, 238, 238, 238],
-                    holder: [81, 60, 31, 244, 53, 236, 206, 221, 15, 218, 94, 221, 42, 213, 229, 70, 31, 14, 135, 38],
+                    sender: [254, 177, 234, 39, 248, 136, 195, 132, 241, 176, 220, 20, 253, 107, 56, 125, 95, 244, 112, 49],
+                    recipient: [81, 60, 31, 244, 53, 236, 206, 221, 15, 218, 94, 221, 42, 213, 229, 70, 31, 14, 135, 38],
                     amount: 5000000000000000,
                 },
             }));


### PR DESCRIPTION
This patch adds `lockTo` and adds a bunch of miscellaneous unit tests and patches for tests. The lock to required a significant downstream effort since it changed a variety of events, but a lot of that was from adding indices, which is overall, probably a good idea.