### PR TITLE
Rename Old Versions to Milestones

### DIFF
--- a/integration/__tests__/gov_scen.js
+++ b/integration/__tests__/gov_scen.js
@@ -29,11 +29,11 @@ buildScenarios('Gov Scenarios', gov_scen_info, [
   {
     name: "Upgrade Chain WASM [Set Code]",
     info: {
-      versions: ['v1.1.1'],
-      genesis_version: 'v1.1.1',
+      versions: ['m1'],
+      genesis_version: 'm1',
       validators: {
         alice: {
-          version: 'v1.1.1',
+          version: 'm1',
         }
       }
     },
@@ -49,11 +49,11 @@ buildScenarios('Gov Scenarios', gov_scen_info, [
     skip: true,
     name: "Upgrade Chain WASM [Allow Next Code]",
     info: {
-      versions: ['v1.2.1'],
-      genesis_version: 'v1.2.1',
+      versions: ['m2'],
+      genesis_version: 'm2',
       validators: {
         alice: {
-          version: 'v1.2.1',
+          version: 'm2',
         }
       },
     },
@@ -62,7 +62,7 @@ buildScenarios('Gov Scenarios', gov_scen_info, [
       let currHash = await curr.hash();
       let extrinsic = ctx.api().tx.cash.allowNextCodeWithHash(currHash);
 
-      await starport.executeProposal("Upgrade from v1.2.1 to Current [Allow Next Code]", [extrinsic]);
+      await starport.executeProposal("Upgrade from m2 to Current [Allow Next Code]", [extrinsic]);
 
       expect(await chain.nextCodeHash()).toEqual(currHash);
 

--- a/integration/__tests__/upgrade_to_m3_scen.js
+++ b/integration/__tests__/upgrade_to_m3_scen.js
@@ -10,18 +10,18 @@ let scen_info = {
   ],
 };
 
-buildScenarios('Upgrade to 1.3.1', scen_info, [
+buildScenarios('Upgrade to m3', scen_info, [
   {
-    name: "Upgrade from 1.2.1 to 1.3.1 with Live Events",
+    name: "Upgrade from m2 to m3 with Live Events",
     info: {
-      versions: ['v1.2.1'],
-      genesis_version: 'v1.2.1',
+      versions: ['m2'],
+      genesis_version: 'm2',
       eth_opts: {
-        version: 'v1.2.1',
+        version: 'm2',
       },
       validators: {
         alice: {
-          version: 'v1.2.1',
+          version: 'm2',
         }
       },
     },
@@ -50,7 +50,7 @@ buildScenarios('Upgrade to 1.3.1', scen_info, [
       });
       expect(await ashley.chainBalance(zrx)).toEqual(300);
 
-      // Next, upgrade the Starport to 1.3.1
+      // Next, upgrade the Starport to m3
       await starport.upgradeTo(curr);
 
       // Lock an asset (Lock New) and make sure it passes

--- a/integration/package.json
+++ b/integration/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "postinstall": "cd node_modules/solidity-parser-antlr && yarn install && yarn build",
     "test": "jest --runInBand",
+    "build": "cargo build && (cd ../ethereum && yarn compile)",
     "console": "NODE_OPTIONS='--experimental-repl-await' npx saddle console"
   },
   "resolutions": {


### PR DESCRIPTION
This is simply a fix for any code that referenced the old version names into the new ones. We also add a quick script for compiling cargo and ethereum for integration tests since we hop between versions more frequently now and the integration tests always require a re-compile to current code.