### PR TITLE
Max Cash Less Fee

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[profile.dev]
+split-debuginfo = 'unpacked'
+
 [profile.release]
 panic = 'unwind'
 

--- a/integration/__tests__/transfer_scen.js
+++ b/integration/__tests__/transfer_scen.js
@@ -38,19 +38,23 @@ buildScenarios('Transfer Scenarios', transfer_scen_info, { beforeEach: lockUSDC 
     }
   },
   {
-    skip: true,
     name: "Transfer Cash Max",
     scenario: async ({ ashley, bert, chuck, zrx, chain, starport, cash }) => {
-      await ashley.transfer(10, cash, bert);
-      await bert.transfer('Max', cash, chuck); // This is failing due to Insufficient Liquidity (!)
-      let ashleyCash = await ashley.cash();
-      let bertCash = await bert.cash();
-      let chuckCash = await chuck.cash();
-
-      // TODO: Fix checks below
-      expect(ashleyCash).toBeCloseTo(-10.01, 4);
-      expect(bertCash).toEqual(0, 4);
-      expect(chuckCash).toEqual(10, 4);
+      await ashley.transfer(2, cash, bert);
+      await bert.transfer('Max', cash, chuck);
+      expect(await bert.cash()).toBeCloseTo(0, 4);
+      expect(await chuck.cash()).toBeCloseTo(1.99, 4);
+    }
+  },
+  {
+    name: "Transfer Cash Max Insufficient",
+    scenario: async ({ ashley, bert, chuck, zrx, chain, starport, cash }) => {
+      await ashley.transfer(2, cash, bert);
+      await bert.transfer(1.985, cash, ashley);
+      expect(await bert.cash()).toBeCloseTo(0.005, 4);
+      await expect(bert.transfer('Max', cash, chuck)).rejects.toThrow(/InsufficientCashForMaxTransfer/);
+      expect(await bert.cash()).toBeCloseTo(0.005, 4);
+      expect(await chuck.cash()).toBeCloseTo(0, 4);
     }
   }
 ]);

--- a/integration/package.json
+++ b/integration/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "postinstall": "cat /dev/null > node_modules/source-map-support/register.js",
     "test": "QUIET_SCENARIOS=true jest",
+    "rtest": "PROFILE=release QUIET_SCENARIOS=true jest",
     "build": "(cd ../ethereum && yarn compile) && cargo build",
     "build-full": "(cd ../ethereum && yarn compile) && cargo build --release --features freeze-time",
     "full-test": "yarn build-full && PROFILE=release QUIET_SCENARIOS=true jest",

--- a/integration/util/scenario/event_tracker.js
+++ b/integration/util/scenario/event_tracker.js
@@ -160,7 +160,7 @@ class EventTracker {
 
                 return new Error(`DispatchError[id=${id}]: ${section}.${method}: ${documentation.join(' ')}`);
               } catch (e) {
-                console.error("Error looking up module", e);
+                // Ignore
               }
             }
 

--- a/pallets/cash/src/reason.rs
+++ b/pallets/cash/src/reason.rs
@@ -62,6 +62,7 @@ pub enum Reason {
     InvalidChain,
     PendingAuthNotice,
     ChangeValidatorsError,
+    InsufficientCashForMaxTransfer,
 }
 
 impl From<Reason> for frame_support::dispatch::DispatchError {
@@ -119,6 +120,7 @@ impl From<Reason> for frame_support::dispatch::DispatchError {
             Reason::InvalidChain => (29, 0, "invalid chain"),
             Reason::PendingAuthNotice => (30, 0, "change auth notice is already pending"),
             Reason::ChangeValidatorsError => (31, 0, "change validators error"),
+            Reason::InsufficientCashForMaxTransfer => (32, 0, "insufficient cash for max transfer"),
         };
         frame_support::dispatch::DispatchError::Module {
             index,

--- a/types.json
+++ b/types.json
@@ -467,7 +467,8 @@
       "UnknownValidator": "",
       "InvalidChain": "",
       "PendingAuthNotice": "",
-      "ChangeValidatorsError": ""
+      "ChangeValidatorsError": "",
+      "InsufficientCashForMaxTransfer": ""
     }
   },
   "ReasonIncorrectNonce": "(Nonce,Nonce)",


### PR DESCRIPTION
This patch fixes "Transfer Max Cash" to subtract out the fee before calculating "max" so it doesn't necessarily push you into a negative cash position (since, e.g. if you had 5 CASH and then you transfered max, we would calculate that as "you want to transfer 5 Cash" and then charge you 0.01 Cash as a transfer fee and end up with a -0.01 CASH balance. Now we say you want to transfer 4.99 and you'll end up with exactly 0 CASH balance afterwards).
    
Additionally, we un-mock the tests and start to build a nice little suite of unit tests.

Finally, we also add support for partial debug compilation, which should speed up `cargo build` builds.