### PR TITLE
Derive Types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ releases
 # Chains
 chains/dev/*
 *.gateway_history
+
+# Backups
+*.bak

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,6 +1522,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+ "types-derive",
 ]
 
 [[package]]
@@ -4434,6 +4435,7 @@ dependencies = [
  "sp-std",
  "tiny-keccak 2.0.2",
  "trx-request",
+ "types-derive",
 ]
 
 [[package]]
@@ -4497,6 +4499,7 @@ dependencies = [
  "sp-runtime",
  "tiny-keccak 2.0.2",
  "trx-request",
+ "types-derive",
 ]
 
 [[package]]
@@ -7056,9 +7059,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.61"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
@@ -8940,6 +8943,16 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "types-derive"
+version = "0.1.0"
+dependencies = [
+ "lazy_static",
+ "quote 1.0.9",
+ "serde_json",
+ "syn 1.0.58",
+]
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2214,6 +2214,7 @@ dependencies = [
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
  "tempfile",
+ "types-derive",
  "wasm-timer",
 ]
 
@@ -2233,6 +2234,7 @@ dependencies = [
  "sp-core",
  "tiny-keccak 2.0.2",
  "tokio 0.2.25",
+ "types-derive",
 ]
 
 [[package]]
@@ -7063,6 +7065,7 @@ version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,6 @@ members = [
     'gateway-crypto',
     'ethereum-client',
     'test-utils/open-oracle-mock-reporter',
-    'trx-request'
+    'trx-request',
+    'types-derive',
 ]

--- a/base_types.json
+++ b/base_types.json
@@ -1,0 +1,16 @@
+{
+  "AccountId32": "[u8;32]",
+  "Authorities": "Vec<AccountId32>",
+  "Address": "MultiAddress",
+  "Keys": "SessionKeys",
+  "SignedPayload": "Vec<u8>",
+  "VersionedAuthorityList": {
+    "authorityList": "AuthorityList",
+    "version": "u8"
+  },
+  "LookupSource": "MultiAddress",
+  "SessionKeys": {
+    "aura": "[u8;32]",
+    "grandpa": "[u8;32]"
+  }
+}

--- a/ethereum-client/Cargo.toml
+++ b/ethereum-client/Cargo.toml
@@ -21,6 +21,8 @@ sp-std = { default-features = false, git = 'https://github.com/compound-finance/
 
 our-std = { path = '../our-std', default-features = false }
 
+types-derive = { path = '../types-derive' }
+
 [features]
 default = ['std']
 std = [

--- a/ethereum-client/src/events.rs
+++ b/ethereum-client/src/events.rs
@@ -3,7 +3,9 @@ use codec::{Decode, Encode};
 use our_std::convert::TryInto;
 use our_std::RuntimeDebug;
 
-#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+use types_derive::Types;
+
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum EthereumEvent {
     Lock {
         asset: [u8; 20],

--- a/ethereum-client/src/lib.rs
+++ b/ethereum-client/src/lib.rs
@@ -13,7 +13,9 @@ use our_std::RuntimeDebug;
 use serde::Deserialize;
 use sp_runtime::offchain::{http, Duration};
 
-#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+use types_derive::Types;
+
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum EthereumClientError {
     HttpIoError,
     HttpTimeout,
@@ -22,27 +24,27 @@ pub enum EthereumClientError {
     JsonParseError,
 }
 
-#[derive(Deserialize, RuntimeDebug, PartialEq)]
+#[derive(Deserialize, RuntimeDebug, PartialEq, Types)]
 pub struct ResponseError {
     pub message: Option<String>,
     pub code: Option<i64>,
 }
 
-#[derive(Deserialize, RuntimeDebug, PartialEq)]
+#[derive(Deserialize, RuntimeDebug, PartialEq, Types)]
 pub struct EventsResponse<T> {
     pub id: Option<u64>,
     pub result: Option<Vec<T>>,
     pub error: Option<ResponseError>,
 }
 
-#[derive(Deserialize, RuntimeDebug, PartialEq)]
+#[derive(Deserialize, RuntimeDebug, PartialEq, Types)]
 pub struct BlockResponse {
     pub id: Option<u64>,
     pub result: Option<String>,
     pub error: Option<ResponseError>,
 }
 
-#[derive(Deserialize, RuntimeDebug, PartialEq)]
+#[derive(Deserialize, RuntimeDebug, PartialEq, Types)]
 #[serde(rename_all = "camelCase")]
 pub struct LogObject {
     /// true when the log was removed, due to a chain reorganization. false if it's a valid log.

--- a/ethereum-client/src/lib.rs
+++ b/ethereum-client/src/lib.rs
@@ -15,7 +15,7 @@ use sp_runtime::offchain::{http, Duration};
 
 use types_derive::Types;
 
-#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
 pub enum EthereumClientError {
     HttpIoError,
     HttpTimeout,
@@ -24,27 +24,27 @@ pub enum EthereumClientError {
     JsonParseError,
 }
 
-#[derive(Deserialize, RuntimeDebug, PartialEq, Types)]
+#[derive(Deserialize, RuntimeDebug, PartialEq)]
 pub struct ResponseError {
     pub message: Option<String>,
     pub code: Option<i64>,
 }
 
-#[derive(Deserialize, RuntimeDebug, PartialEq, Types)]
+#[derive(Deserialize, RuntimeDebug, PartialEq)]
 pub struct EventsResponse<T> {
     pub id: Option<u64>,
     pub result: Option<Vec<T>>,
     pub error: Option<ResponseError>,
 }
 
-#[derive(Deserialize, RuntimeDebug, PartialEq, Types)]
+#[derive(Deserialize, RuntimeDebug, PartialEq)]
 pub struct BlockResponse {
     pub id: Option<u64>,
     pub result: Option<String>,
     pub error: Option<ResponseError>,
 }
 
-#[derive(Deserialize, RuntimeDebug, PartialEq, Types)]
+#[derive(Deserialize, RuntimeDebug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct LogObject {
     /// true when the log was removed, due to a chain reorganization. false if it's a valid log.
@@ -79,7 +79,7 @@ fn deserialize_get_block_number_response(
     serde_json::from_str(response)
 }
 
-#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub struct EthereumLogEvent {
     pub block_hash: [u8; 32],
     pub block_number: u64,

--- a/gateway-crypto/Cargo.toml
+++ b/gateway-crypto/Cargo.toml
@@ -23,6 +23,8 @@ sp-core = { default-features = false, git = 'https://github.com/compound-finance
 
 our-std = { path = "../our-std", default-features = false }
 
+types-derive = { path = "../types-derive" }
+
 [features]
 default = ['std']
 std = [

--- a/gateway-crypto/src/no_std.rs
+++ b/gateway-crypto/src/no_std.rs
@@ -2,6 +2,8 @@ use codec::{Decode, Encode};
 use our_std::{convert::TryInto, RuntimeDebug};
 use tiny_keccak::Hasher;
 
+use types_derive::Types;
+
 pub type SignatureBytes = [u8; 65];
 
 pub type AddressBytes = [u8; 20];
@@ -19,7 +21,7 @@ pub type HashedMessageBytes = [u8; 32];
 /// * The key id provided is unknown
 /// * The HSM is not available
 /// * The HSM failed to sign this request for some other reason
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug, Types)]
 pub enum CryptoError {
     Unknown,
     KeyNotFound,

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -81,6 +81,8 @@ pallet-cash-runtime-api = { path = '../pallets/cash/runtime-api' }
 pallet-oracle = { path = '../pallets/oracle' }
 runtime-interfaces = { path = '../pallets/runtime-interfaces' }
 
+types-derive = { path = '../types-derive' }
+
 [dev-dependencies]
 tempfile = "3.1.0"
 
@@ -92,7 +94,7 @@ sp-timestamp = { default-features = false, git = 'https://github.com/compound-fi
 frame-system = { git = 'https://github.com/compound-finance/substrate', branch = 'master' }
 
 [features]
-default = ['with-rocks-db', 'runtime-benchmarks']
+default = ['with-parity-db']
 with-parity-db=['sc-client-db/with-parity-db']
 with-rocks-db=['sc-client-db/with-kvdb-rocksdb']
 runtime-benchmarks = [

--- a/node/src/api.rs
+++ b/node/src/api.rs
@@ -18,15 +18,20 @@ use pallet_cash::{
 use pallet_cash_runtime_api::CashApi as CashRuntimeApi;
 use pallet_oracle::types::AssetPrice;
 
+use types_derive::{type_alias, Types};
+
 const RUNTIME_ERROR: i64 = 1;
 const CHAIN_ERROR: i64 = 2;
 
 // Note: no 128 bit integers for the moment
 //  due to issues with serde/serde_json
+#[type_alias]
 pub type ApiAPR = u64;
+
+#[type_alias]
 pub type ApiRates = (ApiAPR, ApiAPR);
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Types)]
 pub struct ApiAssetData {
     asset: ChainAsset,
     balance: String,
@@ -38,7 +43,7 @@ pub struct ApiAssetData {
     price: String,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Types)]
 pub struct ApiCashData {
     balance: String,
     cash_yield: String,

--- a/pallets/cash/Cargo.toml
+++ b/pallets/cash/Cargo.toml
@@ -46,6 +46,8 @@ gateway-crypto = { path = '../../gateway-crypto', default-features = false }
 trx-request = { path = '../../trx-request', default-features = false }
 our-std = { path = '../../our-std', default-features = false }
 
+types-derive = { path = '../../types-derive' }
+
 [dev-dependencies]
 frame-benchmarking = { git = 'https://github.com/compound-finance/substrate', branch = 'master'}
 serial_test = "*"

--- a/pallets/cash/src/chains.rs
+++ b/pallets/cash/src/chains.rs
@@ -9,9 +9,11 @@ use codec::{Decode, Encode};
 use gateway_crypto::public_key_bytes_to_eth_address;
 use our_std::{str::FromStr, Debuggable, Deserialize, RuntimeDebug, Serialize};
 
+use types_derive::{type_alias, Types};
+
 /// Type for representing the selection of a supported chain.
 #[derive(Serialize, Deserialize)] // used in config
-#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum ChainId {
     Gate,
     Eth,
@@ -99,7 +101,7 @@ impl Default for ChainId {
 }
 
 /// Type for an account tied to a chain.
-#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum ChainAccount {
     Gate(<Gateway as Chain>::Address),
     Eth(<Ethereum as Chain>::Address),
@@ -143,7 +145,7 @@ impl From<ChainAccount> for String {
 }
 
 /// Type for an asset tied to a chain.
-#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum ChainAsset {
     Gate(<Gateway as Chain>::Address),
     Eth(<Ethereum as Chain>::Address),
@@ -187,7 +189,7 @@ impl From<ChainAsset> for String {
 }
 
 /// Type for a signature and account tied to a chain.
-#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum ChainAccountSignature {
     Gate(<Gateway as Chain>::Address, <Gateway as Chain>::Signature),
     Eth(<Ethereum as Chain>::Address, <Ethereum as Chain>::Signature),
@@ -223,7 +225,7 @@ impl ChainAccountSignature {
 }
 
 /// Type for an hash tied to a chain.
-#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum ChainHash {
     Gate(<Gateway as Chain>::Hash),
     Eth(<Ethereum as Chain>::Hash),
@@ -233,7 +235,7 @@ pub enum ChainHash {
 }
 
 /// Type for a signature tied to a chain.
-#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum ChainSignature {
     Gate(<Gateway as Chain>::Signature),
     Eth(<Ethereum as Chain>::Signature),
@@ -262,7 +264,7 @@ impl ChainSignature {
 }
 
 /// Type for a list of chain signatures.
-#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum ChainSignatureList {
     Gate(Vec<(<Gateway as Chain>::Address, <Gateway as Chain>::Signature)>),
     Eth(Vec<(<Ethereum as Chain>::Address, <Ethereum as Chain>::Signature)>),
@@ -371,7 +373,34 @@ impl Chain for Gateway {
 impl Chain for Ethereum {
     const ID: ChainId = ChainId::Eth;
 
+    #[type_alias("Ethereum__Chain__")]
+    type Address = [u8; 20];
+
+    #[type_alias("Ethereum__Chain__")]
+    type Amount = u128;
+
+    #[type_alias("Ethereum__Chain__")]
+    type CashIndex = u128;
+
+    #[type_alias("Ethereum__Chain__")]
+    type Rate = u128;
+
+    #[type_alias("Ethereum__Chain__")]
+    type Timestamp = u64;
+
+    #[type_alias("Ethereum__Chain__")]
+    type Hash = [u8; 32];
+
+    #[type_alias("Ethereum__Chain__")]
+    type PublicKey = [u8; 64];
+
+    #[type_alias("Ethereum__Chain__")]
+    type Signature = [u8; 65];
+
+    #[type_alias("Ethereum__Chain__")]
     type EventId = eth::EventId;
+
+    #[type_alias("Ethereum__Chain__")]
     type Event = eth::Event;
 
     fn zero_hash() -> Self::Hash {
@@ -582,14 +611,20 @@ pub mod eth {
     use codec::{Decode, Encode};
     use our_std::RuntimeDebug;
 
+    use types_derive::type_alias;
+
     #[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
     pub enum RecoveryError {
         SignatureRecoveryError,
     }
 
+    #[type_alias("Eth__")]
     pub type BlockNumber = u64;
+
+    #[type_alias("Eth__")]
     pub type LogIndex = u64;
 
+    #[type_alias("Eth__")]
     pub type EventId = (BlockNumber, LogIndex);
 
     #[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]

--- a/pallets/cash/src/chains.rs
+++ b/pallets/cash/src/chains.rs
@@ -289,14 +289,14 @@ impl FromStr for ChainId {
 pub trait Chain {
     const ID: ChainId;
 
-    type Address: Debuggable + Clone + Eq + Into<Vec<u8>> = [u8; 20];
-    type Amount: Debuggable + Clone + Eq + Into<AssetAmount> = u128;
-    type CashIndex: Debuggable + Clone + Eq + Into<CashIndex> = u128;
-    type Rate: Debuggable + Clone + Eq + Into<APR> = u128;
-    type Timestamp: Debuggable + Clone + Eq + Into<Timestamp> = u64;
-    type Hash: Debuggable + Clone + Eq = [u8; 32];
-    type PublicKey: Debuggable + Clone + Eq = [u8; 64];
-    type Signature: Debuggable + Clone + Eq = [u8; 65]; // secp256k1 sign
+    type Address: Debuggable + Clone + Eq + Into<Vec<u8>>;
+    type Amount: Debuggable + Clone + Eq + Into<AssetAmount>;
+    type CashIndex: Debuggable + Clone + Eq + Into<CashIndex>;
+    type Rate: Debuggable + Clone + Eq + Into<APR>;
+    type Timestamp: Debuggable + Clone + Eq + Into<Timestamp>;
+    type Hash: Debuggable + Clone + Eq;
+    type PublicKey: Debuggable + Clone + Eq;
+    type Signature: Debuggable + Clone + Eq;
     type EventId: Debuggable + Clone + Eq + Ord;
     type Event: Debuggable + Clone + Eq;
 
@@ -331,7 +331,34 @@ pub struct Tezos {}
 impl Chain for Gateway {
     const ID: ChainId = ChainId::Gate;
 
+    #[type_alias("Gateway__Chain__")]
+    type Address = [u8; 20];
+
+    #[type_alias("Gateway__Chain__")]
+    type Amount = u128;
+
+    #[type_alias("Gateway__Chain__")]
+    type CashIndex = u128;
+
+    #[type_alias("Gateway__Chain__")]
+    type Rate = u128;
+
+    #[type_alias("Gateway__Chain__")]
+    type Timestamp = u64;
+
+    #[type_alias("Gateway__Chain__")]
+    type Hash = [u8; 32];
+
+    #[type_alias("Gateway__Chain__")]
+    type PublicKey = [u8; 64];
+
+    #[type_alias("Gateway__Chain__")]
+    type Signature = [u8; 65];
+
+    #[type_alias("Gateway__Chain__")]
     type EventId = comp::EventId;
+
+    #[type_alias("Gateway__Chain__")]
     type Event = comp::Event;
 
     fn zero_hash() -> Self::Hash {
@@ -466,7 +493,34 @@ impl Chain for Ethereum {
 impl Chain for Polkadot {
     const ID: ChainId = ChainId::Dot;
 
+    #[type_alias("Polkadot__Chain__")]
+    type Address = [u8; 20];
+
+    #[type_alias("Polkadot__Chain__")]
+    type Amount = u128;
+
+    #[type_alias("Polkadot__Chain__")]
+    type CashIndex = u128;
+
+    #[type_alias("Polkadot__Chain__")]
+    type Rate = u128;
+
+    #[type_alias("Polkadot__Chain__")]
+    type Timestamp = u64;
+
+    #[type_alias("Polkadot__Chain__")]
+    type Hash = [u8; 32];
+
+    #[type_alias("Polkadot__Chain__")]
+    type PublicKey = [u8; 64];
+
+    #[type_alias("Polkadot__Chain__")]
+    type Signature = [u8; 65];
+
+    #[type_alias("Polkadot__Chain__")]
     type EventId = dot::EventId;
+
+    #[type_alias("Polkadot__Chain__")]
     type Event = dot::Event;
 
     fn zero_hash() -> Self::Hash {
@@ -508,7 +562,34 @@ impl Chain for Polkadot {
 impl Chain for Solana {
     const ID: ChainId = ChainId::Sol;
 
+    #[type_alias("Solana__Chain__")]
+    type Address = [u8; 20];
+
+    #[type_alias("Solana__Chain__")]
+    type Amount = u128;
+
+    #[type_alias("Solana__Chain__")]
+    type CashIndex = u128;
+
+    #[type_alias("Solana__Chain__")]
+    type Rate = u128;
+
+    #[type_alias("Solana__Chain__")]
+    type Timestamp = u64;
+
+    #[type_alias("Solana__Chain__")]
+    type Hash = [u8; 32];
+
+    #[type_alias("Solana__Chain__")]
+    type PublicKey = [u8; 64];
+
+    #[type_alias("Solana__Chain__")]
+    type Signature = [u8; 65];
+
+    #[type_alias("Solana__Chain__")]
     type EventId = sol::EventId;
+
+    #[type_alias("Solana__Chain__")]
     type Event = sol::Event;
 
     fn zero_hash() -> Self::Hash {
@@ -550,7 +631,34 @@ impl Chain for Solana {
 impl Chain for Tezos {
     const ID: ChainId = ChainId::Tez;
 
+    #[type_alias("Tezos__Chain__")]
+    type Address = [u8; 20];
+
+    #[type_alias("Tezos__Chain__")]
+    type Amount = u128;
+
+    #[type_alias("Tezos__Chain__")]
+    type CashIndex = u128;
+
+    #[type_alias("Tezos__Chain__")]
+    type Rate = u128;
+
+    #[type_alias("Tezos__Chain__")]
+    type Timestamp = u64;
+
+    #[type_alias("Tezos__Chain__")]
+    type Hash = [u8; 32];
+
+    #[type_alias("Tezos__Chain__")]
+    type PublicKey = [u8; 64];
+
+    #[type_alias("Tezos__Chain__")]
+    type Signature = [u8; 65];
+
+    #[type_alias("Tezos__Chain__")]
     type EventId = tez::EventId;
+
+    #[type_alias("Tezos__Chain__")]
     type Event = tez::Event;
 
     fn zero_hash() -> Self::Hash {
@@ -597,6 +705,9 @@ pub mod comp {
     use codec::{Decode, Encode};
     use our_std::RuntimeDebug;
 
+    use types_derive::type_alias;
+
+    #[type_alias("comp__")]
     pub type EventId = (u64, u64); // XXX
 
     #[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
@@ -618,13 +729,13 @@ pub mod eth {
         SignatureRecoveryError,
     }
 
-    #[type_alias("Eth__")]
+    #[type_alias("eth__")]
     pub type BlockNumber = u64;
 
-    #[type_alias("Eth__")]
+    #[type_alias("eth__")]
     pub type LogIndex = u64;
 
-    #[type_alias("Eth__")]
+    #[type_alias("eth__")]
     pub type EventId = (BlockNumber, LogIndex);
 
     #[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
@@ -658,6 +769,9 @@ pub mod dot {
     use codec::{Decode, Encode};
     use our_std::RuntimeDebug;
 
+    use types_derive::type_alias;
+
+    #[type_alias("dot__")]
     pub type EventId = (u64, u64);
 
     #[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
@@ -668,6 +782,9 @@ pub mod sol {
     use codec::{Decode, Encode};
     use our_std::RuntimeDebug;
 
+    use types_derive::type_alias;
+
+    #[type_alias("sol__")]
     pub type EventId = (u64, u64);
 
     #[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
@@ -678,6 +795,9 @@ pub mod tez {
     use codec::{Decode, Encode};
     use our_std::RuntimeDebug;
 
+    use types_derive::type_alias;
+
+    #[type_alias("tez__")]
     pub type EventId = (u128, u128);
 
     #[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]

--- a/pallets/cash/src/events.rs
+++ b/pallets/cash/src/events.rs
@@ -4,17 +4,20 @@ use crate::reason::Reason;
 use crate::types::SignersSet;
 use codec::alloc::string::String;
 use codec::{Decode, Encode};
+use ethereum_client::EthereumClientError;
 use our_std::{vec::Vec, RuntimeDebug};
+
+use types_derive::Types;
 
 extern crate ethereum_client;
 
-#[derive(RuntimeDebug)]
+#[derive(RuntimeDebug, Types)]
 pub struct EventInfo {
     pub latest_eth_block: u64,
     pub events: Vec<(ChainLogId, ChainLogEvent)>,
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum ChainLogId {
     Eth(eth::BlockNumber, eth::LogIndex),
 }
@@ -29,7 +32,7 @@ impl ChainLogId {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum ChainLogEvent {
     Eth(ethereum_client::EthereumLogEvent),
 }
@@ -47,7 +50,7 @@ impl ChainLogEvent {
 }
 
 /// Type for the status of an event on the queue.
-#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum EventState {
     Pending { signers: SignersSet },
     Failed { reason: Reason },
@@ -62,12 +65,12 @@ impl Default for EventState {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum EventError {
     EthRpcUrlMissing,
     EthRpcUrlInvalid,
     StarportAddressInvalid,
-    EthereumClientError(ethereum_client::EthereumClientError),
+    EthereumClientError(EthereumClientError),
     ErrorDecodingHex,
 }
 

--- a/pallets/cash/src/events.rs
+++ b/pallets/cash/src/events.rs
@@ -4,7 +4,7 @@ use crate::reason::Reason;
 use crate::types::SignersSet;
 use codec::alloc::string::String;
 use codec::{Decode, Encode};
-use ethereum_client::EthereumClientError;
+use ethereum_client::{EthereumClientError, EthereumLogEvent};
 use our_std::{vec::Vec, RuntimeDebug};
 
 use types_derive::Types;
@@ -34,7 +34,7 @@ impl ChainLogId {
 
 #[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum ChainLogEvent {
-    Eth(ethereum_client::EthereumLogEvent),
+    Eth(EthereumLogEvent),
 }
 
 impl ChainLogEvent {
@@ -65,7 +65,7 @@ impl Default for EventState {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
 pub enum EventError {
     EthRpcUrlMissing,
     EthRpcUrlInvalid,

--- a/pallets/cash/src/factor.rs
+++ b/pallets/cash/src/factor.rs
@@ -8,6 +8,8 @@ use crate::{
     types::{Decimals, Int, Uint},
 };
 
+use types_derive::Types;
+
 /// Type for wrapping intermediate signed calculations.
 pub struct BigInt(pub BigI);
 
@@ -92,7 +94,7 @@ impl BigUint {
 
 /// Type for an unsigned factor, with a large fixed number of decimals.
 #[derive(Serialize, Deserialize)] // used in config
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug, Types)]
 pub struct Factor(pub Uint);
 
 impl Factor {

--- a/pallets/cash/src/internal/set_yield_next.rs
+++ b/pallets/cash/src/internal/set_yield_next.rs
@@ -12,7 +12,9 @@ use codec::{Decode, Encode};
 use frame_support::storage::StorageValue;
 use our_std::Debuggable;
 
-#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, Debuggable)]
+use types_derive::Types;
+
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, Debuggable, Types)]
 pub enum SetYieldNextError {
     TimestampTooSoonToNow,
     TimestampTooSoonToNext,

--- a/pallets/cash/src/internal/validate_trx.rs
+++ b/pallets/cash/src/internal/validate_trx.rs
@@ -12,9 +12,7 @@ use frame_support::storage::{IterableStorageMap, StorageDoubleMap, StorageValue}
 use our_std::RuntimeDebug;
 use sp_runtime::transaction_validity::{TransactionSource, TransactionValidity, ValidTransaction};
 
-use types_derive::Types;
-
-#[derive(Eq, PartialEq, RuntimeDebug, Types)]
+#[derive(Eq, PartialEq, RuntimeDebug)]
 pub enum ValidationError {
     InvalidInternalOnly,
     InvalidNextCode,

--- a/pallets/cash/src/internal/validate_trx.rs
+++ b/pallets/cash/src/internal/validate_trx.rs
@@ -12,7 +12,9 @@ use frame_support::storage::{IterableStorageMap, StorageDoubleMap, StorageValue}
 use our_std::RuntimeDebug;
 use sp_runtime::transaction_validity::{TransactionSource, TransactionValidity, ValidTransaction};
 
-#[derive(Eq, PartialEq, RuntimeDebug)]
+use types_derive::Types;
+
+#[derive(Eq, PartialEq, RuntimeDebug, Types)]
 pub enum ValidationError {
     InvalidInternalOnly,
     InvalidNextCode,

--- a/pallets/cash/src/lib.rs
+++ b/pallets/cash/src/lib.rs
@@ -44,6 +44,7 @@ use pallet_oracle;
 use pallet_oracle::ticker::Ticker;
 use pallet_session;
 use pallet_timestamp;
+use types_derive::type_alias;
 
 #[macro_use]
 extern crate lazy_static;
@@ -74,6 +75,7 @@ pub mod benchmarking;
 mod tests;
 
 /// Type for linking sessions to validators.
+#[type_alias]
 pub type SubstrateId = AccountId32;
 
 /// Configure the pallet by specifying the parameters and types on which it depends.

--- a/pallets/cash/src/notices.rs
+++ b/pallets/cash/src/notices.rs
@@ -8,13 +8,19 @@ use codec::{Decode, Encode};
 use ethabi::Token;
 use our_std::{vec::Vec, RuntimeDebug};
 
+use types_derive::{type_alias, Types};
+
 /// Type for a generic encoded message, potentially for any chain.
+#[type_alias]
 pub type EncodedNotice = Vec<u8>;
 
+#[type_alias]
 pub type EraId = u32;
+
+#[type_alias]
 pub type EraIndex = u32;
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug, Types)]
 pub struct NoticeId(pub EraId, pub EraIndex);
 
 impl NoticeId {
@@ -50,7 +56,7 @@ lazy_static! {
         <Ethereum as Chain>::hash_bytes(b"changeAuthorities(address[])");
 }
 
-#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum ExtractionNotice {
     Eth {
         id: NoticeId,
@@ -61,7 +67,7 @@ pub enum ExtractionNotice {
     },
 }
 
-#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum CashExtractionNotice {
     Eth {
         id: NoticeId,
@@ -71,7 +77,7 @@ pub enum CashExtractionNotice {
     },
 }
 
-#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum FutureYieldNotice {
     Eth {
         id: NoticeId,
@@ -82,7 +88,7 @@ pub enum FutureYieldNotice {
     },
 }
 
-#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum SetSupplyCapNotice {
     Eth {
         id: NoticeId,
@@ -92,7 +98,7 @@ pub enum SetSupplyCapNotice {
     },
 }
 
-#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum ChangeAuthorityNotice {
     Eth {
         id: NoticeId,
@@ -101,7 +107,7 @@ pub enum ChangeAuthorityNotice {
     },
 }
 
-#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum Notice {
     ExtractionNotice(ExtractionNotice),
     CashExtractionNotice(CashExtractionNotice),
@@ -306,7 +312,7 @@ pub fn default_notice_signatures(notice: &Notice) -> ChainSignatureList {
 }
 
 /// Type for the status of a notice on the queue.
-#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum NoticeState {
     Missing,
     Pending { signature_pairs: ChainSignatureList },

--- a/pallets/cash/src/portfolio.rs
+++ b/pallets/cash/src/portfolio.rs
@@ -11,8 +11,10 @@ use crate::{
     AssetBalances, AssetsWithNonZeroBalance, Config,
 };
 
+use types_derive::Types;
+
 /// Type for representing a set of positions for an account.
-#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub struct Portfolio {
     pub cash: Balance,
     pub positions: Vec<(AssetInfo, Balance)>,

--- a/pallets/cash/src/primitives.rs
+++ b/pallets/cash/src/primitives.rs
@@ -6,6 +6,7 @@ use our_std::{
     RuntimeDebug,
 };
 
+// TODO: This conflicts with `Uint` defined in types.rs
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, RuntimeDebug)]
 pub struct Uint(pub BigUint);
 

--- a/pallets/cash/src/rates.rs
+++ b/pallets/cash/src/rates.rs
@@ -11,8 +11,10 @@ use crate::{
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 
+use types_derive::Types;
+
 /// Error enum for interest rates
-#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum RatesError {
     ModelRateOutOfBounds,
     ZeroAboveKink,
@@ -23,7 +25,7 @@ pub enum RatesError {
 
 /// Annualized interest rate
 #[derive(Serialize, Deserialize)] // used in config
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug, Types)]
 pub struct APR(pub Uint);
 
 impl From<Uint> for APR {
@@ -102,7 +104,7 @@ pub fn get_utilization(supplied: AssetAmount, borrowed: AssetAmount) -> Result<F
 
 /// This represents an interest rate model type and parameters.
 #[derive(Serialize, Deserialize)] // used in config
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug, Types)]
 pub enum InterestRateModel {
     Kink {
         zero_rate: APR,

--- a/pallets/cash/src/reason.rs
+++ b/pallets/cash/src/reason.rs
@@ -9,8 +9,10 @@ use our_std::RuntimeDebug;
 use pallet_oracle::error::OracleError;
 use trx_request;
 
+use types_derive::Types;
+
 /// Type for reporting failures for reasons outside of our control.
-#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum Reason {
     AssetExtractionNotSupported,
     AssetNotSupported,
@@ -177,7 +179,7 @@ impl serde::de::Error for Reason {
 impl serde::de::StdError for Reason {}
 
 /// Type for reporting failures from calculations.
-#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum MathError {
     AbnormalFloatingPointResult,
     DivisionByZero,
@@ -189,7 +191,7 @@ pub enum MathError {
 }
 
 /// Error from parsing trx requests.
-#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum TrxReqParseError {
     NotImplemented,
     LexError,

--- a/pallets/cash/src/symbol.rs
+++ b/pallets/cash/src/symbol.rs
@@ -11,9 +11,11 @@ use crate::{
 };
 use pallet_oracle::ticker::{Ticker, CASH_TICKER, USD_TICKER};
 
+use types_derive::Types;
+
 /// Type for the abstract symbol of an asset, not tied to a chain.
-#[derive(Copy, Clone, Eq, Encode, Decode, PartialEq, Ord, PartialOrd, RuntimeDebug)]
-pub struct Symbol(pub [u8; WIDTH]);
+#[derive(Copy, Clone, Eq, Encode, Decode, PartialEq, Ord, PartialOrd, RuntimeDebug, Types)]
+pub struct Symbol(pub [u8; 12]);
 
 impl Symbol {
     pub const fn new(symbol_str: &str) -> Self {
@@ -41,7 +43,7 @@ impl From<Symbol> for String {
 }
 
 /// Type for determining whether quantities may be combined.
-#[derive(Copy, Clone, Eq, Encode, Decode, PartialEq, Ord, PartialOrd, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, Encode, Decode, PartialEq, Ord, PartialOrd, RuntimeDebug, Types)]
 pub struct Units {
     pub ticker: Ticker,
     pub decimals: Decimals,

--- a/pallets/cash/src/types.rs
+++ b/pallets/cash/src/types.rs
@@ -10,6 +10,8 @@ use frame_support::sp_runtime::DispatchError;
 
 use pallet_oracle::{ticker::Ticker, types::Price};
 
+use types_derive::{type_alias, Types};
+
 pub use crate::{
     chains::{Chain, ChainAsset, ChainId, Ethereum},
     factor::{BigInt, BigUint, Factor},
@@ -23,55 +25,71 @@ pub use crate::{
 // Type aliases //
 
 /// Type for representing a percentage/fractional, often between [0, 100].
+#[type_alias]
 pub type Bips = u128;
 
 /// Type for representing a number of decimal places.
+#[type_alias]
 pub type Decimals = u8;
 
 /// Type for a nonce.
+#[type_alias]
 pub type Nonce = u32;
 
 /// Type for representing time since current Unix epoch in milliseconds.
+#[type_alias]
 pub type Timestamp = u64;
 
 /// Type of the largest possible signed integer.
+#[type_alias]
 pub type Int = i128;
 
 /// Type of the largest possible unsigned integer.
+#[type_alias]
 pub type Uint = u128;
 
 /// Type for a generic encoded message, potentially for any chain.
+#[type_alias]
 pub type EncodedNotice = Vec<u8>;
 
 /// Type for representing an amount, potentially of any symbol.
+#[type_alias]
 pub type AssetAmount = Uint;
 
 /// Type for representing an amount of CASH
+#[type_alias]
 pub type CashAmount = Uint;
 
 /// Type for representing a balance of a specific asset.
+#[type_alias]
 pub type AssetBalance = Int;
 
 /// Type for representing an amount of an asset, together with its units.
+#[type_alias]
 pub type AssetQuantity = Quantity;
 
 /// Type for representing a quantity of CASH.
+#[type_alias]
 pub type CashQuantity = Quantity; // ideally Quantity<{ CASH }>
 
 /// Type for representing a quantity of USD.
+#[type_alias]
 pub type USDQuantity = Quantity; // ideally Quantity<{ USD }>
 
 /// Type for a market's liquidity factor.
+#[type_alias]
 pub type LiquidityFactor = Factor;
 
 /// Type for the miner shares portion of interest going to miners.
+#[type_alias]
 pub type MinerShares = Factor;
 
 /// Type for a code hash.
+#[type_alias]
 pub type CodeHash = <Ethereum as Chain>::Hash; // XXX what to use?
 
 /// Governance Result type
-#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum GovernanceResult {
     FailedToDecodeCall,
     DispatchSuccess,
@@ -79,26 +97,30 @@ pub enum GovernanceResult {
 }
 
 /// Type for enumerating sessions.
+#[type_alias]
 pub type SessionIndex = u32;
 
 /// Type for an address used to identify a validator.
+#[type_alias]
 pub type ValidatorIdentity = <Ethereum as Chain>::Address;
 
 /// Type for signature used to verify that a signed payload comes from a validator.
+#[type_alias]
 pub type ValidatorSig = <Ethereum as Chain>::Signature;
 
 /// Type for signers set used to identify validators that signed this event.
+#[type_alias]
 pub type SignersSet = BTreeSet<ValidatorIdentity>;
 
 /// Type for representing the keys to sign notices.
-#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub struct ValidatorKeys {
     pub substrate_id: SubstrateId,
     pub eth_address: <Ethereum as Chain>::Address,
 }
 
 /// Type for referring to either an asset or CASH.
-#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub enum CashOrChainAsset {
     Cash,
     ChainAsset(ChainAsset),
@@ -106,7 +128,7 @@ pub enum CashOrChainAsset {
 
 /// Type for representing a quantity, potentially of any symbol.
 #[derive(Serialize, Deserialize)] // used in config
-#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, Types)]
 pub struct AssetInfo {
     pub asset: ChainAsset,
     pub decimals: Decimals,
@@ -154,7 +176,7 @@ impl AssetInfo {
 }
 
 /// Type for representing a quantity of an asset, bound to its ticker and number of decimals.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug, Types)]
 pub struct Quantity {
     pub value: AssetAmount,
     pub units: Units,
@@ -256,7 +278,7 @@ impl Quantity {
 }
 
 /// Type for representing a signed balance of an asset, bound to its ticker and number of decimals.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug, Types)]
 pub struct Balance {
     pub value: AssetBalance,
     pub units: Units,
@@ -327,7 +349,9 @@ impl Balance {
 }
 
 /// Type for representing a balance of CASH Principal.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Default, RuntimeDebug)]
+#[derive(
+    Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Default, RuntimeDebug, Types,
+)]
 pub struct CashPrincipal(pub AssetBalance);
 
 impl CashPrincipal {
@@ -385,7 +409,9 @@ impl CashPrincipal {
 }
 
 /// Type for representing an amount of CASH Principal.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Default, RuntimeDebug)]
+#[derive(
+    Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Default, RuntimeDebug, Types,
+)]
 pub struct CashPrincipalAmount(pub AssetAmount);
 
 impl CashPrincipalAmount {
@@ -434,8 +460,10 @@ impl TryInto<CashPrincipalAmount> for CashPrincipal {
 }
 
 /// Type for representing a multiplicative index on Gateway.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug, Types)]
 pub struct CashIndex(pub Uint);
+
+#[type_alias]
 pub type CashPerCashPrincipal = CashIndex;
 
 impl CashIndex {
@@ -530,8 +558,10 @@ where
 }
 
 /// Type for representing the additive asset indices.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug, Types)]
 pub struct AssetIndex(pub Uint);
+
+#[type_alias]
 pub type CashPrincipalPerAsset = AssetIndex;
 
 impl AssetIndex {

--- a/pallets/oracle/Cargo.toml
+++ b/pallets/oracle/Cargo.toml
@@ -43,6 +43,8 @@ gateway-crypto = { path = '../../gateway-crypto', default-features = false }
 trx-request = { path = '../../trx-request', default-features = false }
 our-std = { path = '../../our-std', default-features = false }
 
+types-derive = { path = '../../types-derive' }
+
 [features]
 default = ['std']
 std = [

--- a/pallets/oracle/src/error.rs
+++ b/pallets/oracle/src/error.rs
@@ -3,8 +3,10 @@ use frame_support;
 use gateway_crypto::CryptoError;
 use our_std::Debuggable;
 
+use types_derive::Types;
+
 /// Errors coming from the price oracle.
-#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, Debuggable)]
+#[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, Debuggable, Types)]
 pub enum OracleError {
     BadTicker,
     CryptoError,

--- a/pallets/oracle/src/ticker.rs
+++ b/pallets/oracle/src/ticker.rs
@@ -5,11 +5,13 @@ use our_std::{
     RuntimeDebug,
 };
 
+use types_derive::Types;
+
 use crate::error::OracleError;
 
 /// Type for an asset price ticker.
-#[derive(Copy, Clone, Eq, Encode, Decode, PartialEq, Ord, PartialOrd, RuntimeDebug)]
-pub struct Ticker(pub [u8; WIDTH]);
+#[derive(Copy, Clone, Eq, Encode, Decode, PartialEq, Ord, PartialOrd, RuntimeDebug, Types)]
+pub struct Ticker(pub [u8; 12]);
 
 impl Ticker {
     pub const fn new(ticker_str: &str) -> Self {

--- a/pallets/oracle/src/types.rs
+++ b/pallets/oracle/src/types.rs
@@ -2,13 +2,19 @@ use crate::{error::OracleError, ticker::Ticker};
 use codec::{Decode, Encode};
 use our_std::{consts::uint_from_string_with_decimals, convert::TryFrom, RuntimeDebug};
 
+use types_derive::{type_alias, Types};
+
 /// Type for an open price feed reporter.
+
+#[type_alias]
 pub type Reporter = [u8; 20];
 
 /// Type for representing time since current Unix epoch in milliseconds.
+#[type_alias("Oracle__")]
 pub type Timestamp = u64;
 
 /// Type for representing a price, potentially for any symbol.
+#[type_alias]
 pub type AssetPrice = u128;
 
 // XXX ideally we should really impl Ord ourselves for these
@@ -16,7 +22,7 @@ pub type AssetPrice = u128;
 //   would have to panic, though not for partial ord
 
 /// Type for representing a price (in USD), bound to its ticker.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug, Types)]
 pub struct Price {
     pub ticker: Ticker,
     pub value: AssetPrice,
@@ -37,7 +43,7 @@ impl Price {
 }
 
 /// Type for a set of open price feed reporters.
-#[derive(Clone, Eq, PartialEq, Encode, Decode, Default, RuntimeDebug)]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, Default, RuntimeDebug, Types)]
 pub struct ReporterSet(pub Vec<Reporter>);
 
 impl ReporterSet {

--- a/scripts/build_types.sh
+++ b/scripts/build_types.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+cd $(dirname ${BASH_SOURCE[0]})/..
+
+types_json="./types.json"
+
+cp "$types_json" "$types_json.bak"
+
+projects=("pallet-cash" "pallet-oracle" "ethereum-client")
+
+set -x
+
+json_files=()
+
+for project in ${projects[@]}; do
+  json_file="$(mktemp)"
+  echo "Building $project to $json_file"
+  cargo clean -p $project
+  TYPES_FILE="$json_file" cargo build -p $project
+  json_files[${#json_files[@]}]="$json_file"
+done
+
+jq -sS 'add' ${json_files[@]} > $types_json
+
+echo "Built $types_json"

--- a/scripts/build_types.sh
+++ b/scripts/build_types.sh
@@ -8,11 +8,11 @@ types_json="./types.json"
 
 cp "$types_json" "$types_json.bak"
 
-projects=("pallet-cash" "pallet-oracle" "ethereum-client")
+projects=("gateway" "pallet-cash" "pallet-oracle" "ethereum-client" "gateway-crypto")
 
 set -x
 
-json_files=()
+json_files=(./base_types.json)
 
 for project in ${projects[@]}; do
   json_file="$(mktemp)"
@@ -22,6 +22,6 @@ for project in ${projects[@]}; do
   json_files[${#json_files[@]}]="$json_file"
 done
 
-jq -sS 'add' ${json_files[@]} > $types_json
+jq -s 'add' ${json_files[@]} | jq -r 'to_entries|sort|from_entries' > $types_json
 
 echo "Built $types_json"

--- a/types-derive/Cargo.toml
+++ b/types-derive/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 syn = { version = "1.0", features=["full"] }
 quote = "1.0"
 lazy_static = '1.4.0'
-serde_json = "1.0.64"
+serde_json = { version = "1.0.64", features=["preserve_order"] }
 
 [lib]
 proc-macro = true

--- a/types-derive/Cargo.toml
+++ b/types-derive/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "types-derive"
+version = "0.1.0"
+authors = ["Geoffrey Hayes <hayesgm@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+syn = { version = "1.0", features=["full"] }
+quote = "1.0"
+lazy_static = '1.4.0'
+serde_json = "1.0.64"
+
+[lib]
+proc-macro = true

--- a/types-derive/src/lib.rs
+++ b/types-derive/src/lib.rs
@@ -52,7 +52,7 @@ pub fn derive_types(input: TokenStream) -> TokenStream {
 }
 
 fn write_types(new_types: Vec<(String, serde_json::Value)>) {
-    let data = serde_json::to_string_pretty(&json!(new_types
+    let data = serde_json::to_string(&json!(new_types
         .clone()
         .into_iter()
         .collect::<serde_json::Map<_, _>>()))
@@ -168,7 +168,7 @@ fn process_fields(
                     .collect::<Vec<_>>());
                 match prefix_opt {
                     Some(prefix) => {
-                        let new_type_name = format!("{}Type", prefix);
+                        let new_type_name = format!("{}", prefix);
                         new_types.push((new_type_name.clone(), ty));
                         json!(new_type_name)
                     }
@@ -187,7 +187,7 @@ fn process_fields(
                 .collect::<serde_json::Map<_, _>>());
             match prefix_opt {
                 Some(prefix) => {
-                    let new_type_name = format!("{}Type", prefix);
+                    let new_type_name = format!("{}", prefix);
                     new_types.push((new_type_name.clone(), ty));
                     json!(new_type_name)
                 }

--- a/types-derive/src/lib.rs
+++ b/types-derive/src/lib.rs
@@ -161,18 +161,22 @@ fn process_fields(
             if fields.unnamed.len() == 1 {
                 type_to_json(&fields.unnamed.iter().next().unwrap().ty)
             } else {
-                let ty = json!(fields
+                let ty_fields = fields
                     .unnamed
                     .iter()
-                    .map(|field| type_to_json(&field.ty))
-                    .collect::<Vec<_>>());
+                    .map(|field| type_to_str(&field.ty))
+                    .collect::<Vec<_>>()
+                    .join(",");
+
+                let ty = json!(format!("({})", ty_fields));
+
                 match prefix_opt {
                     Some(prefix) => {
                         let new_type_name = format!("{}", prefix);
                         new_types.push((new_type_name.clone(), ty));
                         json!(new_type_name)
                     }
-                    None => json!(ty),
+                    None => ty,
                 }
             }
         }

--- a/types-derive/src/lib.rs
+++ b/types-derive/src/lib.rs
@@ -1,0 +1,225 @@
+extern crate proc_macro;
+use lazy_static::lazy_static;
+use proc_macro::TokenStream;
+use serde_json;
+use serde_json::json;
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::io::{Seek, SeekFrom};
+use std::sync::Mutex;
+
+lazy_static! {
+    static ref TYPES: Mutex<Vec<(String, serde_json::Value)>> = Mutex::new(vec![]);
+    static ref TYPES_JSON: Mutex<File> = Mutex::new(
+        File::create(env::var("TYPES_FILE").unwrap_or(String::from("/tmp/types.json")))
+            .expect("Unable to create file")
+    );
+}
+
+#[proc_macro_attribute]
+pub fn type_alias(attr: TokenStream, item: TokenStream) -> TokenStream {
+    if let Ok(_) = env::var("TYPES_FILE") {
+        let prefix: Option<syn::LitStr> = syn::parse(attr).ok();
+        let ast: syn::ItemType = syn::parse(item.clone()).expect("was parsing...");
+
+        let mut new_types = TYPES.lock().unwrap();
+
+        new_types.push((
+            format!(
+                "{}{}",
+                prefix.map(|l| l.value()).unwrap_or(String::from("")),
+                ast.ident
+            ),
+            type_to_json(&*ast.ty),
+        ));
+
+        write_types(new_types.clone());
+    }
+
+    item
+}
+
+#[proc_macro_derive(Types)]
+pub fn derive_types(input: TokenStream) -> TokenStream {
+    if let Ok(_) = env::var("TYPES_FILE") {
+        let ast = syn::parse(input).unwrap();
+
+        derive_and_write_types(&ast);
+    }
+
+    TokenStream::new()
+}
+
+fn write_types(new_types: Vec<(String, serde_json::Value)>) {
+    let data = serde_json::to_string_pretty(&json!(new_types
+        .clone()
+        .into_iter()
+        .collect::<serde_json::Map<_, _>>()))
+    .expect("unable to serialize json");
+
+    let mut types_json = TYPES_JSON.lock().unwrap();
+
+    types_json
+        .set_len(0)
+        .expect("Unable to truncate types.json");
+
+    types_json
+        .seek(SeekFrom::Start(0))
+        .expect("Unable to seek to file start");
+
+    types_json
+        .write_all(data.as_bytes())
+        .expect("Unable to write data");
+}
+
+fn show_arg(arg: &syn::GenericArgument) -> String {
+    match arg {
+        syn::GenericArgument::Type(ty) => type_to_str(ty),
+        _ => String::from("unknown arg"),
+    }
+}
+
+fn show_segment(seg: &syn::PathSegment) -> String {
+    let args = match &seg.arguments {
+        syn::PathArguments::AngleBracketed(bracket_args) => {
+            let inner = bracket_args
+                .args
+                .iter()
+                .map(show_arg)
+                .collect::<Vec<_>>()
+                .join(",");
+
+            format!("<{}>", inner)
+        }
+        _ => format!(""),
+    };
+
+    format!("{}{}", seg.ident, args)
+}
+
+fn show_expr(e: &syn::Expr) -> String {
+    match e {
+        syn::Expr::Lit(l) => match &l.lit {
+            syn::Lit::Int(i) => i.to_string(),
+            _ => String::from("unknown lit"),
+        },
+        _ => String::from("unknown expr"),
+    }
+}
+
+fn type_to_str(ty: &syn::Type) -> String {
+    match ty {
+        syn::Type::Path(p) => {
+            let prefix = match &p.qself {
+                Some(qself) => format!("{}__", type_to_str(&*qself.ty)),
+                None => String::from(""),
+            };
+
+            let postfix = if p.path.segments.len() == 1 {
+                show_segment(p.path.segments.iter().next().unwrap())
+            } else {
+                p.path
+                    .segments
+                    .iter()
+                    .map(show_segment)
+                    .collect::<Vec<_>>()
+                    .join("__")
+            };
+
+            format!("{}{}", prefix, postfix)
+        }
+        syn::Type::Array(a) => {
+            let elem = type_to_str(&*a.elem);
+
+            format!("[{}; {}]", elem, show_expr(&a.len))
+        }
+        syn::Type::Tuple(tuple) => {
+            let inner = tuple
+                .elems
+                .iter()
+                .map(|ty_| type_to_str(ty_))
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("({})", inner)
+        }
+        _ => String::from("unknown type"),
+    }
+}
+
+fn type_to_json(ty: &syn::Type) -> serde_json::Value {
+    json!(type_to_str(ty))
+}
+
+fn process_fields(
+    new_types: &mut Vec<(String, serde_json::Value)>,
+    prefix_opt: Option<String>,
+    fields: &syn::Fields,
+) -> serde_json::Value {
+    match fields {
+        syn::Fields::Unnamed(fields) => {
+            if fields.unnamed.len() == 1 {
+                type_to_json(&fields.unnamed.iter().next().unwrap().ty)
+            } else {
+                let ty = json!(fields
+                    .unnamed
+                    .iter()
+                    .map(|field| type_to_json(&field.ty))
+                    .collect::<Vec<_>>());
+                match prefix_opt {
+                    Some(prefix) => {
+                        let new_type_name = format!("{}Type", prefix);
+                        new_types.push((new_type_name.clone(), ty));
+                        json!(new_type_name)
+                    }
+                    None => json!(ty),
+                }
+            }
+        }
+        syn::Fields::Named(fields) => {
+            let ty = json!(fields
+                .named
+                .iter()
+                .map(|field| (
+                    field.ident.clone().unwrap().to_string(),
+                    type_to_json(&field.ty)
+                ))
+                .collect::<serde_json::Map<_, _>>());
+            match prefix_opt {
+                Some(prefix) => {
+                    let new_type_name = format!("{}Type", prefix);
+                    new_types.push((new_type_name.clone(), ty));
+                    json!(new_type_name)
+                }
+                None => json!(ty),
+            }
+        }
+        syn::Fields::Unit => {
+            json!("")
+        }
+    }
+}
+
+fn merge_ident(a: &syn::Ident, b: &syn::Ident) -> String {
+    format!("{}{}", a.to_string(), b.to_string())
+}
+
+fn derive_and_write_types(ast: &syn::DeriveInput) {
+    let name = &ast.ident;
+
+    let mut new_types = TYPES.lock().unwrap();
+
+    let inner: serde_json::Value = match &ast.data {
+        syn::Data::Struct(data_struct) => process_fields(&mut new_types, None, &data_struct.fields),
+        syn::Data::Enum(data_enum) => json!({"_enum": data_enum
+            .variants
+            .iter()
+            .map(|variant| (variant.ident.to_string(), process_fields(&mut new_types, Some(merge_ident(&ast.ident, &variant.ident)), &variant.fields)))
+            .collect::<serde_json::Map<_, _>>()}),
+        _ => json!("not implemented"),
+    };
+
+    new_types.push((name.to_string(), inner));
+
+    write_types(new_types.clone());
+}

--- a/types.json
+++ b/types.json
@@ -1,251 +1,389 @@
 {
-  "Source0": "TypesRS",
-  "Decimals": "u8",
-  "Bips": "u128",
-  "Nonce": "u32",
-  "Timestamp": "u64",
-  "Int": "i128",
-  "Uint": "u128",
+  "APR": "Uint",
   "AssetAmount": "Uint",
   "AssetBalance": "Int",
-  "AssetQuantity": "Quantity",
-  "CashQuantity": "Quantity",
-  "USDQuantity": "Quantity",
-  "LiquidityFactor": "Factor",
-  "SignedPayload": "Vec<u8>",
-  "ValidatorSig": "[u8; 65]",
-  "ValidatorIdentity": "[u8; 20]",
-  "ValidatorKeys": {
-    "substrate_id": "SubstrateId",
-    "eth_address": "[u8; 20]"
-  },
-  "SignersSet": "BTreeSet<ValidatorIdentity>",
+  "AssetIndex": "Uint",
   "AssetInfo": {
     "asset": "ChainAsset",
     "decimals": "Decimals",
     "liquidity_factor": "LiquidityFactor",
-    "rate_model": "InterestRateModel",
     "miner_shares": "MinerShares",
+    "rate_model": "InterestRateModel",
     "supply_cap": "AssetAmount",
     "symbol": "Symbol",
     "ticker": "Ticker"
   },
-  "ConfigSetString": "Vec<String>",
-  "Quantity": ["Symbol", "AssetAmount"],
-  "CashPrincipal": "(Int)",
-  "CashPrincipalAmount": "(Uint)",
-  "CashIndex": "(Uint)",
-  "AssetIndex": "(Uint)",
-  "SessionIndex": "u32",
-  "AccountId32": "[u8;32]",
-  "SubstrateId": "AccountId32",
-  "GovernanceResult": {
+  "AssetPrice": "u128",
+  "AssetQuantity": "Quantity",
+  "Balance": {
+    "units": "Units",
+    "value": "AssetBalance"
+  },
+  "Bips": "u128",
+  "BlockResponse": {
+    "error": "Option<ResponseError>",
+    "id": "Option<u64>",
+    "result": "Option<String>"
+  },
+  "CashAmount": "Uint",
+  "CashExtractionNotice": {
     "_enum": {
-      "FailedToDecodeCall": "",
-      "DispatchSuccess": "",
-      "DispatchFailure": "(DispatchError)"
+      "Eth": "CashExtractionNoticeEthType"
     }
   },
-
-  "Source1": "SymbolRS",
-  "Symbol": "[u8; 12]",
-  "Units": "(Ticker, u8)",
-
-  "Source2": "ChainsRS",
-  "ChainId": {
-    "_enum": ["Comp", "Eth", "Dot", "Sol", "Tez"]
+  "CashExtractionNoticeEthType": {
+    "account": "Ethereum__Chain__Address",
+    "id": "NoticeId",
+    "parent": "Ethereum__Chain__Hash",
+    "principal": "Ethereum__Chain__Amount"
   },
-  "ChainAccount": {
-    "_enum": {
-      "Comp": ["[u8; 20]"],
-      "Eth": ["[u8; 20]"],
-      "Dot": ["[u8; 20]"],
-      "Sol": ["[u8; 20]"],
-      "Tez": ["[u8; 20]"]
-    }
-  },
-  "ChainHash": {
-    "_enum": {
-      "Comp": ["[u8; 32]"],
-      "Eth": ["[u8; 32]"],
-      "Dot": ["[u8; 32]"],
-      "Sol": ["[u8; 32]"],
-      "Tez": ["[u8; 32]"]
-    }
-  },
-  "CashAsset": {
+  "CashIndex": "Uint",
+  "CashOrChainAsset": {
     "_enum": {
       "Cash": "",
-      "Asset": "ChainAsset"
+      "ChainAsset": "ChainAsset"
     }
   },
-  "ChainAsset": {
+  "CashPerCashPrincipal": "CashIndex",
+  "CashPrincipal": "AssetBalance",
+  "CashPrincipalAmount": "AssetAmount",
+  "CashPrincipalPerAsset": "AssetIndex",
+  "CashQuantity": "Quantity",
+  "ChainAccount": {
     "_enum": {
-      "Comp": ["[u8; 20]"],
-      "Eth": ["[u8; 20]"],
-      "Dot": ["[u8; 20]"],
-      "Sol": ["[u8; 20]"],
-      "Tez": ["[u8; 20]"]
+      "Dot": "Polkadot__Chain__Address",
+      "Eth": "Ethereum__Chain__Address",
+      "Gate": "Gateway__Chain__Address",
+      "Sol": "Solana__Chain__Address",
+      "Tez": "Tezos__Chain__Address"
     }
   },
   "ChainAccountSignature": {
     "_enum": {
-      "Comp": "([u8; 20], [u8; 65])",
-      "Eth": "([u8; 20], [u8; 65])",
-      "Dot": "([u8; 20], [u8; 65])",
-      "Sol": "([u8; 20], [u8; 65])",
-      "Tez": "([u8; 20], [u8; 65])"
+      "Dot": "ChainAccountSignatureDotType",
+      "Eth": "ChainAccountSignatureEthType",
+      "Gate": "ChainAccountSignatureGateType",
+      "Sol": "ChainAccountSignatureSolType",
+      "Tez": "ChainAccountSignatureTezType"
     }
   },
+  "ChainAccountSignatureDotType": [
+    "Polkadot__Chain__Address",
+    "Polkadot__Chain__Signature"
+  ],
+  "ChainAccountSignatureEthType": [
+    "Ethereum__Chain__Address",
+    "Ethereum__Chain__Signature"
+  ],
+  "ChainAccountSignatureGateType": [
+    "Gateway__Chain__Address",
+    "Gateway__Chain__Signature"
+  ],
+  "ChainAccountSignatureSolType": [
+    "Solana__Chain__Address",
+    "Solana__Chain__Signature"
+  ],
+  "ChainAccountSignatureTezType": [
+    "Tezos__Chain__Address",
+    "Tezos__Chain__Signature"
+  ],
+  "ChainAsset": {
+    "_enum": {
+      "Dot": "Polkadot__Chain__Address",
+      "Eth": "Ethereum__Chain__Address",
+      "Gate": "Gateway__Chain__Address",
+      "Sol": "Solana__Chain__Address",
+      "Tez": "Tezos__Chain__Address"
+    }
+  },
+  "ChainHash": {
+    "_enum": {
+      "Dot": "Polkadot__Chain__Hash",
+      "Eth": "Ethereum__Chain__Hash",
+      "Gate": "Gateway__Chain__Hash",
+      "Sol": "Solana__Chain__Hash",
+      "Tez": "Tezos__Chain__Hash"
+    }
+  },
+  "ChainId": {
+    "_enum": {
+      "Dot": "",
+      "Eth": "",
+      "Gate": "",
+      "Sol": "",
+      "Tez": ""
+    }
+  },
+  "ChainLogEvent": {
+    "_enum": {
+      "Eth": "ethereum_client__EthereumLogEvent"
+    }
+  },
+  "ChainLogId": {
+    "_enum": {
+      "Eth": "ChainLogIdEthType"
+    }
+  },
+  "ChainLogIdEthType": [
+    "eth__BlockNumber",
+    "eth__LogIndex"
+  ],
   "ChainSignature": {
     "_enum": {
-      "Comp": ["[u8; 65]"],
-      "Eth": ["[u8; 65]"],
-      "Dot": ["[u8; 65]"],
-      "Sol": ["[u8; 65]"],
-      "Tez": ["[u8; 65]"]
+      "Dot": "Polkadot__Chain__Signature",
+      "Eth": "Ethereum__Chain__Signature",
+      "Gate": "Gateway__Chain__Signature",
+      "Sol": "Solana__Chain__Signature",
+      "Tez": "Tezos__Chain__Signature"
     }
   },
   "ChainSignatureList": {
     "_enum": {
-      "Comp": ["Vec<([u8; 20], [u8; 65])>"],
-      "Eth": ["Vec<([u8; 20], [u8; 65])>"],
-      "Dot": ["Vec<([u8; 20], [u8; 65])>"],
-      "Sol": ["Vec<([u8; 20], [u8; 65])>"],
-      "Tez": ["Vec<([u8; 20], [u8; 65])>"]
+      "Dot": "Vec<(Polkadot__Chain__Address,Polkadot__Chain__Signature)>",
+      "Eth": "Vec<(Ethereum__Chain__Address,Ethereum__Chain__Signature)>",
+      "Gate": "Vec<(Gateway__Chain__Address,Gateway__Chain__Signature)>",
+      "Sol": "Vec<(Solana__Chain__Address,Solana__Chain__Signature)>",
+      "Tez": "Vec<(Tezos__Chain__Address,Tezos__Chain__Signature)>"
     }
-  },
-  "Compound": {},
-  "Ethereum": {},
-  "Polkadot": {},
-  "Solana": {},
-  "Tezos": {},
-
-  "Source3": "NoticesRS",
-  "EncodedNotice": "Vec<u8>",
-  "EraId": "u32",
-  "EraIndex": "u32",
-  "NoticeId": "(EraId, EraIndex)",
-  "ExtractionNoticeEth": {
-    "id": "NoticeId",
-    "parent": "[u8; 32]",
-    "asset": "[u8; 20]",
-    "account": "[u8; 20]",
-    "amount": "u128"
-  },
-  "ExtractionNotice": {
-    "_enum": {
-      "Eth": "ExtractionNoticeEth"
-    }
-  },
-  "CashExtractionNoticeEth": {
-    "id": "NoticeId",
-    "parent": "[u8; 32]",
-    "account": "[u8; 20]",
-    "principal": "u128"
-  },
-  "CashExtractionNotice": {
-    "_enum": {
-      "Eth": "CashExtractionNoticeEth"
-    }
-  },
-  "FutureYieldNoticeEth": {
-    "id": "NoticeId",
-    "parent": "[u8; 32]",
-    "next_cash_yield": "u128",
-    "next_cash_index": "u128",
-    "next_cash_yield_start_at": "u64"
-  },
-  "FutureYieldNotice": {
-    "_enum": {
-      "Eth": "FutureYieldNoticeEth"
-    }
-  },
-  "SetSupplyCapNoticeEth": {
-    "id": "NoticeId",
-    "parent": "[u8; 32]",
-    "asset": "[u8; 20]",
-    "amount": "u128"
-  },
-  "SetSupplyCapNotice": {
-    "_enum": {
-      "Eth": "SetSupplyCapNoticeEth"
-    }
-  },
-  "ChangeAuthorityNoticeEth": {
-    "id": "NoticeId",
-    "parent": "[u8; 32]",
-    "new_authorities": "Vec<[u8; 20]>"
   },
   "ChangeAuthorityNotice": {
     "_enum": {
-      "Eth": "ChangeAuthorityNoticeEth"
+      "Eth": "ChangeAuthorityNoticeEthType"
     }
   },
-  "Notice": {
+  "ChangeAuthorityNoticeEthType": {
+    "id": "NoticeId",
+    "new_authorities": "Vec<Ethereum__Chain__Address>",
+    "parent": "Ethereum__Chain__Hash"
+  },
+  "CodeHash": "Ethereum__Chain__Hash",
+  "Decimals": "u8",
+  "EncodedNotice": "Vec<u8>",
+  "EraId": "u32",
+  "EraIndex": "u32",
+  "Eth__BlockNumber": "u64",
+  "Eth__EventId": "(BlockNumber,LogIndex)",
+  "Eth__LogIndex": "u64",
+  "EthereumClientError": {
     "_enum": {
-      "ExtractionNotice": "ExtractionNotice",
-      "CashExtractionNotice": "CashExtractionNotice",
-      "FutureYieldNotice": "FutureYieldNotice",
-      "SetSupplyCapNotice": "SetSupplyCapNotice",
-      "ChangeAuthorityNotice": "ChangeAuthorityNotice"
+      "HttpErrorCode": "u16",
+      "HttpIoError": "",
+      "HttpTimeout": "",
+      "InvalidUTF8": "",
+      "JsonParseError": ""
     }
   },
-  "NoticeState": {
+  "EthereumEvent": {
     "_enum": {
-      "Missing": "",
-      "Pending": "NoticeStatePending",
-      "Executed": ""
+      "ExecTrxRequest": "EthereumEventExecTrxRequestType",
+      "ExecuteProposal": "EthereumEventExecuteProposalType",
+      "Lock": "EthereumEventLockType",
+      "LockCash": "EthereumEventLockCashType",
+      "NoticeInvoked": "EthereumEventNoticeInvokedType"
     }
   },
-  "NoticeStatePending": {
-    "signature_pairs": "ChainSignatureList"
+  "EthereumEventExecTrxRequestType": {
+    "account": "[u8; 20]",
+    "trx_request": "String"
   },
-
-  "Source4": "CompoundCrypto",
-  "CryptoError": {
-    "_enum": [
-      "Unknown",
-      "KeyNotFound",
-      "KeyringLock",
-      "InvalidKeyId",
-      "ParseError",
-      "RecoverError",
-      "HSMError",
-      "EnvironmentVariablePrivateKeyNotSet",
-      "HexDecodeFailed",
-      "EnvironmentVariableHexDecodeFailed",
-      "EnvironmentVariableInvalidSeed"
-    ]
+  "EthereumEventExecuteProposalType": {
+    "extrinsics": "Vec<Vec<u8>>",
+    "title": "String"
   },
-
-  "Source5": "RatesRS",
-  "RatesError": {
-    "_enum": [
-      "ModelRateOutOfBounds",
-      "ZeroAboveKink",
-      "KinkAboveFull",
-      "KinkUtilizationTooHigh",
-      "Overflowed"
-    ]
+  "EthereumEventLockCashType": {
+    "amount": "u128",
+    "chain": "String",
+    "principal": "u128",
+    "recipient": "[u8; 32]",
+    "sender": "[u8; 20]"
   },
-  "Factor": "(Uint)",
-  "MinerShares": "Factor",
-  "APR": "(Uint)",
-  "Utilization": "(Uint)",
-  "KinkModel": {
-    "zero_rate": "APR",
-    "kink_rate": "APR",
-    "kink_utilization": "Utilization",
-    "full_rate": "APR"
+  "EthereumEventLockType": {
+    "amount": "u128",
+    "asset": "[u8; 20]",
+    "chain": "String",
+    "recipient": "[u8; 32]",
+    "sender": "[u8; 20]"
   },
+  "EthereumEventNoticeInvokedType": {
+    "era_id": "u32",
+    "era_index": "u32",
+    "notice_hash": "[u8; 32]",
+    "result": "Vec<u8>"
+  },
+  "Ethereum__Chain__Address": "[u8; 20]",
+  "Ethereum__Chain__Amount": "u128",
+  "Ethereum__Chain__CashIndex": "u128",
+  "Ethereum__Chain__Event": "eth__Event",
+  "Ethereum__Chain__EventId": "eth__EventId",
+  "Ethereum__Chain__Hash": "[u8; 32]",
+  "Ethereum__Chain__PublicKey": "[u8; 64]",
+  "Ethereum__Chain__Rate": "u128",
+  "Ethereum__Chain__Signature": "[u8; 65]",
+  "Ethereum__Chain__Timestamp": "u64",
+  "EventError": {
+    "_enum": {
+      "ErrorDecodingHex": "",
+      "EthRpcUrlInvalid": "",
+      "EthRpcUrlMissing": "",
+      "EthereumClientError": "EthereumClientError",
+      "StarportAddressInvalid": ""
+    }
+  },
+  "EventInfo": {
+    "events": "Vec<(ChainLogId,ChainLogEvent)>",
+    "latest_eth_block": "u64"
+  },
+  "EventState": {
+    "_enum": {
+      "Done": "",
+      "Failed": "EventStateFailedType",
+      "Pending": "EventStatePendingType"
+    }
+  },
+  "EventStateFailedType": {
+    "reason": "Reason"
+  },
+  "EventStatePendingType": {
+    "signers": "SignersSet"
+  },
+  "EventsResponse": {
+    "error": "Option<ResponseError>",
+    "id": "Option<u64>",
+    "result": "Option<Vec<T>>"
+  },
+  "ExtractionNotice": {
+    "_enum": {
+      "Eth": "ExtractionNoticeEthType"
+    }
+  },
+  "ExtractionNoticeEthType": {
+    "account": "Ethereum__Chain__Address",
+    "amount": "Ethereum__Chain__Amount",
+    "asset": "Ethereum__Chain__Address",
+    "id": "NoticeId",
+    "parent": "Ethereum__Chain__Hash"
+  },
+  "Factor": "Uint",
+  "FutureYieldNotice": {
+    "_enum": {
+      "Eth": "FutureYieldNoticeEthType"
+    }
+  },
+  "FutureYieldNoticeEthType": {
+    "id": "NoticeId",
+    "next_cash_index": "Ethereum__Chain__CashIndex",
+    "next_cash_yield": "Ethereum__Chain__Rate",
+    "next_cash_yield_start": "Ethereum__Chain__Timestamp",
+    "parent": "Ethereum__Chain__Hash"
+  },
+  "GovernanceResult": {
+    "_enum": {
+      "DispatchFailure": "DispatchError",
+      "DispatchSuccess": "",
+      "FailedToDecodeCall": ""
+    }
+  },
+  "Int": "i128",
   "InterestRateModel": {
     "_enum": {
-      "Kink": "KinkModel"
+      "Kink": "InterestRateModelKinkType"
     }
   },
-
-  "Source6": "ReasonRS",
+  "InterestRateModelKinkType": {
+    "full_rate": "APR",
+    "kink_rate": "APR",
+    "kink_utilization": "Factor",
+    "zero_rate": "APR"
+  },
+  "LiquidityFactor": "Factor",
+  "LogObject": {
+    "address": "Option<String>",
+    "block_hash": "Option<String>",
+    "block_number": "Option<String>",
+    "data": "Option<String>",
+    "log_index": "Option<String>",
+    "removed": "Option<bool>",
+    "topics": "Option<Vec<String>>",
+    "transaction_hash": "Option<String>",
+    "transaction_index": "Option<String>"
+  },
+  "MathError": {
+    "_enum": {
+      "AbnormalFloatingPointResult": "",
+      "DivisionByZero": "",
+      "Overflow": "",
+      "PriceNotUSD": "",
+      "SignMismatch": "",
+      "Underflow": "",
+      "UnitsMismatch": ""
+    }
+  },
+  "MinerShares": "Factor",
+  "Nonce": "u32",
+  "Notice": {
+    "_enum": {
+      "CashExtractionNotice": "CashExtractionNotice",
+      "ChangeAuthorityNotice": "ChangeAuthorityNotice",
+      "ExtractionNotice": "ExtractionNotice",
+      "FutureYieldNotice": "FutureYieldNotice",
+      "SetSupplyCapNotice": "SetSupplyCapNotice"
+    }
+  },
+  "NoticeId": [
+    "EraId",
+    "EraIndex"
+  ],
+  "NoticeState": {
+    "_enum": {
+      "Executed": "",
+      "Missing": "",
+      "Pending": "NoticeStatePendingType"
+    }
+  },
+  "NoticeStatePendingType": {
+    "signature_pairs": "ChainSignatureList"
+  },
+  "OracleError": {
+    "_enum": {
+      "BadTicker": "",
+      "CryptoError": "",
+      "EthAbiParseError": "",
+      "HexParseError": "",
+      "HttpError": "",
+      "InvalidApiEndpoint": "",
+      "InvalidKind": "",
+      "InvalidReporter": "",
+      "InvalidSymbol": "",
+      "InvalidTicker": "",
+      "InvalidTimestamp": "",
+      "JsonParseError": "",
+      "NoPriceFeedURL": "",
+      "StalePrice": "",
+      "SubmitError": ""
+    }
+  },
+  "Oracle__Timestamp": "u64",
+  "Portfolio": {
+    "cash": "Balance",
+    "positions": "Vec<(AssetInfo,Balance)>"
+  },
+  "Price": {
+    "ticker": "Ticker",
+    "value": "AssetPrice"
+  },
+  "Quantity": {
+    "units": "Units",
+    "value": "AssetAmount"
+  },
+  "RatesError": {
+    "_enum": {
+      "KinkAboveFull": "",
+      "KinkUtilizationTooHigh": "",
+      "ModelRateOutOfBounds": "",
+      "Overflowed": "",
+      "ZeroAboveKink": ""
+    }
+  },
   "Reason": {
     "_enum": {
       "AssetExtractionNotSupported": "",
@@ -259,206 +397,117 @@
       "BadTicker": "",
       "BadUnits": "",
       "ChainMismatch": "",
-      "CryptoError": "(CryptoError)",
+      "ChangeValidatorsError": "",
+      "CryptoError": "CryptoError",
+      "DeprecatedNoticeAlreadySigned": "",
       "FailedToSubmitExtrinsic": "",
       "FetchError": "",
-      "IncorrectNonce": "(Nonce, Nonce)",
       "InKindLiquidation": "",
+      "IncorrectNonce": "ReasonIncorrectNonceType",
       "InsufficientChainCash": "",
       "InsufficientLiquidity": "",
       "InsufficientTotalFunds": "",
       "InvalidAPR": "",
+      "InvalidChain": "",
       "InvalidCodeHash": "",
       "InvalidLiquidation": "",
       "InvalidUTF8": "",
       "KeyNotFound": "",
-      "MathError": "(MathError)",
+      "MathError": "MathError",
       "MaxForNonCashAsset": "",
       "MinTxValueNotMet": "",
-      "None": "",
       "NoPrice": "",
       "NoSuchAsset": "",
-      "DeprecatedNoticeAlreadySigned": "",
-      "NoticeHashMismatch": "",
-      "NoticeMissing": "(ChainId, NoticeId)",
+      "None": "",
       "NotImplemented": "",
-      "OracleError": "(OracleError)",
-      "RatesError": "(RatesError)",
+      "NoticeHashMismatch": "",
+      "NoticeMissing": "ReasonNoticeMissingType",
+      "OracleError": "OracleError",
+      "PendingAuthNotice": "",
+      "RatesError": "RatesError",
       "RepayTooMuch": "",
       "SelfTransfer": "",
       "SerdeError": "",
-      "SetYieldNextError": "(SetYieldNextError)",
+      "SetYieldNextError": "SetYieldNextError",
       "SignatureAccountMismatch": "",
       "SignatureMismatch": "",
       "TimeTravelNotAllowed": "",
-      "TrxRequestParseError": "(TrxReqParseError)",
-      "UnknownValidator": "",
-      "InvalidChain": "",
-      "PendingEraNotice": "",
-      "ChangeValidatorsError": ""
+      "TrxRequestParseError": "TrxReqParseError",
+      "UnknownValidator": ""
     }
   },
-  "MathError": {
-    "_enum": [
-      "Overflow",
-      "Underflow",
-      "SignMismatch",
-      "SymbolMismatch",
-      "PriceNotUSD",
-      "DivisionByZero"
-    ]
+  "ReasonIncorrectNonceType": [
+    "Nonce",
+    "Nonce"
+  ],
+  "ReasonNoticeMissingType": [
+    "ChainId",
+    "NoticeId"
+  ],
+  "Reporter": "[u8; 20]",
+  "ReporterSet": "Vec<Reporter>",
+  "ResponseError": {
+    "code": "Option<i64>",
+    "message": "Option<String>"
   },
-  "TrxReqParseError": {
-    "_enum": [
-      "NotImplemented",
-      "LexError",
-      "InvalidAmount",
-      "InvalidAddress",
-      "InvalidArgs",
-      "UnknownFunction",
-      "InvalidExpression",
-      "InvalidChain",
-      "InvalidChainAccount"
-    ]
-  },
-
-  "Source7": "EventsRS",
-  "EventInfo": {
-    "latest_eth_block": "u64",
-    "events": "Vec<(ChainLogId, ChainLogEvent)>"
-  },
-  "ChainLogId": {
+  "SessionIndex": "u32",
+  "SetSupplyCapNotice": {
     "_enum": {
-      "Eth": "(u64, u64)"
+      "Eth": "SetSupplyCapNoticeEthType"
     }
   },
-  "ChainLogEvent": {
-    "_enum": {
-      "Eth": "EthereumLogEvent"
-    }
+  "SetSupplyCapNoticeEthType": {
+    "asset": "Ethereum__Chain__Address",
+    "cap": "Ethereum__Chain__Amount",
+    "id": "NoticeId",
+    "parent": "Ethereum__Chain__Hash"
   },
-  "EventState": {
-    "_enum": {
-      "Pending": {
-        "signers": "SignersSet"
-      },
-      "Failed": {
-        "reason": "Reason"
-      },
-      "Done": {}
-    }
-  },
-
-  "Source8": "EthereumClientRS",
-  "EthereumLogEvent": {
-    "block_hash": "[u8; 32]",
-    "block_number": "u64",
-    "transaction_index": "u64",
-    "log_index": "u64",
-    "event": "EthereumEvent"
-  },
-  "LockEvent": {
-    "asset": "[u8; 20]",
-    "sender": "[u8; 20]",
-    "recipient": "[u8; 20]",
-    "amount": "u128"
-  },
-  "LockCashEvent": {
-    "sender": "[u8; 20]",
-    "recipient": "[u8; 20]",
-    "amount": "u128",
-    "principal": "u128"
-  },
-  "ExecTrxRequest": {
-    "account": "[u8; 20]",
-    "trx_request": "String"
-  },
-  "ExecuteProposalEvent": {
-    "title": "String",
-    "extrinsics": "Vec<Vec<u8>>"
-  },
-  "NoticeInvokedEvent": {
-    "era_id": "u32",
-    "era_index": "u32",
-    "notice_hash": "[u8; 32]",
-    "result": "Vec<u8>"
-  },
-  "EthereumEvent": {
-    "_enum": {
-      "Lock": "LockEvent",
-      "LockCash": "LockCashEvent",
-      "ExecTrxRequest": "ExecTrxRequestEvent",
-      "ExecuteProposal": "ExecuteProposalEvent",
-      "NoticeInvoked": "NoticeInvokedEvent"
-    }
-  },
-
-  "Source9": "SetYieldNextRS",
   "SetYieldNextError": {
     "_enum": {
-      "TimestampTooSoonToNow": "",
-      "TimestampTooSoonToNext": ""
+      "TimestampTooSoonToNext": "",
+      "TimestampTooSoonToNow": ""
     }
   },
-  "Source10": "AccountRS",
-  "Address": "MultiAddress",
-  "LookupSource": "MultiAddress",
-  "VersionedAuthorityList": {
-    "version": "u8",
-    "authorityList": "AuthorityList"
-  },
-  "Authorities": "Vec<AccountId32>",
-  "SessionKeys": {
-    "aura": "[u8;32]",
-    "grandpa": "[u8;32]"
-  },
-  "Keys": "SessionKeys",
-
-  "Source11": "Oracle_ErrorRS",
-  "OracleError": {
-    "_enum": [
-      "BadTicker",
-      "CryptoError",
-      "EthAbiParseError",
-      "HexParseError",
-      "HttpError",
-      "InvalidApiEndpoint",
-      "InvalidKind",
-      "InvalidReporter",
-      "InvalidSymbol",
-      "InvalidTicker",
-      "JsonParseError",
-      "NoPriceFeedURL",
-      "StalePrice",
-      "SubmitError"
-    ]
-  },
-
-  "Source12": "Oracle_TypesRS",
-  "Reporter": "[u8; 20]",
-  "Timestamp": "u64",
-  "AssetPrice": "u128",
-  "Price": ["Ticker", "AssetPrice"],
-  "ReporterSet": "Vec<Reporter>",
-
-  "Source12": "Oracle_TickerRS",
+  "SignersSet": "BTreeSet<ValidatorIdentity>",
+  "SubstrateId": "AccountId32",
+  "Symbol": "[u8; 12]",
   "Ticker": "[u8; 12]",
-
-  "Source13": "Node_ApiRS",
-  "ApiRates": "(u64, u64)",
-  "ApiAssetData": {
-    "asset": "String",
-    "balance": "String",
-    "total_borrow": "String",
-    "total_supply": "String",
-    "borrow_rate": "String",
-    "supply_rate": "String",
-    "liquidity_factor": "String",
-    "price": "String"
+  "Timestamp": "u64",
+  "TrxReqParseError": {
+    "_enum": {
+      "InvalidAddress": "",
+      "InvalidAmount": "",
+      "InvalidArgs": "",
+      "InvalidChain": "",
+      "InvalidChainAccount": "",
+      "InvalidExpression": "",
+      "LexError": "",
+      "NotImplemented": "",
+      "UnknownFunction": ""
+    }
   },
-  "ApiCashData": {
-    "balance": "String",
-    "cash_yield": "String",
-    "price": "String"
-  }
+  "USDQuantity": "Quantity",
+  "Uint": "u128",
+  "Units": {
+    "decimals": "Decimals",
+    "ticker": "Ticker"
+  },
+  "ValidationError": {
+    "_enum": {
+      "InvalidCall": "",
+      "InvalidInternalOnly": "",
+      "InvalidNextCode": "",
+      "InvalidPrice": "Reason",
+      "InvalidPriceSignature": "",
+      "InvalidSignature": "",
+      "InvalidValidator": "",
+      "UnknownNotice": ""
+    }
+  },
+  "ValidatorIdentity": "Ethereum__Chain__Address",
+  "ValidatorKeys": {
+    "eth_address": "Ethereum__Chain__Address",
+    "substrate_id": "SubstrateId"
+  },
+  "ValidatorSig": "Ethereum__Chain__Signature"
 }

--- a/types.json
+++ b/types.json
@@ -1,5 +1,24 @@
 {
   "APR": "Uint",
+  "AccountId32": "[u8;32]",
+  "Address": "MultiAddress",
+  "ApiAPR": "u64",
+  "ApiAssetData": {
+    "asset": "ChainAsset",
+    "balance": "String",
+    "total_supply": "String",
+    "total_borrow": "String",
+    "supply_rate": "String",
+    "borrow_rate": "String",
+    "liquidity_factor": "String",
+    "price": "String"
+  },
+  "ApiCashData": {
+    "balance": "String",
+    "cash_yield": "String",
+    "price": "String"
+  },
+  "ApiRates": "(ApiAPR,ApiAPR)",
   "AssetAmount": "Uint",
   "AssetBalance": "Int",
   "AssetIndex": "Uint",
@@ -7,34 +26,30 @@
     "asset": "ChainAsset",
     "decimals": "Decimals",
     "liquidity_factor": "LiquidityFactor",
-    "miner_shares": "MinerShares",
     "rate_model": "InterestRateModel",
+    "miner_shares": "MinerShares",
     "supply_cap": "AssetAmount",
     "symbol": "Symbol",
     "ticker": "Ticker"
   },
   "AssetPrice": "u128",
   "AssetQuantity": "Quantity",
+  "Authorities": "Vec<AccountId32>",
   "Balance": {
-    "units": "Units",
-    "value": "AssetBalance"
+    "value": "AssetBalance",
+    "units": "Units"
   },
   "Bips": "u128",
-  "BlockResponse": {
-    "error": "Option<ResponseError>",
-    "id": "Option<u64>",
-    "result": "Option<String>"
-  },
   "CashAmount": "Uint",
   "CashExtractionNotice": {
     "_enum": {
-      "Eth": "CashExtractionNoticeEthType"
+      "Eth": "CashExtractionNoticeEth"
     }
   },
-  "CashExtractionNoticeEthType": {
-    "account": "Ethereum__Chain__Address",
+  "CashExtractionNoticeEth": {
     "id": "NoticeId",
     "parent": "Ethereum__Chain__Hash",
+    "account": "Ethereum__Chain__Address",
     "principal": "Ethereum__Chain__Amount"
   },
   "CashIndex": "Uint",
@@ -51,112 +66,127 @@
   "CashQuantity": "Quantity",
   "ChainAccount": {
     "_enum": {
-      "Dot": "Polkadot__Chain__Address",
-      "Eth": "Ethereum__Chain__Address",
       "Gate": "Gateway__Chain__Address",
+      "Eth": "Ethereum__Chain__Address",
+      "Dot": "Polkadot__Chain__Address",
       "Sol": "Solana__Chain__Address",
       "Tez": "Tezos__Chain__Address"
     }
   },
   "ChainAccountSignature": {
     "_enum": {
-      "Dot": "ChainAccountSignatureDotType",
-      "Eth": "ChainAccountSignatureEthType",
-      "Gate": "ChainAccountSignatureGateType",
-      "Sol": "ChainAccountSignatureSolType",
-      "Tez": "ChainAccountSignatureTezType"
+      "Gate": "ChainAccountSignatureGate",
+      "Eth": "ChainAccountSignatureEth",
+      "Dot": "ChainAccountSignatureDot",
+      "Sol": "ChainAccountSignatureSol",
+      "Tez": "ChainAccountSignatureTez"
     }
   },
-  "ChainAccountSignatureDotType": [
+  "ChainAccountSignatureDot": [
     "Polkadot__Chain__Address",
     "Polkadot__Chain__Signature"
   ],
-  "ChainAccountSignatureEthType": [
+  "ChainAccountSignatureEth": [
     "Ethereum__Chain__Address",
     "Ethereum__Chain__Signature"
   ],
-  "ChainAccountSignatureGateType": [
+  "ChainAccountSignatureGate": [
     "Gateway__Chain__Address",
     "Gateway__Chain__Signature"
   ],
-  "ChainAccountSignatureSolType": [
+  "ChainAccountSignatureSol": [
     "Solana__Chain__Address",
     "Solana__Chain__Signature"
   ],
-  "ChainAccountSignatureTezType": [
+  "ChainAccountSignatureTez": [
     "Tezos__Chain__Address",
     "Tezos__Chain__Signature"
   ],
   "ChainAsset": {
     "_enum": {
-      "Dot": "Polkadot__Chain__Address",
-      "Eth": "Ethereum__Chain__Address",
       "Gate": "Gateway__Chain__Address",
+      "Eth": "Ethereum__Chain__Address",
+      "Dot": "Polkadot__Chain__Address",
       "Sol": "Solana__Chain__Address",
       "Tez": "Tezos__Chain__Address"
     }
   },
   "ChainHash": {
     "_enum": {
-      "Dot": "Polkadot__Chain__Hash",
-      "Eth": "Ethereum__Chain__Hash",
       "Gate": "Gateway__Chain__Hash",
+      "Eth": "Ethereum__Chain__Hash",
+      "Dot": "Polkadot__Chain__Hash",
       "Sol": "Solana__Chain__Hash",
       "Tez": "Tezos__Chain__Hash"
     }
   },
   "ChainId": {
     "_enum": {
-      "Dot": "",
-      "Eth": "",
       "Gate": "",
+      "Eth": "",
+      "Dot": "",
       "Sol": "",
       "Tez": ""
     }
   },
   "ChainLogEvent": {
     "_enum": {
-      "Eth": "ethereum_client__EthereumLogEvent"
+      "Eth": "EthereumLogEvent"
     }
   },
   "ChainLogId": {
     "_enum": {
-      "Eth": "ChainLogIdEthType"
+      "Eth": "ChainLogIdEth"
     }
   },
-  "ChainLogIdEthType": [
+  "ChainLogIdEth": [
     "eth__BlockNumber",
     "eth__LogIndex"
   ],
   "ChainSignature": {
     "_enum": {
-      "Dot": "Polkadot__Chain__Signature",
-      "Eth": "Ethereum__Chain__Signature",
       "Gate": "Gateway__Chain__Signature",
+      "Eth": "Ethereum__Chain__Signature",
+      "Dot": "Polkadot__Chain__Signature",
       "Sol": "Solana__Chain__Signature",
       "Tez": "Tezos__Chain__Signature"
     }
   },
   "ChainSignatureList": {
     "_enum": {
-      "Dot": "Vec<(Polkadot__Chain__Address,Polkadot__Chain__Signature)>",
-      "Eth": "Vec<(Ethereum__Chain__Address,Ethereum__Chain__Signature)>",
       "Gate": "Vec<(Gateway__Chain__Address,Gateway__Chain__Signature)>",
+      "Eth": "Vec<(Ethereum__Chain__Address,Ethereum__Chain__Signature)>",
+      "Dot": "Vec<(Polkadot__Chain__Address,Polkadot__Chain__Signature)>",
       "Sol": "Vec<(Solana__Chain__Address,Solana__Chain__Signature)>",
       "Tez": "Vec<(Tezos__Chain__Address,Tezos__Chain__Signature)>"
     }
   },
   "ChangeAuthorityNotice": {
     "_enum": {
-      "Eth": "ChangeAuthorityNoticeEthType"
+      "Eth": "ChangeAuthorityNoticeEth"
     }
   },
-  "ChangeAuthorityNoticeEthType": {
+  "ChangeAuthorityNoticeEth": {
     "id": "NoticeId",
-    "new_authorities": "Vec<Ethereum__Chain__Address>",
-    "parent": "Ethereum__Chain__Hash"
+    "parent": "Ethereum__Chain__Hash",
+    "new_authorities": "Vec<Ethereum__Chain__Address>"
   },
   "CodeHash": "Ethereum__Chain__Hash",
+  "CryptoError": {
+    "_enum": {
+      "Unknown": "",
+      "KeyNotFound": "",
+      "KeyringLock": "",
+      "InvalidKeyId": "",
+      "ParseError": "",
+      "RecoverError": "",
+      "HSMError": "",
+      "EnvironmentVariablePrivateKeyNotSet": "",
+      "HexDecodeFailed": "",
+      "EnvironmentVariableHexDecodeFailed": "",
+      "EnvironmentVariableInvalidSeed": ""
+    }
+  },
   "Decimals": "u8",
   "EncodedNotice": "Vec<u8>",
   "EraId": "u32",
@@ -164,51 +194,49 @@
   "Eth__BlockNumber": "u64",
   "Eth__EventId": "(BlockNumber,LogIndex)",
   "Eth__LogIndex": "u64",
-  "EthereumClientError": {
-    "_enum": {
-      "HttpErrorCode": "u16",
-      "HttpIoError": "",
-      "HttpTimeout": "",
-      "InvalidUTF8": "",
-      "JsonParseError": ""
-    }
-  },
   "EthereumEvent": {
     "_enum": {
-      "ExecTrxRequest": "EthereumEventExecTrxRequestType",
-      "ExecuteProposal": "EthereumEventExecuteProposalType",
-      "Lock": "EthereumEventLockType",
-      "LockCash": "EthereumEventLockCashType",
-      "NoticeInvoked": "EthereumEventNoticeInvokedType"
+      "Lock": "EthereumEventLock",
+      "LockCash": "EthereumEventLockCash",
+      "ExecTrxRequest": "EthereumEventExecTrxRequest",
+      "ExecuteProposal": "EthereumEventExecuteProposal",
+      "NoticeInvoked": "EthereumEventNoticeInvoked"
     }
   },
-  "EthereumEventExecTrxRequestType": {
+  "EthereumEventExecTrxRequest": {
     "account": "[u8; 20]",
     "trx_request": "String"
   },
-  "EthereumEventExecuteProposalType": {
-    "extrinsics": "Vec<Vec<u8>>",
-    "title": "String"
+  "EthereumEventExecuteProposal": {
+    "title": "String",
+    "extrinsics": "Vec<Vec<u8>>"
   },
-  "EthereumEventLockCashType": {
-    "amount": "u128",
-    "chain": "String",
-    "principal": "u128",
-    "recipient": "[u8; 32]",
-    "sender": "[u8; 20]"
-  },
-  "EthereumEventLockType": {
-    "amount": "u128",
+  "EthereumEventLock": {
     "asset": "[u8; 20]",
+    "sender": "[u8; 20]",
     "chain": "String",
     "recipient": "[u8; 32]",
-    "sender": "[u8; 20]"
+    "amount": "u128"
   },
-  "EthereumEventNoticeInvokedType": {
+  "EthereumEventLockCash": {
+    "sender": "[u8; 20]",
+    "chain": "String",
+    "recipient": "[u8; 32]",
+    "amount": "u128",
+    "principal": "u128"
+  },
+  "EthereumEventNoticeInvoked": {
     "era_id": "u32",
     "era_index": "u32",
     "notice_hash": "[u8; 32]",
     "result": "Vec<u8>"
+  },
+  "EthereumLogEvent": {
+    "block_hash": "[u8; 32]",
+    "block_number": "u64",
+    "transaction_index": "u64",
+    "log_index": "u64",
+    "event": "EthereumEvent"
   },
   "Ethereum__Chain__Address": "[u8; 20]",
   "Ethereum__Chain__Amount": "u128",
@@ -220,101 +248,78 @@
   "Ethereum__Chain__Rate": "u128",
   "Ethereum__Chain__Signature": "[u8; 65]",
   "Ethereum__Chain__Timestamp": "u64",
-  "EventError": {
-    "_enum": {
-      "ErrorDecodingHex": "",
-      "EthRpcUrlInvalid": "",
-      "EthRpcUrlMissing": "",
-      "EthereumClientError": "EthereumClientError",
-      "StarportAddressInvalid": ""
-    }
-  },
   "EventInfo": {
-    "events": "Vec<(ChainLogId,ChainLogEvent)>",
-    "latest_eth_block": "u64"
+    "latest_eth_block": "u64",
+    "events": "Vec<(ChainLogId,ChainLogEvent)>"
   },
   "EventState": {
     "_enum": {
-      "Done": "",
-      "Failed": "EventStateFailedType",
-      "Pending": "EventStatePendingType"
+      "Pending": "EventStatePending",
+      "Failed": "EventStateFailed",
+      "Done": ""
     }
   },
-  "EventStateFailedType": {
+  "EventStateFailed": {
     "reason": "Reason"
   },
-  "EventStatePendingType": {
+  "EventStatePending": {
     "signers": "SignersSet"
-  },
-  "EventsResponse": {
-    "error": "Option<ResponseError>",
-    "id": "Option<u64>",
-    "result": "Option<Vec<T>>"
   },
   "ExtractionNotice": {
     "_enum": {
-      "Eth": "ExtractionNoticeEthType"
+      "Eth": "ExtractionNoticeEth"
     }
   },
-  "ExtractionNoticeEthType": {
-    "account": "Ethereum__Chain__Address",
-    "amount": "Ethereum__Chain__Amount",
-    "asset": "Ethereum__Chain__Address",
+  "ExtractionNoticeEth": {
     "id": "NoticeId",
-    "parent": "Ethereum__Chain__Hash"
+    "parent": "Ethereum__Chain__Hash",
+    "asset": "Ethereum__Chain__Address",
+    "account": "Ethereum__Chain__Address",
+    "amount": "Ethereum__Chain__Amount"
   },
   "Factor": "Uint",
   "FutureYieldNotice": {
     "_enum": {
-      "Eth": "FutureYieldNoticeEthType"
+      "Eth": "FutureYieldNoticeEth"
     }
   },
-  "FutureYieldNoticeEthType": {
+  "FutureYieldNoticeEth": {
     "id": "NoticeId",
-    "next_cash_index": "Ethereum__Chain__CashIndex",
+    "parent": "Ethereum__Chain__Hash",
     "next_cash_yield": "Ethereum__Chain__Rate",
-    "next_cash_yield_start": "Ethereum__Chain__Timestamp",
-    "parent": "Ethereum__Chain__Hash"
+    "next_cash_index": "Ethereum__Chain__CashIndex",
+    "next_cash_yield_start": "Ethereum__Chain__Timestamp"
   },
   "GovernanceResult": {
     "_enum": {
-      "DispatchFailure": "DispatchError",
+      "FailedToDecodeCall": "",
       "DispatchSuccess": "",
-      "FailedToDecodeCall": ""
+      "DispatchFailure": "DispatchError"
     }
   },
   "Int": "i128",
   "InterestRateModel": {
     "_enum": {
-      "Kink": "InterestRateModelKinkType"
+      "Kink": "InterestRateModelKink"
     }
   },
-  "InterestRateModelKinkType": {
-    "full_rate": "APR",
+  "InterestRateModelKink": {
+    "zero_rate": "APR",
     "kink_rate": "APR",
     "kink_utilization": "Factor",
-    "zero_rate": "APR"
+    "full_rate": "APR"
   },
+  "Keys": "SessionKeys",
   "LiquidityFactor": "Factor",
-  "LogObject": {
-    "address": "Option<String>",
-    "block_hash": "Option<String>",
-    "block_number": "Option<String>",
-    "data": "Option<String>",
-    "log_index": "Option<String>",
-    "removed": "Option<bool>",
-    "topics": "Option<Vec<String>>",
-    "transaction_hash": "Option<String>",
-    "transaction_index": "Option<String>"
-  },
+  "LookupSource": "MultiAddress",
   "MathError": {
     "_enum": {
       "AbnormalFloatingPointResult": "",
       "DivisionByZero": "",
       "Overflow": "",
-      "PriceNotUSD": "",
-      "SignMismatch": "",
       "Underflow": "",
+      "SignMismatch": "",
+      "PriceNotUSD": "",
       "UnitsMismatch": ""
     }
   },
@@ -322,11 +327,11 @@
   "Nonce": "u32",
   "Notice": {
     "_enum": {
-      "CashExtractionNotice": "CashExtractionNotice",
-      "ChangeAuthorityNotice": "ChangeAuthorityNotice",
       "ExtractionNotice": "ExtractionNotice",
+      "CashExtractionNotice": "CashExtractionNotice",
       "FutureYieldNotice": "FutureYieldNotice",
-      "SetSupplyCapNotice": "SetSupplyCapNotice"
+      "SetSupplyCapNotice": "SetSupplyCapNotice",
+      "ChangeAuthorityNotice": "ChangeAuthorityNotice"
     }
   },
   "NoticeId": [
@@ -335,12 +340,12 @@
   ],
   "NoticeState": {
     "_enum": {
-      "Executed": "",
       "Missing": "",
-      "Pending": "NoticeStatePendingType"
+      "Pending": "NoticeStatePending",
+      "Executed": ""
     }
   },
-  "NoticeStatePendingType": {
+  "NoticeStatePending": {
     "signature_pairs": "ChainSignatureList"
   },
   "OracleError": {
@@ -372,16 +377,16 @@
     "value": "AssetPrice"
   },
   "Quantity": {
-    "units": "Units",
-    "value": "AssetAmount"
+    "value": "AssetAmount",
+    "units": "Units"
   },
   "RatesError": {
     "_enum": {
+      "ModelRateOutOfBounds": "",
+      "ZeroAboveKink": "",
       "KinkAboveFull": "",
       "KinkUtilizationTooHigh": "",
-      "ModelRateOutOfBounds": "",
-      "Overflowed": "",
-      "ZeroAboveKink": ""
+      "Overflowed": ""
     }
   },
   "Reason": {
@@ -397,18 +402,15 @@
       "BadTicker": "",
       "BadUnits": "",
       "ChainMismatch": "",
-      "ChangeValidatorsError": "",
       "CryptoError": "CryptoError",
-      "DeprecatedNoticeAlreadySigned": "",
       "FailedToSubmitExtrinsic": "",
       "FetchError": "",
+      "IncorrectNonce": "ReasonIncorrectNonce",
       "InKindLiquidation": "",
-      "IncorrectNonce": "ReasonIncorrectNonceType",
       "InsufficientChainCash": "",
       "InsufficientLiquidity": "",
       "InsufficientTotalFunds": "",
       "InvalidAPR": "",
-      "InvalidChain": "",
       "InvalidCodeHash": "",
       "InvalidLiquidation": "",
       "InvalidUTF8": "",
@@ -416,14 +418,14 @@
       "MathError": "MathError",
       "MaxForNonCashAsset": "",
       "MinTxValueNotMet": "",
+      "None": "",
       "NoPrice": "",
       "NoSuchAsset": "",
-      "None": "",
-      "NotImplemented": "",
+      "DeprecatedNoticeAlreadySigned": "",
       "NoticeHashMismatch": "",
-      "NoticeMissing": "ReasonNoticeMissingType",
+      "NoticeMissing": "ReasonNoticeMissing",
+      "NotImplemented": "",
       "OracleError": "OracleError",
-      "PendingAuthNotice": "",
       "RatesError": "RatesError",
       "RepayTooMuch": "",
       "SelfTransfer": "",
@@ -433,41 +435,45 @@
       "SignatureMismatch": "",
       "TimeTravelNotAllowed": "",
       "TrxRequestParseError": "TrxReqParseError",
-      "UnknownValidator": ""
+      "UnknownValidator": "",
+      "InvalidChain": "",
+      "PendingAuthNotice": "",
+      "ChangeValidatorsError": ""
     }
   },
-  "ReasonIncorrectNonceType": [
+  "ReasonIncorrectNonce": [
     "Nonce",
     "Nonce"
   ],
-  "ReasonNoticeMissingType": [
+  "ReasonNoticeMissing": [
     "ChainId",
     "NoticeId"
   ],
   "Reporter": "[u8; 20]",
   "ReporterSet": "Vec<Reporter>",
-  "ResponseError": {
-    "code": "Option<i64>",
-    "message": "Option<String>"
-  },
   "SessionIndex": "u32",
+  "SessionKeys": {
+    "aura": "[u8;32]",
+    "grandpa": "[u8;32]"
+  },
   "SetSupplyCapNotice": {
     "_enum": {
-      "Eth": "SetSupplyCapNoticeEthType"
+      "Eth": "SetSupplyCapNoticeEth"
     }
   },
-  "SetSupplyCapNoticeEthType": {
-    "asset": "Ethereum__Chain__Address",
-    "cap": "Ethereum__Chain__Amount",
+  "SetSupplyCapNoticeEth": {
     "id": "NoticeId",
-    "parent": "Ethereum__Chain__Hash"
+    "parent": "Ethereum__Chain__Hash",
+    "asset": "Ethereum__Chain__Address",
+    "cap": "Ethereum__Chain__Amount"
   },
   "SetYieldNextError": {
     "_enum": {
-      "TimestampTooSoonToNext": "",
-      "TimestampTooSoonToNow": ""
+      "TimestampTooSoonToNow": "",
+      "TimestampTooSoonToNext": ""
     }
   },
+  "SignedPayload": "Vec<u8>",
   "SignersSet": "BTreeSet<ValidatorIdentity>",
   "SubstrateId": "AccountId32",
   "Symbol": "[u8; 12]",
@@ -475,39 +481,31 @@
   "Timestamp": "u64",
   "TrxReqParseError": {
     "_enum": {
-      "InvalidAddress": "",
-      "InvalidAmount": "",
-      "InvalidArgs": "",
-      "InvalidChain": "",
-      "InvalidChainAccount": "",
-      "InvalidExpression": "",
-      "LexError": "",
       "NotImplemented": "",
-      "UnknownFunction": ""
+      "LexError": "",
+      "InvalidAmount": "",
+      "InvalidAddress": "",
+      "InvalidArgs": "",
+      "UnknownFunction": "",
+      "InvalidExpression": "",
+      "InvalidChain": "",
+      "InvalidChainAccount": ""
     }
   },
   "USDQuantity": "Quantity",
   "Uint": "u128",
   "Units": {
-    "decimals": "Decimals",
-    "ticker": "Ticker"
-  },
-  "ValidationError": {
-    "_enum": {
-      "InvalidCall": "",
-      "InvalidInternalOnly": "",
-      "InvalidNextCode": "",
-      "InvalidPrice": "Reason",
-      "InvalidPriceSignature": "",
-      "InvalidSignature": "",
-      "InvalidValidator": "",
-      "UnknownNotice": ""
-    }
+    "ticker": "Ticker",
+    "decimals": "Decimals"
   },
   "ValidatorIdentity": "Ethereum__Chain__Address",
   "ValidatorKeys": {
-    "eth_address": "Ethereum__Chain__Address",
-    "substrate_id": "SubstrateId"
+    "substrate_id": "SubstrateId",
+    "eth_address": "Ethereum__Chain__Address"
   },
-  "ValidatorSig": "Ethereum__Chain__Signature"
+  "ValidatorSig": "Ethereum__Chain__Signature",
+  "VersionedAuthorityList": {
+    "authorityList": "AuthorityList",
+    "version": "u8"
+  }
 }

--- a/types.json
+++ b/types.json
@@ -82,26 +82,11 @@
       "Tez": "ChainAccountSignatureTez"
     }
   },
-  "ChainAccountSignatureDot": [
-    "Polkadot__Chain__Address",
-    "Polkadot__Chain__Signature"
-  ],
-  "ChainAccountSignatureEth": [
-    "Ethereum__Chain__Address",
-    "Ethereum__Chain__Signature"
-  ],
-  "ChainAccountSignatureGate": [
-    "Gateway__Chain__Address",
-    "Gateway__Chain__Signature"
-  ],
-  "ChainAccountSignatureSol": [
-    "Solana__Chain__Address",
-    "Solana__Chain__Signature"
-  ],
-  "ChainAccountSignatureTez": [
-    "Tezos__Chain__Address",
-    "Tezos__Chain__Signature"
-  ],
+  "ChainAccountSignatureDot": "(Polkadot__Chain__Address,Polkadot__Chain__Signature)",
+  "ChainAccountSignatureEth": "(Ethereum__Chain__Address,Ethereum__Chain__Signature)",
+  "ChainAccountSignatureGate": "(Gateway__Chain__Address,Gateway__Chain__Signature)",
+  "ChainAccountSignatureSol": "(Solana__Chain__Address,Solana__Chain__Signature)",
+  "ChainAccountSignatureTez": "(Tezos__Chain__Address,Tezos__Chain__Signature)",
   "ChainAsset": {
     "_enum": {
       "Gate": "Gateway__Chain__Address",
@@ -139,10 +124,7 @@
       "Eth": "ChainLogIdEth"
     }
   },
-  "ChainLogIdEth": [
-    "eth__BlockNumber",
-    "eth__LogIndex"
-  ],
+  "ChainLogIdEth": "(eth__BlockNumber,eth__LogIndex)",
   "ChainSignature": {
     "_enum": {
       "Gate": "Gateway__Chain__Signature",
@@ -191,9 +173,6 @@
   "EncodedNotice": "Vec<u8>",
   "EraId": "u32",
   "EraIndex": "u32",
-  "Eth__BlockNumber": "u64",
-  "Eth__EventId": "(BlockNumber,LogIndex)",
-  "Eth__LogIndex": "u64",
   "EthereumEvent": {
     "_enum": {
       "Lock": "EthereumEventLock",
@@ -290,6 +269,16 @@
     "next_cash_index": "Ethereum__Chain__CashIndex",
     "next_cash_yield_start": "Ethereum__Chain__Timestamp"
   },
+  "Gateway__Chain__Address": "[u8; 20]",
+  "Gateway__Chain__Amount": "u128",
+  "Gateway__Chain__CashIndex": "u128",
+  "Gateway__Chain__Event": "comp__Event",
+  "Gateway__Chain__EventId": "comp__EventId",
+  "Gateway__Chain__Hash": "[u8; 32]",
+  "Gateway__Chain__PublicKey": "[u8; 64]",
+  "Gateway__Chain__Rate": "u128",
+  "Gateway__Chain__Signature": "[u8; 65]",
+  "Gateway__Chain__Timestamp": "u64",
   "GovernanceResult": {
     "_enum": {
       "FailedToDecodeCall": "",
@@ -334,10 +323,7 @@
       "ChangeAuthorityNotice": "ChangeAuthorityNotice"
     }
   },
-  "NoticeId": [
-    "EraId",
-    "EraIndex"
-  ],
+  "NoticeId": "(EraId,EraIndex)",
   "NoticeState": {
     "_enum": {
       "Missing": "",
@@ -368,6 +354,16 @@
     }
   },
   "Oracle__Timestamp": "u64",
+  "Polkadot__Chain__Address": "[u8; 20]",
+  "Polkadot__Chain__Amount": "u128",
+  "Polkadot__Chain__CashIndex": "u128",
+  "Polkadot__Chain__Event": "dot__Event",
+  "Polkadot__Chain__EventId": "dot__EventId",
+  "Polkadot__Chain__Hash": "[u8; 32]",
+  "Polkadot__Chain__PublicKey": "[u8; 64]",
+  "Polkadot__Chain__Rate": "u128",
+  "Polkadot__Chain__Signature": "[u8; 65]",
+  "Polkadot__Chain__Timestamp": "u64",
   "Portfolio": {
     "cash": "Balance",
     "positions": "Vec<(AssetInfo,Balance)>"
@@ -441,14 +437,8 @@
       "ChangeValidatorsError": ""
     }
   },
-  "ReasonIncorrectNonce": [
-    "Nonce",
-    "Nonce"
-  ],
-  "ReasonNoticeMissing": [
-    "ChainId",
-    "NoticeId"
-  ],
+  "ReasonIncorrectNonce": "(Nonce,Nonce)",
+  "ReasonNoticeMissing": "(ChainId,NoticeId)",
   "Reporter": "[u8; 20]",
   "ReporterSet": "Vec<Reporter>",
   "SessionIndex": "u32",
@@ -475,8 +465,28 @@
   },
   "SignedPayload": "Vec<u8>",
   "SignersSet": "BTreeSet<ValidatorIdentity>",
+  "Solana__Chain__Address": "[u8; 20]",
+  "Solana__Chain__Amount": "u128",
+  "Solana__Chain__CashIndex": "u128",
+  "Solana__Chain__Event": "sol__Event",
+  "Solana__Chain__EventId": "sol__EventId",
+  "Solana__Chain__Hash": "[u8; 32]",
+  "Solana__Chain__PublicKey": "[u8; 64]",
+  "Solana__Chain__Rate": "u128",
+  "Solana__Chain__Signature": "[u8; 65]",
+  "Solana__Chain__Timestamp": "u64",
   "SubstrateId": "AccountId32",
   "Symbol": "[u8; 12]",
+  "Tezos__Chain__Address": "[u8; 20]",
+  "Tezos__Chain__Amount": "u128",
+  "Tezos__Chain__CashIndex": "u128",
+  "Tezos__Chain__Event": "tez__Event",
+  "Tezos__Chain__EventId": "tez__EventId",
+  "Tezos__Chain__Hash": "[u8; 32]",
+  "Tezos__Chain__PublicKey": "[u8; 64]",
+  "Tezos__Chain__Rate": "u128",
+  "Tezos__Chain__Signature": "[u8; 65]",
+  "Tezos__Chain__Timestamp": "u64",
   "Ticker": "[u8; 12]",
   "Timestamp": "u64",
   "TrxReqParseError": {
@@ -507,5 +517,12 @@
   "VersionedAuthorityList": {
     "authorityList": "AuthorityList",
     "version": "u8"
-  }
+  },
+  "comp__EventId": "(u64,u64)",
+  "dot__EventId": "(u64,u64)",
+  "eth__BlockNumber": "u64",
+  "eth__EventId": "(BlockNumber,LogIndex)",
+  "eth__LogIndex": "u64",
+  "sol__EventId": "(u64,u64)",
+  "tez__EventId": "(u128,u128)"
 }


### PR DESCRIPTION
This patch adds a set of macros to derive types.json automatically. This is, all in all, a little complicated because the best way to analyze the code is through macros (since we can easily mark types that need to be exported) but macros, for obvious reasons, are run at compile-time and are not _meant_ to be side-effecty. That is, you can't easily just store a bunch of global data and when you're finished just emit it. Instead, we truncate and re-write a file-system temp file each time we encounter a new type and eventually we stop encountering new ones and we're good. We do this separately for each project in `scripts/build_types.json` since partial compilation and project-by-project compilation makes this even harder to do. We also need to clean and rebuild each time to ensure every macro is run. _Also_ there is some compile time slowness added here since I can't seem to remove the macros via features or other settings since this runs in the same layer as those types of tools. All-in-all, it's significantly fast enough and hopefully will make the process of updating our types.json trivial going forward.

Note: some of the code is pretty spaghetti in the derive code itself and can be upgraded over time. The issue is that there is a ton of possibilities that could occur in the syntax and we probably don't want to handle all of them.

The most complex one that we need to consider is `WIDTH` which, as a const, is not very easy to determine its value, so for now, we just use its value directly, since literals are fairly easy.

Note: the goal of `types-derive` is that it is generic and can be added to substrate's core, so we try to avoid "Gateway-specific" features in the code.