### PR TITLE
Only auth notices initiate hold

### DIFF
--- a/pallets/cash/src/internal/change_validators.rs
+++ b/pallets/cash/src/internal/change_validators.rs
@@ -2,10 +2,12 @@ use frame_support::storage::{IterableStorageMap, StorageMap};
 
 use crate::{
     internal, reason::Reason, require, types::ValidatorKeys, Config, Event, Module, NextValidators,
-    SessionInterface,
+    NoticeHolds, SessionInterface,
 };
 
 pub fn change_validators<T: Config>(validators: Vec<ValidatorKeys>) -> Result<(), Reason> {
+    require!(NoticeHolds::iter().count() == 0, Reason::PendingAuthNotice);
+
     for validator in validators.iter() {
         require!(
             <T>::SessionInterface::is_valid_keys(validator.substrate_id.clone()),
@@ -17,7 +19,6 @@ pub fn change_validators<T: Config>(validators: Vec<ValidatorKeys>) -> Result<()
         NextValidators::take(&id);
     }
     for keys in &validators {
-        NextValidators::take(&keys.substrate_id);
         NextValidators::insert(&keys.substrate_id, keys);
     }
 

--- a/pallets/cash/src/lib.rs
+++ b/pallets/cash/src/lib.rs
@@ -173,7 +173,7 @@ decl_storage! {
         /// The most recent notice emitted for a given chain.
         LatestNotice get(fn latest_notice_id): map hasher(blake2_128_concat) ChainId => Option<(NoticeId, ChainHash)>;
 
-        /// Notices which we are waiting to be fully signed before we allow the next session to end.
+        /// The change authority notices which must be fully signed before we allow notice signing to continue
         NoticeHolds get(fn notice_hold): map hasher(blake2_128_concat) ChainId => Option<NoticeId>;
 
         /// Index of notices by chain account

--- a/pallets/cash/src/reason.rs
+++ b/pallets/cash/src/reason.rs
@@ -58,7 +58,7 @@ pub enum Reason {
     TrxRequestParseError(TrxReqParseError),
     UnknownValidator,
     InvalidChain,
-    PendingEraNotice,
+    PendingAuthNotice,
     ChangeValidatorsError,
 }
 
@@ -115,7 +115,7 @@ impl From<Reason> for frame_support::dispatch::DispatchError {
             Reason::TrxRequestParseError(_) => (27, 0, "trx request parse error"),
             Reason::UnknownValidator => (28, 0, "unknown validator"),
             Reason::InvalidChain => (29, 0, "invalid chain"),
-            Reason::PendingEraNotice => (30, 0, "era-changing notice already pending"),
+            Reason::PendingAuthNotice => (30, 0, "change auth notice is already pending"),
             Reason::ChangeValidatorsError => (31, 0, "change validators error"),
         };
         frame_support::dispatch::DispatchError::Module {


### PR DESCRIPTION
only change auth notices should initiate hold, and only change_auth extrinsic should require there to be no hold (other era changing extrinsics should not fail)