### PR TITLE
Add logging for validate_unsigned

### DIFF
--- a/pallets/cash/src/internal/validate_trx.rs
+++ b/pallets/cash/src/internal/validate_trx.rs
@@ -9,10 +9,10 @@ use crate::{
 
 use codec::Encode;
 use frame_support::storage::{IterableStorageMap, StorageDoubleMap, StorageValue};
-use our_std::RuntimeDebug;
+use our_std::{log, RuntimeDebug};
 use sp_runtime::transaction_validity::{TransactionSource, TransactionValidity, ValidTransaction};
 
-#[derive(Eq, PartialEq, RuntimeDebug)]
+#[derive(Eq, PartialEq, RuntimeDebug, Clone, Copy)]
 pub enum ValidationError {
     InvalidInternalOnly,
     InvalidNextCode,
@@ -23,6 +23,16 @@ pub enum ValidationError {
     InvalidPrice(Reason),
     UnknownNotice,
     InvalidTrxRequest(Reason),
+}
+
+pub fn check_validation_failure<T: Config>(
+    call: &Call<T>,
+    res: Result<TransactionValidity, ValidationError>,
+) -> Result<TransactionValidity, ValidationError> {
+    if let Err(err) = res {
+        log!("validate_unsigned call {:#?}, Error {:#?}", call, err);
+    }
+    res
 }
 
 pub fn validate_unsigned<T: Config>(

--- a/pallets/cash/src/internal/validate_trx.rs
+++ b/pallets/cash/src/internal/validate_trx.rs
@@ -30,7 +30,7 @@ pub fn check_validation_failure<T: Config>(
     res: Result<TransactionValidity, ValidationError>,
 ) -> Result<TransactionValidity, ValidationError> {
     if let Err(err) = res {
-        log!("validate_unsigned call {:#?}, Error {:#?}", call, err);
+        log!("validate_unsigned: call = {:#?}, error = {:#?}", call, err);
     }
     res
 }

--- a/pallets/cash/src/lib.rs
+++ b/pallets/cash/src/lib.rs
@@ -686,7 +686,10 @@ impl<T: Config> frame_support::unsigned::ValidateUnsigned for Module<T> {
     /// here we make sure that some particular calls (the ones produced by offchain worker)
     /// are being whitelisted and marked as valid.
     fn validate_unsigned(source: TransactionSource, call: &Self::Call) -> TransactionValidity {
-        internal::validate_trx::validate_unsigned::<T>(source, call)
-            .unwrap_or(InvalidTransaction::Call.into())
+        internal::validate_trx::check_validation_failure(
+            call,
+            internal::validate_trx::validate_unsigned::<T>(source, call),
+        )
+        .unwrap_or(InvalidTransaction::Call.into())
     }
 }

--- a/pallets/oracle/src/lib.rs
+++ b/pallets/oracle/src/lib.rs
@@ -163,7 +163,10 @@ impl<T: Config> frame_support::unsigned::ValidateUnsigned for Module<T> {
     /// here we make sure that some particular calls (the ones produced by offchain worker)
     /// are being whitelisted and marked as valid.
     fn validate_unsigned(source: TransactionSource, call: &Self::Call) -> TransactionValidity {
-        validate_trx::validate_unsigned::<T>(source, call)
-            .unwrap_or(InvalidTransaction::Call.into())
+        validate_trx::check_validation_failure(
+            call,
+            validate_trx::validate_unsigned::<T>(source, call),
+        )
+        .unwrap_or(InvalidTransaction::Call.into())
     }
 }

--- a/pallets/oracle/src/validate_trx.rs
+++ b/pallets/oracle/src/validate_trx.rs
@@ -1,14 +1,14 @@
 use crate::{error::OracleError, oracle, Call, Config};
 use codec::Decode;
 use codec::Encode;
-use our_std::RuntimeDebug;
+use our_std::{log, RuntimeDebug};
 use sp_runtime::transaction_validity::{TransactionSource, TransactionValidity, ValidTransaction};
 
 const MAX_EXTERNAL_PAIRS: usize = 30;
 const UNSIGNED_TXS_PRIORITY: u64 = 100;
 const UNSIGNED_TXS_LONGEVITY: u64 = 32;
 
-#[derive(Encode, Eq, PartialEq, RuntimeDebug)]
+#[derive(Encode, Eq, PartialEq, RuntimeDebug, Clone, Copy)]
 #[cfg_attr(feature = "std", derive(Decode))]
 pub enum ValidationError {
     InvalidInternalOnly,
@@ -16,6 +16,16 @@ pub enum ValidationError {
     InvalidPrice(OracleError),
     InvalidCall,
     ExcessivePrices,
+}
+
+pub fn check_validation_failure<T: Config>(
+    call: &Call<T>,
+    res: Result<TransactionValidity, ValidationError>,
+) -> Result<TransactionValidity, ValidationError> {
+    if let Err(err) = res {
+        log!("validate_unsigned call {:#?}, Error {:#?}", call, err);
+    }
+    res
 }
 
 pub fn validate_unsigned<T: Config>(

--- a/pallets/oracle/src/validate_trx.rs
+++ b/pallets/oracle/src/validate_trx.rs
@@ -23,7 +23,7 @@ pub fn check_validation_failure<T: Config>(
     res: Result<TransactionValidity, ValidationError>,
 ) -> Result<TransactionValidity, ValidationError> {
     if let Err(err) = res {
-        log!("validate_unsigned call {:#?}, Error {:#?}", call, err);
+        log!("validate_unsigned: call = {:#?}, error = {:#?}", call, err);
     }
     res
 }


### PR DESCRIPTION
`sp_tracing` didn't give many benefits (it can give better error tracing for tests for sure), and unclarity how to properly use it for the testnet or even if it needed, led me to take this simple way for missing `validate_unsigned` error logging.