### PR TITLE
Build Ethereum Contract to test Trx Request from Chain

### DIFF
--- a/ethereum/contracts/test/Locker.sol
+++ b/ethereum/contracts/test/Locker.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.1;
+
+import "../Starport.sol";
+import "./TrxRequestBuilder.sol";
+
+contract Locker is TrxRequestBuilder {
+  Starport public immutable starport;
+
+  constructor(address payable starport_) {
+    starport = Starport(starport_);
+  }
+
+  receive () external payable {
+    lockAndtransfer();
+  }
+
+  function lockAndtransfer() public payable {
+    address recipient = msg.sender;
+    string memory trxRequest = transferCashMaxRequest(recipient);
+    bytes32 recipient32 = starport.toBytes32(recipient);
+    starport.execTrxRequest(trxRequest);
+    starport.lockEthTo{value: msg.value}("ETH", recipient32);
+  }
+}

--- a/ethereum/contracts/test/TrxRequestBuilder.sol
+++ b/ethereum/contracts/test/TrxRequestBuilder.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.1;
+
+contract TrxRequestBuilder {
+  function nibbleToHex(uint8 v) pure public returns (bytes1) {
+    require(v < 0x10, "Nibble should be below 16");
+
+    if (v < 10) {
+      return bytes1(0x30 + v); // '0' + v
+    } else {
+      return bytes1(0x41 + (v - 10)); // 'A' + v
+    }
+  }
+
+  function toHexByte(uint8 v) pure public returns (bytes1, bytes1) {
+    bytes1 high = nibbleToHex((v >> 4) & 0xf);
+    bytes1 low = nibbleToHex(v & 0x0f);
+    return (high, low);
+  }
+
+  function toHex(address addr) pure public returns (string memory) {
+    bytes20 address20 = bytes20(addr);
+    bytes memory res = new bytes(40);
+    for (uint i = 0; i < 20; i++) {
+      (bytes1 high, bytes1 low) = toHexByte(uint8(address20[i]));
+      res[i * 2] = high;
+      res[i * 2 + 1] = low;
+    }
+    return string(res);
+  }
+
+  function strcpy(string memory src, string memory dest, uint offset) pure internal {
+    bytes memory srcb = bytes(src);
+    bytes memory destb = bytes(dest);
+
+    require(offset + srcb.length <= destb.length, "strcpy beyond end of target");
+
+    for (uint i = 0; i < srcb.length; i++) {
+      destb[offset+i] = srcb[i];
+    }
+  }
+
+  function transferCashMaxRequest(address recipient) pure public returns (string memory) {
+    string memory res = "(Transfer MAX Cash Eth:0x0000000000000000000000000000000000000000)";
+    strcpy(toHex(recipient), res, 25);
+    return string(res);
+  }
+}

--- a/integration/__tests__/ethereum_scen.js
+++ b/integration/__tests__/ethereum_scen.js
@@ -1,0 +1,18 @@
+const { buildScenarios } = require('../util/scenario');
+
+let ethereum_scen_info = {
+  tokens: []
+};
+
+buildScenarios('Ethereum Scenarios', ethereum_scen_info, [
+  {
+    name: "Locker: Lock and Extract",
+    scenario: async ({ chain, zrx, eth, starport }) => {
+      let locker = await eth.__deploy('Locker', [starport.ethAddress()]);
+      await locker.methods.lockAndtransfer().send({ from: eth.root(), value: 0.1e18 });
+      // This should, if all goes well, XXX
+      let event = await chain.waitForEvent('cash', 'TransferCash');
+      console.log({event});
+    }
+  }
+]);


### PR DESCRIPTION
This patch adds a new contract (and a `TrxRequestBuilder`) which tests executing a trx request from on-chain. The builder is rudimentary, but can be the start of a full-time builder. The contract `Locker` just locks Eth and transfers it to you (the sender)'s account on Gateway. I believe this is currenty failing due to `(Transfer Cash Max 0x...)` failing right now.

Note: the one bug discovered so far is that events from a trx are processed in reverse order. We should ensure we fix that in our new event system.