### PR TITLE
Bump to m5

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -121,7 +121,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("gateway"),
     impl_name: create_runtime_str!("gateway"),
     authoring_version: 1,
-    spec_version: 4,
+    spec_version: 5,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
This patch bumps the chain spec version to 5.