### PR TITLE
Clean up `receive_event` signing and signature recovery

### DIFF
--- a/pallets/cash/src/internal/events.rs
+++ b/pallets/cash/src/internal/events.rs
@@ -91,7 +91,6 @@ fn submit_events<T: Config>(events: Vec<(ChainLogId, ChainLogEvent)>) -> Result<
         // XXX why are we signing with eth?
         //  bc eth is identity key...
         let signature = <Ethereum as Chain>::sign_message(&event.encode()[..])?;
-
         let call = Call::receive_event(event_id, event, signature);
 
         // TODO: Do we want to short-circuit on an error here?

--- a/pallets/cash/src/internal/validate_trx.rs
+++ b/pallets/cash/src/internal/validate_trx.rs
@@ -52,24 +52,18 @@ pub fn validate_unsigned<T: Config>(
             }
         }
         Call::receive_event(event_id, event, signature) => {
-            if let Ok(signer) = runtime_interfaces::keyring_interface::eth_recover(
-                event.encode(),
-                signature.clone(),
-                false,
-            ) {
-                let validators: Vec<_> = Validators::iter().map(|v| v.1.eth_address).collect();
-                if validators.contains(&signer) {
-                    Ok(ValidTransaction::with_tag_prefix("Gateway::receive_event")
-                        .priority(100)
-                        .longevity(32)
-                        .and_provides((event_id, signature))
-                        .propagate(true)
-                        .build())
-                } else {
-                    Err(ValidationError::InvalidValidator)
-                }
+            let signer = <Ethereum as Chain>::recover_address(&event.encode(), *signature)
+                .map_err(|_| ValidationError::InvalidSignature)?;
+            let validators: Vec<_> = Validators::iter().map(|v| v.1.eth_address).collect();
+            if validators.contains(&signer) {
+                Ok(ValidTransaction::with_tag_prefix("Gateway::receive_event")
+                    .priority(100)
+                    .longevity(32)
+                    .and_provides((event_id, signature))
+                    .propagate(true)
+                    .build())
             } else {
-                Err(ValidationError::InvalidSignature)
+                Err(ValidationError::InvalidValidator)
             }
         }
         Call::exec_trx_request(request, signature, nonce) => {
@@ -235,6 +229,7 @@ mod tests {
                     amount: 500,
                 },
             });
+
             let signature: ValidatorSig = [0u8; 65];
 
             assert_eq!(

--- a/pallets/cash/src/internal/validate_trx.rs
+++ b/pallets/cash/src/internal/validate_trx.rs
@@ -229,7 +229,6 @@ mod tests {
                     amount: 500,
                 },
             });
-
             let signature: ValidatorSig = [0u8; 65];
 
             assert_eq!(


### PR DESCRIPTION
This pr was inspired by a discussion in the discord channel regarding non-standard signature signing and verification for the `receive_event` method. The proposed approach makes it match other code parts better. At first, I tried passing `ChainSignature`, but it was messy to recover and match the chain later, so just kept the Ethereum signature type.