### PR TITLE
Fix Incorrect Reference

### DIFF
--- a/pallets/cash/src/internal/notices.rs
+++ b/pallets/cash/src/internal/notices.rs
@@ -524,7 +524,7 @@ mod tests {
             };
             let signer = <Ethereum as Chain>::signer_address().unwrap();
             let notice_state = NoticeState::Pending {
-                signature_pairs: ChainSignatureList::Comp(vec![(signer, eth_signature)]),
+                signature_pairs: ChainSignatureList::Gate(vec![(signer, eth_signature)]),
             };
             NoticeStates::insert(chain_id, notice_id, notice_state);
             Notices::insert(chain_id, notice_id, notice);


### PR DESCRIPTION
This patch fixes an incorrect reference, specifically to `ChainSignatureList::Comp` which was renamed `ChainSignatureList::Gate`. This is breaking test cases.