### PR TITLE
Add Validator Option

### DIFF
--- a/integration/util/scenario/chain_spec.js
+++ b/integration/util/scenario/chain_spec.js
@@ -29,7 +29,7 @@ async function baseChainSpec(validatorsInfoHash, tokensInfoHash, ctx) {
 
   // aurakey == validator id, account id
   let session_args = validatorsInfo.map(([_, v]) => [v.aura_key, v.aura_key, {aura: v.aura_key, grandpa: v.grandpa_key}]);
-  let validators = validatorsInfo.map(([_, v]) => ({
+  let validators = validatorsInfo.filter(([_, v]) => v.validator).map(([_, v]) => ({
       substrate_id: Array.from(ctx.actors.keyring.decodeAddress(v.aura_key)), // from ss58 str => byte array
       eth_address: v.eth_account
   }));

--- a/integration/util/scenario/validator.js
+++ b/integration/util/scenario/validator.js
@@ -40,6 +40,7 @@ let validatorInfoMap = {
     peer_id: '12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp', // I have _no idea_ how this is generated
     spawn_args: ['--alice'],
     color: chalk.blue,
+    validator: true,
   },
   'bob': {
     aura_key: "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
@@ -50,6 +51,7 @@ let validatorInfoMap = {
     peer_id: '12D3KooWHdiAxVd8uMQR1hGWXccidmfCwLqcMpGwR6QcTP6QRMuD', // I have _no idea_ how this is generated
     spawn_args: ['--bob'],
     color: chalk.green,
+    validator: true,
   }
 };
 


### PR DESCRIPTION
This patch makes it possible to start a validator in scenarios without it being listed as a validator in the genesis. This is useful for testing validator rotation.