### PR TITLE
Rpcs for asset and cash data

### DIFF
--- a/node/src/api.rs
+++ b/node/src/api.rs
@@ -168,7 +168,7 @@ where
 
         Ok(
             ApiAssetData {
-                asset: asset_info.asset,
+                asset: asset,
                 balance: (account_balance as ApiAssetBalance).into(),
                 total_supply: total_supply as ApiAssetAmount,
                 total_borrow: total_borrow as ApiAssetAmount,

--- a/node/src/api.rs
+++ b/node/src/api.rs
@@ -75,8 +75,8 @@ pub trait GatewayRpcApi<BlockHash> {
     #[rpc(name = "get_rates")]
     fn get_rates(&self, asset: ChainAsset, at: Option<BlockHash>) -> RpcResult<ApiRates>;
 
-    #[rpc(name = "gateway_asset_data")]
-    fn gateway_asset_data(&self, account: ChainAccount, assets: ChainAsset, at: Option<BlockHash>) -> RpcResult<ApiAssetData>;
+    #[rpc(name = "get_assetdata")]
+    fn get_assetdata(&self, account: ChainAccount, assets: ChainAsset, at: Option<BlockHash>) -> RpcResult<ApiAssetData>;
 }
 
 pub struct GatewayRpcHandler<C, B> {
@@ -137,7 +137,7 @@ where
         Ok((borrow_rate.0 as ApiAPR, supply_rate.0 as ApiAPR)) // XXX try_into?
     }
 
-    fn gateway_asset_data(&self, account: ChainAccount, asset: ChainAsset, at: Option<<B as BlockT>::Hash>) -> RpcResult<ApiAssetData> {
+    fn get_assetdata(&self, account: ChainAccount, asset: ChainAsset, at: Option<<B as BlockT>::Hash>) -> RpcResult<ApiAssetData> {
         let api = self.client.runtime_api();
         let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
         let asset_info: AssetInfo = api

--- a/pallets/cash/runtime-api/src/lib.rs
+++ b/pallets/cash/runtime-api/src/lib.rs
@@ -8,12 +8,14 @@ use pallet_oracle::{ticker::Ticker, types::AssetPrice};
 
 sp_api::decl_runtime_apis! {
     pub trait CashApi {
+        fn get_account_balance(account: ChainAccount, asset: ChainAsset) -> Result<AssetBalance, Reason>;
+        fn get_asset(asset: ChainAsset) -> Result<AssetInfo, Reason>;
+        fn get_cash_yield() -> Result<APR, Reason>;
+        fn get_full_cash_balance(account: ChainAccount) -> Result<AssetBalance, Reason>;
         fn get_liquidity(account: ChainAccount) -> Result<AssetBalance, Reason>;
+        fn get_market_totals(asset: ChainAsset) -> Result<(AssetAmount, AssetAmount), Reason>;
         fn get_price(ticker: String) -> Result<AssetPrice, Reason>;
         fn get_price_with_ticker(ticker: Ticker) -> Result<AssetPrice, Reason>;
         fn get_rates(asset: ChainAsset) -> Result<(APR, APR), Reason>;
-        fn get_asset(asset: ChainAsset) -> Result<AssetInfo, Reason>;
-        fn get_market_totals(asset: ChainAsset) -> Result<(AssetAmount, AssetAmount), Reason>;
-        fn get_account_balance(account: ChainAccount, asset: ChainAsset) -> Result<AssetBalance, Reason>;
     }
 }

--- a/pallets/cash/runtime-api/src/lib.rs
+++ b/pallets/cash/runtime-api/src/lib.rs
@@ -2,14 +2,18 @@ use pallet_cash::{
     chains::{ChainAccount, ChainAsset},
     rates::APR,
     reason::Reason,
-    types::AssetBalance,
+    types::{AssetAmount, AssetBalance, AssetInfo},
 };
-use pallet_oracle::types::AssetPrice;
+use pallet_oracle::{ticker::Ticker, types::AssetPrice};
 
 sp_api::decl_runtime_apis! {
     pub trait CashApi {
         fn get_liquidity(account: ChainAccount) -> Result<AssetBalance, Reason>;
         fn get_price(ticker: String) -> Result<AssetPrice, Reason>;
+        fn get_price_with_ticker(ticker: Ticker) -> Result<AssetPrice, Reason>;
         fn get_rates(asset: ChainAsset) -> Result<(APR, APR), Reason>;
+        fn get_asset(asset: ChainAsset) -> Result<AssetInfo, Reason>;
+        fn get_market_totals(asset: ChainAsset) -> Result<(AssetAmount, AssetAmount), Reason>;
+        fn get_account_balance(account: ChainAccount, asset: ChainAsset) -> Result<AssetBalance, Reason>;
     }
 }

--- a/pallets/cash/src/core.rs
+++ b/pallets/cash/src/core.rs
@@ -126,6 +126,20 @@ pub fn get_rates<T: Config>(asset: ChainAsset) -> Result<(APR, APR), Reason> {
         .get_rates(utilization, APR::ZERO, info.miner_shares)?)
 }
 
+/// Return the current total borrow and total supply balances for the asset.
+pub fn get_market_totals<T: Config>(asset: ChainAsset) -> Result<(AssetAmount, AssetAmount), Reason> {
+    let _info = SupportedAssets::get(asset).ok_or(Reason::AssetNotSupported)?;
+    let total_borrow = TotalBorrowAssets::get(asset);
+    let total_supply = TotalSupplyAssets::get(asset);
+    Ok((total_borrow, total_supply))
+}
+
+/// Return the account's balance for the asset.
+pub fn get_account_balance<T: Config>(account: ChainAccount, asset: ChainAsset) -> Result<AssetBalance, Reason> {
+    let _info = SupportedAssets::get(asset).ok_or(Reason::AssetNotSupported)?;
+    Ok(AssetBalances::get(asset, account))
+}
+
 // Internal helpers
 
 pub fn passes_validation_threshold(

--- a/pallets/cash/src/core.rs
+++ b/pallets/cash/src/core.rs
@@ -140,6 +140,12 @@ pub fn get_account_balance<T: Config>(account: ChainAccount, asset: ChainAsset) 
     Ok(AssetBalances::get(asset, account))
 }
 
+/// Return the current cash yield.
+pub fn get_cash_yield<T: Config>() -> Result<APR, Reason> {
+    Ok(CashYield::get())
+}
+
+
 // Internal helpers
 
 pub fn passes_validation_threshold(

--- a/pallets/cash/src/lib.rs
+++ b/pallets/cash/src/lib.rs
@@ -614,14 +614,9 @@ impl<T: Config> Module<T> {
 
     // ** API / View Functions ** //
 
-    /// Get the liquidity for the given account.
-    pub fn get_liquidity(account: ChainAccount) -> Result<AssetBalance, Reason> {
-        Ok(core::get_liquidity::<T>(account)?.value)
-    }
-
-    /// Get the rates for the given asset.
-    pub fn get_rates(asset: ChainAsset) -> Result<(APR, APR), Reason> {
-        Ok(core::get_rates::<T>(asset)?)
+    /// Get the asset balance for the given account.
+    pub fn get_account_balance(account: ChainAccount, asset: ChainAsset) -> Result<AssetBalance, Reason> {
+        Ok(core::get_account_balance::<T>(account, asset)?)
     }
 
     /// Get the asset info for the given asset.
@@ -629,14 +624,29 @@ impl<T: Config> Module<T> {
         Ok(core::get_asset::<T>(asset)?)
     }
 
+    /// Get the cash yield.
+    pub fn get_cash_yield() -> Result<APR, Reason> {
+        Ok(core::get_cash_yield::<T>()?)
+    }
+
+    /// Get the full cash balance for the given account.
+    pub fn get_full_cash_balance(account: ChainAccount) -> Result<AssetBalance, Reason> {
+        Ok(core::get_cash_balance_with_asset_interest::<T>(account)?.value)
+    }
+
+    /// Get the liquidity for the given account.
+    pub fn get_liquidity(account: ChainAccount) -> Result<AssetBalance, Reason> {
+        Ok(core::get_liquidity::<T>(account)?.value)
+    }
+
     /// Get the total supply for the given asset.
     pub fn get_market_totals(asset: ChainAsset) -> Result<(AssetAmount, AssetAmount), Reason> {
         Ok(core::get_market_totals::<T>(asset)?)
     }
 
-    /// Get the asset balance for the given account.
-    pub fn get_account_balance(account: ChainAccount, asset: ChainAsset) -> Result<AssetBalance, Reason> {
-        Ok(core::get_account_balance::<T>(account, asset)?)
+    /// Get the rates for the given asset.
+    pub fn get_rates(asset: ChainAsset) -> Result<(APR, APR), Reason> {
+        Ok(core::get_rates::<T>(asset)?)
     }
 }
 

--- a/pallets/cash/src/lib.rs
+++ b/pallets/cash/src/lib.rs
@@ -623,6 +623,21 @@ impl<T: Config> Module<T> {
     pub fn get_rates(asset: ChainAsset) -> Result<(APR, APR), Reason> {
         Ok(core::get_rates::<T>(asset)?)
     }
+
+    /// Get the asset info for the given asset.
+    pub fn get_asset(asset: ChainAsset) -> Result<AssetInfo, Reason> {
+        Ok(core::get_asset::<T>(asset)?)
+    }
+
+    /// Get the total supply for the given asset.
+    pub fn get_market_totals(asset: ChainAsset) -> Result<(AssetAmount, AssetAmount), Reason> {
+        Ok(core::get_market_totals::<T>(asset)?)
+    }
+
+    /// Get the asset balance for the given account.
+    pub fn get_account_balance(account: ChainAccount, asset: ChainAsset) -> Result<AssetBalance, Reason> {
+        Ok(core::get_account_balance::<T>(account, asset)?)
+    }
 }
 
 impl<T: Config> frame_support::unsigned::ValidateUnsigned for Module<T> {

--- a/rpc.json
+++ b/rpc.json
@@ -1,0 +1,53 @@
+{
+  "gateway": {
+    "assetdata": {
+      "description": "An rpc to fetch all data by chain account and chain asset.",
+      "params": [
+        {
+          "name": "account",
+          "type": "String"
+        },
+        {
+          "name": "asset",
+          "type": "String"
+        },
+        {
+          "name": "at",
+          "type": "BlockHash",
+          "isOptional": true
+        }
+      ],
+      "type": "ApiAssetData"
+    },
+    "cashdata": {
+      "description": "An rpc to fetch cash data for chain account.",
+      "params": [
+        {
+          "name": "account",
+          "type": "String"
+        },
+        {
+          "name": "at",
+          "type": "BlockHash",
+          "isOptional": true
+        }
+      ],
+      "type": "ApiCashData"
+    },
+    "rates": {
+      "description": "An rpc to fetch borrow and supply rates by chain asset.",
+      "params": [
+        {
+          "name": "asset",
+          "type": "String"
+        },
+        {
+          "name": "at",
+          "type": "BlockHash",
+          "isOptional": true
+        }
+      ],
+      "type": "ApiRates"
+    }
+  }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -47,7 +47,7 @@ use pallet_cash::{
     chains::{ChainAccount, ChainAsset},
     rates::APR,
     reason::Reason,
-    types::AssetBalance,
+    types::{AssetAmount, AssetBalance, AssetInfo},
 };
 use pallet_oracle::{ticker::Ticker, types::AssetPrice};
 
@@ -550,8 +550,24 @@ impl_runtime_apis! {
             Oracle::get_price(Ticker::from_str(&ticker_str).map_err(Reason::OracleError)?).map_err(Reason::OracleError)
         }
 
+        fn get_price_with_ticker(ticker: Ticker) -> Result<AssetPrice, Reason> {
+            Oracle::get_price(ticker).map_err(Reason::OracleError)
+        }
+
         fn get_rates(asset: ChainAsset) -> Result<(APR, APR), Reason> {
             Cash::get_rates(asset)
+        }
+
+        fn get_asset(asset: ChainAsset) -> Result<AssetInfo, Reason> {
+            Cash::get_asset(asset)
+        }
+
+        fn get_market_totals(asset: ChainAsset) -> Result<(AssetAmount, AssetAmount), Reason> {
+            Cash::get_market_totals(asset)
+        }
+
+        fn get_account_balance(account: ChainAccount, asset: ChainAsset) -> Result<AssetBalance, Reason> {
+            Cash::get_account_balance(account, asset)
         }
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -542,8 +542,28 @@ impl_runtime_apis! {
     }
 
     impl pallet_cash_runtime_api::CashApi<Block> for Runtime {
+        fn get_asset(asset: ChainAsset) -> Result<AssetInfo, Reason> {
+            Cash::get_asset(asset)
+        }
+
+        fn get_account_balance(account: ChainAccount, asset: ChainAsset) -> Result<AssetBalance, Reason> {
+            Cash::get_account_balance(account, asset)
+        }
+
+        fn get_cash_yield() -> Result<APR, Reason> {
+            Cash::get_cash_yield()
+        }
+
+        fn get_full_cash_balance(account: ChainAccount) -> Result<AssetBalance, Reason> {
+            Cash::get_full_cash_balance(account)
+        }
+
         fn get_liquidity(account: ChainAccount) -> Result<AssetBalance, Reason> {
             Cash::get_liquidity(account)
+        }
+
+        fn get_market_totals(asset: ChainAsset) -> Result<(AssetAmount, AssetAmount), Reason> {
+            Cash::get_market_totals(asset)
         }
 
         fn get_price(ticker_str: String) -> Result<AssetPrice, Reason> {
@@ -556,18 +576,6 @@ impl_runtime_apis! {
 
         fn get_rates(asset: ChainAsset) -> Result<(APR, APR), Reason> {
             Cash::get_rates(asset)
-        }
-
-        fn get_asset(asset: ChainAsset) -> Result<AssetInfo, Reason> {
-            Cash::get_asset(asset)
-        }
-
-        fn get_market_totals(asset: ChainAsset) -> Result<(AssetAmount, AssetAmount), Reason> {
-            Cash::get_market_totals(asset)
-        }
-
-        fn get_account_balance(account: ChainAccount, asset: ChainAsset) -> Result<AssetBalance, Reason> {
-            Cash::get_account_balance(account, asset)
         }
     }
 

--- a/types.json
+++ b/types.json
@@ -230,7 +230,13 @@
 
   "Source5": "RatesRS",
   "RatesError": {
-    "_enum": ["ModelRateOutOfBounds", "ZeroAboveKink", "KinkAboveFull", "KinkUtilizationTooHigh", "Overflowed"]
+    "_enum": [
+      "ModelRateOutOfBounds",
+      "ZeroAboveKink",
+      "KinkAboveFull",
+      "KinkUtilizationTooHigh",
+      "Overflowed"
+    ]
   },
   "Factor": "(Uint)",
   "MinerShares": "Factor",
@@ -302,7 +308,14 @@
     }
   },
   "MathError": {
-    "_enum": ["Overflow", "Underflow", "SignMismatch", "SymbolMismatch", "PriceNotUSD", "DivisionByZero"]
+    "_enum": [
+      "Overflow",
+      "Underflow",
+      "SignMismatch",
+      "SymbolMismatch",
+      "PriceNotUSD",
+      "DivisionByZero"
+    ]
   },
   "TrxReqParseError": {
     "_enum": [
@@ -450,5 +463,22 @@
   "ReporterSet": "Vec<Reporter>",
 
   "Source12": "Oracle_TickerRS",
-  "Ticker": "[u8; 12]"
+  "Ticker": "[u8; 12]",
+
+  "ApiRates": "(u64, u64)",
+  "ApiAssetData": {
+    "asset": "String",
+    "balance": "i64",
+    "total_borrow": "u64",
+    "total_supply": "u64",
+    "borrow_rate": "u64",
+    "supply_rate": "u64",
+    "liquidity_factor": "String",
+    "price": "u64"
+  },
+  "ApiCashData": {
+    "balance": "i64",
+    "cash_yield": "u64",
+    "price": "u64"
+  }
 }


### PR DESCRIPTION
This patch adds two rpcs, one for retrieving all necessary asset data for a given account (i.e. balance, supply rate, borrow rate, price, liquidity factor), and another for retrieving cash data for a given account (i.e. balance, cash_yield, price).