### PR TITLE
Test Future Yield

### DIFF
--- a/integration/__tests__/set_future_yield_scen.js
+++ b/integration/__tests__/set_future_yield_scen.js
@@ -1,0 +1,31 @@
+const {
+  buildScenarios
+} = require('../util/scenario');
+const { getNotice } = require('../util/substrate');
+
+let set_future_yield_scen_info = {
+  validators: ['alice', 'bob']
+};
+
+buildScenarios('Set Future Yield Scenarios', set_future_yield_scen_info, [
+  {
+    name: 'Set a future yield',
+    scenario: async ({ ashley, zrx, starport, cash, chain, ctx }) => {
+      expect(await cash.nextCashYieldStart(zrx)).toEqual('0');
+      expect(await cash.getNextCashYieldAndIndex(zrx)).toEqual({
+        yield: '0',
+        index: '0'
+      });
+      let futureDate = Date.now() + (2 * 24 * 60 * 60 * 1000);
+      console.log({yield: 1000, futureDate});
+      let extrinsic = ctx.api().tx.cash.setYieldNext(1000, futureDate);
+      let { notice } = await starport.executeProposal("Set Future Yield", [extrinsic], { awaitNotice: true, awaitEvent: false });
+      let signatures = await chain.getNoticeSignatures(notice, { signatures: 2 });
+      await starport.invoke(notice, signatures);
+      expect(await cash.nextCashYieldStart(zrx)).toEqual(futureDate.toString());
+      expect((await cash.getNextCashYieldAndIndex(zrx)).yield).toEqual('1000');
+      expect(Number((await cash.getNextCashYieldAndIndex(zrx)).index)).toBeGreaterThan(0);
+      // TODO: Advance chain time and check yield and index afterwards
+    }
+  }
+]);

--- a/integration/__tests__/supply_cap_scen.js
+++ b/integration/__tests__/supply_cap_scen.js
@@ -7,7 +7,7 @@ let supply_cap_scen_info = {
   tokens: [
     { token: 'zrx', balances: { ashley: 1000 } }
   ],
-  validators: ['alice']
+  validators: ['alice', 'bob']
 };
 
 buildScenarios('Supply Cap Scenarios', supply_cap_scen_info, [
@@ -16,7 +16,7 @@ buildScenarios('Supply Cap Scenarios', supply_cap_scen_info, [
     scenario: async ({ ashley, zrx, starport, chain, ctx }) => {
       expect(await starport.supplyCap(zrx)).toEqual("1000000000000000000000000");
       let extrinsic = ctx.api().tx.cash.setSupplyCap(zrx.toChainAsset(), 1000);
-      let { notice } = await starport.executeProposal("Set ZRX Supply Cap", [extrinsic], true, true);
+      let { notice } = await starport.executeProposal("Set ZRX Supply Cap", [extrinsic], { awaitNotice: true });
       let signatures = await chain.getNoticeSignatures(notice, { signatures: 1 });
       await starport.invoke(notice, signatures);
       expect(await starport.supplyCap(zrx)).toEqual("1000");

--- a/integration/package.json
+++ b/integration/package.json
@@ -13,9 +13,10 @@
     "jest-junit": "^12.0.0"
   },
   "scripts": {
-    "postinstall": "cd node_modules/solidity-parser-antlr && yarn install && yarn build",
     "test": "jest --runInBand",
     "build": "(cd ../ethereum && yarn compile) && cargo build",
+    "build:ethereum": "(cd ../ethereum && yarn compile)",
+    "build:chain": "cargo build",
     "console": "NODE_OPTIONS='--experimental-repl-await' npx saddle console"
   },
   "resolutions": {

--- a/integration/util/scenario/cash_token.js
+++ b/integration/util/scenario/cash_token.js
@@ -40,8 +40,22 @@ class CashToken extends Token {
     return Number(await this.cashToken.methods.totalCashPrincipal().call());
   }
 
+  async cashYieldStart() {
+    return await this.cashToken.methods.cashYieldStart().call();
+  }
+
   async getCashYieldAndIndex() {
-    return await this.cashToken.methods.cashYieldAndIndex().call();
+    let { yield: theYield, index } = await this.cashToken.methods.cashYieldAndIndex().call();
+    return { yield: theYield, index };
+  }
+
+  async nextCashYieldStart() {
+    return await this.cashToken.methods.nextCashYieldStart().call();
+  }
+
+  async getNextCashYieldAndIndex() {
+    let { yield: theYield, index } = await this.cashToken.methods.nextCashYieldAndIndex().call();
+    return { yield: theYield, index };
   }
 
   async upgradeTo(version) {

--- a/integration/util/scenario/starport.js
+++ b/integration/util/scenario/starport.js
@@ -57,7 +57,7 @@ class Starport {
     return await this.starport.methods.setSupplyCap(token.ethAddress(), weiAmount).send({ from: this.ctx.eth.root() });
   }
 
-  async executeProposal(title, extrinsics, opts) {
+  async executeProposal(title, extrinsics, opts = {}) {
     opts = {
       awaitEvent: true,
       awaitNotice: false,
@@ -75,13 +75,15 @@ class Starport {
     }
     if (opts.awaitEvent) {
       event = await this.ctx.chain.waitForEthProcessEvent('cash', 'ExecutedGovernance');
-    }
-    if (opts.checkSuccess) {
-      let [payload, govResult] = event.data[0][0];
-      if (!govResult.isDispatchSuccess) {
-        expect(govResult.toJSON()).toBe(null);
+
+      if (opts.checkSuccess) {
+        let [payload, govResult] = event.data[0][0];
+        if (!govResult.isDispatchSuccess) {
+          expect(govResult.toJSON()).toBe(null);
+        }
       }
     }
+
     return {
       event,
       notice,

--- a/types.json
+++ b/types.json
@@ -153,8 +153,8 @@
     "id": "NoticeId",
     "parent": "[u8; 32]",
     "next_cash_yield": "u128",
-    "next_cash_yield_start_at": "u128",
-    "next_cash_index": "u128"
+    "next_cash_index": "u128",
+    "next_cash_yield_start_at": "u64"
   },
   "FutureYieldNotice": {
     "_enum": {


### PR DESCRIPTION
This patch tests setting the future yield and ensures that we are, in fact, able to properly sign and accept the notice in the Starport. Types.json misconfigured the type and thus we needed to patch the type for this fix.