### PR TITLE
CLI Configuration

### DIFF
--- a/gateway-crypto/src/dev.rs
+++ b/gateway-crypto/src/dev.rs
@@ -25,6 +25,8 @@ fn get_eth_private_key_from_environment_variable() -> Result<EcdsaPair, CryptoEr
     Ok(pair)
 }
 
+const ETH_KEY_ID_ENV_VAR: &str = "ETH_KEY_ID";
+
 /// Sets up the development keyring, an in memory keyring loaded with the default key
 /// for signing messages headed to ethereum.
 ///
@@ -32,7 +34,15 @@ fn get_eth_private_key_from_environment_variable() -> Result<EcdsaPair, CryptoEr
 /// variable. That is "ok" because it should only be used during boot.
 pub fn dev_keyring() -> InMemoryKeyring {
     let mut keyring = InMemoryKeyring::new();
-    let eth_key_id: KeyId = ETH_KEY_ID_ENV_VAR_DEV_DEFAULT.into();
+    let eth_key_id: KeyId = if let Ok(eth_key_id_from_env) = std::env::var(ETH_KEY_ID_ENV_VAR) {
+        if eth_key_id_from_env.len() > 0 {
+            KeyId::from(eth_key_id_from_env)
+        } else {
+            ETH_KEY_ID_ENV_VAR_DEV_DEFAULT.into()
+        }
+    } else {
+        ETH_KEY_ID_ENV_VAR_DEV_DEFAULT.into()
+    };
 
     let pair = match get_eth_private_key_from_environment_variable() {
         Ok(pair) => pair,

--- a/gateway-crypto/src/std.rs
+++ b/gateway-crypto/src/std.rs
@@ -31,6 +31,12 @@ impl From<&str> for KeyId {
     }
 }
 
+impl From<String> for KeyId {
+    fn from(source: String) -> Self {
+        KeyId { data: source }
+    }
+}
+
 impl Into<String> for KeyId {
     fn into(self) -> String {
         self.data

--- a/integration/util/scenario/validator.js
+++ b/integration/util/scenario/validator.js
@@ -132,11 +132,7 @@ class Validator {
 
     let env = {
       ...this.spawnOpts,
-      ETH_RPC_URL: this.ctx.eth.web3Url,
       ETH_KEY: this.ethPrivateKey,
-      ETH_KEY_ID: "my_eth_key_id",
-      MINER: `Eth:${this.ethAccount}`,
-      OPF_URL: this.ctx.__opfUrl()
     };
 
     let versioning = [];
@@ -166,6 +162,10 @@ class Validator {
       '--no-mdns',
       '--node-key',
       this.nodeKey,
+      '--eth-rpc-url', this.ctx.eth.web3Url,
+      '--eth-key-id', "my_eth_key_id",
+      '--miner', `Eth:${this.ethAccount}`,
+      '--opf-url', this.ctx.__opfUrl(),
       '-lruntime=debug',
       '--reserved-only',
       ...versioning,

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -2,12 +2,34 @@ use sc_cli::RunCmd;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
+pub struct GatewayCmd {
+    /// Set the ETH Key ID for AWS KMS integration
+    #[structopt(long = "eth-key-id")]
+    pub eth_key_id: Option<String>,
+
+    /// Set the ETH RPC Url for interfacing with ethereum
+    #[structopt(long = "eth-rpc-url")]
+    pub eth_rpc_url: Option<String>,
+
+    /// Set the miner address (only useful for validator)
+    #[structopt(long = "miner")]
+    pub miner: Option<String>,
+
+    /// Open price feed URL
+    #[structopt(long = "opf-url")]
+    pub opf_url: Option<String>,
+}
+
+#[derive(Debug, StructOpt)]
 pub struct Cli {
     #[structopt(subcommand)]
     pub subcommand: Option<Subcommand>,
 
     #[structopt(flatten)]
     pub run: RunCmd,
+
+    #[structopt(flatten)]
+    pub gateway: GatewayCmd,
 }
 
 #[derive(Debug, StructOpt)]

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -31,11 +31,6 @@ impl SubstrateCli for Cli {
     }
 
     fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
-        if id == "dev" {
-            // check for our required environment variables and set them to the defaults if necessary
-            runtime_interfaces::set_validator_config_dev_defaults();
-        }
-
         Ok(match id {
             "dev" => Box::new(chain_spec::development_config()),
             "" | "local" | "testnet" => Box::new(chain_spec::local_testnet_config()),
@@ -138,6 +133,12 @@ pub fn run() -> sc_cli::Result<()> {
         }
         None => {
             let runner = cli.create_runner(&cli.run)?;
+            runtime_interfaces::initialize_validator_config(
+                cli.gateway.eth_key_id.clone(),
+                cli.gateway.eth_rpc_url.clone(),
+                cli.gateway.miner.clone(),
+                cli.gateway.opf_url.clone(),
+            );
             Ok(runner.run_node_until_exit(|config| async move {
                 match config.role {
                     Role::Light => service::new_light(config),

--- a/pallets/cash/src/events.rs
+++ b/pallets/cash/src/events.rs
@@ -138,7 +138,6 @@ pub mod tests {
             "0xbbde1662bC3ED16aA8C618c9833c801F3543B587".into();
         let config = runtime_interfaces::new_config(given_eth_starport_address.clone());
         runtime_interfaces::config_interface::set(config);
-        runtime_interfaces::set_validator_config_dev_defaults();
 
         let given_eth_rpc_url =
             runtime_interfaces::validator_config_interface::get_eth_rpc_url().unwrap();

--- a/pallets/cash/src/internal/notices.rs
+++ b/pallets/cash/src/internal/notices.rs
@@ -470,7 +470,6 @@ mod tests {
     #[test]
     fn test_process_notice_state_missing_notice() {
         new_test_ext().execute_with(|| {
-            runtime_interfaces::set_validator_config_dev_defaults();
             let chain_id = ChainId::Eth;
             let notice_id = NoticeId(5, 6);
             let notice = Notice::ExtractionNotice(ExtractionNotice::Eth {
@@ -492,7 +491,6 @@ mod tests {
     #[test]
     fn test_process_notice_state_non_pending() {
         new_test_ext().execute_with(|| {
-            runtime_interfaces::set_validator_config_dev_defaults();
             let chain_id = ChainId::Eth;
             let notice_id = NoticeId(5, 6);
             let notice_state = NoticeState::Executed {};
@@ -507,7 +505,6 @@ mod tests {
     #[test]
     fn test_process_notice_state_already_signed() {
         new_test_ext().execute_with(|| {
-            runtime_interfaces::set_validator_config_dev_defaults();
             let chain_id = ChainId::Eth;
             let notice_id = NoticeId(5, 6);
             let signer = <Ethereum as Chain>::signer_address().unwrap();
@@ -525,7 +522,6 @@ mod tests {
     #[test]
     fn test_process_notice_state_valid() {
         new_test_ext().execute_with(|| {
-            runtime_interfaces::set_validator_config_dev_defaults();
             let chain_id = ChainId::Eth;
             let notice_id = NoticeId(5, 6);
             let notice = Notice::ExtractionNotice(ExtractionNotice::Eth {
@@ -550,7 +546,6 @@ mod tests {
     #[test]
     fn test_process_notices() {
         new_test_ext().execute_with(|| {
-            runtime_interfaces::set_validator_config_dev_defaults();
             let chain_id = ChainId::Eth;
             let notice_id_1 = NoticeId(5, 6);
             let notice_1 = Notice::ExtractionNotice(ExtractionNotice::Eth {
@@ -616,7 +611,6 @@ mod tests {
     #[test]
     fn test_publish_signature_pending_valid() {
         new_test_ext().execute_with(|| {
-            runtime_interfaces::set_validator_config_dev_defaults();
             let chain_id = ChainId::Eth;
             let notice_id = NoticeId(5, 6);
             let notice = Notice::ExtractionNotice(ExtractionNotice::Eth {
@@ -685,7 +679,6 @@ mod tests {
     #[test]
     fn test_publish_signature_pending_already_signed() {
         new_test_ext().execute_with(|| {
-            runtime_interfaces::set_validator_config_dev_defaults();
             let chain_id = ChainId::Eth;
             let notice_id = NoticeId(5, 6);
             let notice = Notice::ExtractionNotice(ExtractionNotice::Eth {
@@ -714,7 +707,6 @@ mod tests {
     #[test]
     fn test_publish_signature_signature_mismatch() {
         new_test_ext().execute_with(|| {
-            runtime_interfaces::set_validator_config_dev_defaults();
             let chain_id = ChainId::Eth;
             let notice_id = NoticeId(5, 6);
             let notice = Notice::ExtractionNotice(ExtractionNotice::Eth {
@@ -746,7 +738,6 @@ mod tests {
     #[test]
     fn test_publish_signature_pending_unknown_validator() {
         new_test_ext().execute_with(|| {
-            runtime_interfaces::set_validator_config_dev_defaults();
             let chain_id = ChainId::Eth;
             let notice_id = NoticeId(5, 6);
             let notice = Notice::ExtractionNotice(ExtractionNotice::Eth {
@@ -773,7 +764,6 @@ mod tests {
     #[test]
     fn test_publish_signature_pending_invalid_signature() {
         new_test_ext().execute_with(|| {
-            runtime_interfaces::set_validator_config_dev_defaults();
             let chain_id = ChainId::Eth;
             let notice_id = NoticeId(5, 6);
             let notice = Notice::ExtractionNotice(ExtractionNotice::Eth {

--- a/pallets/cash/src/internal/validate_trx.rs
+++ b/pallets/cash/src/internal/validate_trx.rs
@@ -249,8 +249,6 @@ mod tests {
     #[test]
     fn test_receive_event_not_a_validator() {
         new_test_ext().execute_with(|| {
-            runtime_interfaces::set_validator_config_dev_defaults();
-
             let event_id: ChainLogId = ChainLogId::Eth(1, 1);
             let event: ChainLogEvent = ChainLogEvent::Eth(EthereumLogEvent {
                 block_hash: [0u8; 32],
@@ -283,7 +281,6 @@ mod tests {
     #[test]
     fn test_receive_event_is_validator() {
         new_test_ext().execute_with(|| {
-            runtime_interfaces::set_validator_config_dev_defaults();
             let substrate_id = AccountId32::new([0u8; 32]);
             let eth_address = <Ethereum as Chain>::signer_address().unwrap();
             Validators::insert(
@@ -332,7 +329,6 @@ mod tests {
     #[test]
     fn test_exec_trx_request_nonce_zero() {
         new_test_ext().execute_with(|| {
-            runtime_interfaces::set_validator_config_dev_defaults();
             let request: Vec<u8> = String::from("Hello").as_bytes().into();
             let nonce = 0;
             let full_request: Vec<u8> = format!("\x19Ethereum Signed Message:\n70:Hello")
@@ -366,7 +362,6 @@ mod tests {
     #[test]
     fn test_exec_trx_request_nonce_nonzero() {
         new_test_ext().execute_with(|| {
-            runtime_interfaces::set_validator_config_dev_defaults();
             let request: Vec<u8> = String::from("Hello").as_bytes().into();
             let nonce = 5;
             let full_request: Vec<u8> = format!("\x19Ethereum Signed Message:\n75:Hello")
@@ -400,7 +395,6 @@ mod tests {
     #[test]
     fn test_publish_signature_invalid_signature() {
         new_test_ext().execute_with(|| {
-            runtime_interfaces::set_validator_config_dev_defaults();
             let chain_id = ChainId::Eth;
             let notice_id = NoticeId(5, 6);
             let notice = Notice::ExtractionNotice(ExtractionNotice::Eth {
@@ -438,7 +432,6 @@ mod tests {
     #[test]
     fn test_publish_signature_invalid_validator() {
         new_test_ext().execute_with(|| {
-            runtime_interfaces::set_validator_config_dev_defaults();
             let chain_id = ChainId::Eth;
             let notice_id = NoticeId(5, 6);
             let notice = Notice::ExtractionNotice(ExtractionNotice::Eth {
@@ -473,7 +466,6 @@ mod tests {
     #[test]
     fn test_publish_signature_valid() {
         new_test_ext().execute_with(|| {
-            runtime_interfaces::set_validator_config_dev_defaults();
             let chain_id = ChainId::Eth;
             let notice_id = NoticeId(5, 6);
             let notice = Notice::ExtractionNotice(ExtractionNotice::Eth {

--- a/pallets/cash/src/tests/mod.rs
+++ b/pallets/cash/src/tests/mod.rs
@@ -72,7 +72,6 @@ macro_rules! qty {
 }
 
 pub fn initialize_storage() {
-    runtime_interfaces::set_validator_config_dev_defaults();
     CashModule::initialize_assets(vec![
         AssetInfo {
             liquidity_factor: FromStr::from_str("7890").unwrap(),

--- a/pallets/oracle/src/tests/mod.rs
+++ b/pallets/oracle/src/tests/mod.rs
@@ -11,7 +11,6 @@ pub use mock::*;
 pub const ETH_TICKER: Ticker = Ticker::new("ETH");
 
 pub fn initialize_storage() {
-    runtime_interfaces::set_validator_config_dev_defaults();
     OracleModule::initialize_reporters(
         vec![
             "0x85615b076615317c80f14cbad6501eec031cd51c",


### PR DESCRIPTION
We were previously inserting a lot of the validator configuration via environment variables only.

We now have the ability to configure the node via CLI with an environment variable override. This allows everyone that already set up environment variables to continue using them while at the same time allowing our integration tests to set the variables in the CLI. 