### PR TITLE
Handle Unpriced and Mismatched Assets

### DIFF
--- a/integration/__tests__/liquidate_scen.js
+++ b/integration/__tests__/liquidate_scen.js
@@ -239,7 +239,7 @@ buildScenarios('Liquidate Scenarios', liquidate_scen_info, [
       expect(await bert.chainBalance(usdc)).toEqual(0);
       expect(await bert.chainBalance(comp)).toEqual(0);
 
-      await expect(ashley.liquidate(0.5, comp, usdc, ashley)).rejects.toThrow(/SufficientLiquidity/);
+      await expect(bert.liquidate(0.5, comp, usdc, ashley)).rejects.toThrow(/SufficientLiquidity/);
 
       expect(await ashley.chainBalance(usdc)).toBeCloseTo(600); // 600 Received
       expect(await ashley.chainBalance(comp)).toBeCloseTo(-1, 2); // -1 Borrowed

--- a/pallets/cash/src/internal/liquidity.rs
+++ b/pallets/cash/src/internal/liquidity.rs
@@ -250,7 +250,6 @@ mod tests {
 
     #[test]
     fn test_has_liquidity_to_reduce_asset_mismatch() {
-        // TODO: This should fail -- and currently doesn't
         new_test_ext().execute_with(|| {
             assert_eq!(
                 has_liquidity_to_reduce_asset::<Test>(
@@ -265,7 +264,6 @@ mod tests {
 
     #[test]
     fn test_has_liquidity_to_reduce_asset_unpriced() {
-        // TODO: This should fail -- and currently doesn't
         new_test_ext().execute_with(|| {
             pallet_oracle::Prices::insert(
                 ETH.ticker,

--- a/pallets/cash/src/internal/liquidity.rs
+++ b/pallets/cash/src/internal/liquidity.rs
@@ -30,6 +30,9 @@ pub fn has_liquidity_to_reduce_asset<T: Config>(
     asset: AssetInfo,
     amount: AssetQuantity,
 ) -> Result<bool, Reason> {
+    if asset.ticker != amount.units.ticker {
+        Err(Reason::AssetQuantityMismatch)?
+    }
     let liquidity = Portfolio::from_storage::<T>(account)?
         .asset_change(asset, amount.as_decrease()?)?
         .get_liquidity::<T>()?;
@@ -43,6 +46,9 @@ pub fn has_liquidity_to_reduce_asset_with_fee<T: Config>(
     amount: AssetQuantity,
     fee: CashQuantity,
 ) -> Result<bool, Reason> {
+    if asset.ticker != amount.units.ticker {
+        Err(Reason::AssetQuantityMismatch)?
+    }
     let liquidity = Portfolio::from_storage::<T>(account)?
         .asset_change(asset, amount.as_decrease()?)?
         .cash_change(fee.as_decrease()?)?
@@ -58,6 +64,12 @@ pub fn has_liquidity_to_reduce_asset_with_added_collateral<T: Config>(
     collateral_asset: AssetInfo,
     collateral_amount: AssetQuantity,
 ) -> Result<bool, Reason> {
+    if asset.ticker != amount.units.ticker {
+        Err(Reason::AssetQuantityMismatch)?
+    }
+    if collateral_asset.ticker != collateral_amount.units.ticker {
+        Err(Reason::AssetQuantityMismatch)?
+    }
     let liquidity = Portfolio::from_storage::<T>(account)?
         .asset_change(asset, amount.as_decrease()?)?
         .asset_change(collateral_asset, collateral_amount.as_increase()?)?
@@ -72,6 +84,9 @@ pub fn has_liquidity_to_reduce_asset_with_added_cash<T: Config>(
     amount: AssetQuantity,
     cash_amount: CashQuantity,
 ) -> Result<bool, Reason> {
+    if asset.ticker != amount.units.ticker {
+        Err(Reason::AssetQuantityMismatch)?
+    }
     let liquidity = Portfolio::from_storage::<T>(account)?
         .asset_change(asset, amount.as_decrease()?)?
         .cash_change(cash_amount.as_increase()?)?
@@ -98,6 +113,9 @@ pub fn has_liquidity_to_reduce_cash_with_added_collateral<T: Config>(
     collateral_asset: AssetInfo,
     collateral_amount: AssetQuantity,
 ) -> Result<bool, Reason> {
+    if collateral_asset.ticker != collateral_amount.units.ticker {
+        Err(Reason::AssetQuantityMismatch)?
+    }
     let liquidity = Portfolio::from_storage::<T>(account)?
         .cash_change(amount.as_decrease()?)?
         .asset_change(collateral_asset, collateral_amount.as_increase()?)?
@@ -115,9 +133,12 @@ mod tests {
     use super::*;
     use crate::{
         chains::*,
-        tests::{common::*, mock::*, *},
+        tests::{assets::*, common::*, mock::*},
         types::*,
+        SupportedAssets,
     };
+    use frame_support::storage::StorageMap;
+    use pallet_oracle::{self, types::Price};
 
     #[test]
     fn test_has_non_negative_liquidity_positive() {
@@ -227,10 +248,8 @@ mod tests {
         })
     }
 
-    // TODO: Better handle unsupported, non-collateral and/or unpriced assets
-
     #[test]
-    fn test_has_liquidity_to_reduce_unsupported_asset_mismatch() {
+    fn test_has_liquidity_to_reduce_asset_mismatch() {
         // TODO: This should fail -- and currently doesn't
         new_test_ext().execute_with(|| {
             assert_eq!(
@@ -239,10 +258,33 @@ mod tests {
                     eth,
                     Quantity::from_nominal("0.01", WBTC)
                 ),
-                Ok(true)
+                Err(Reason::AssetQuantityMismatch)
             );
         })
     }
+
+    #[test]
+    fn test_has_liquidity_to_reduce_asset_unpriced() {
+        // TODO: This should fail -- and currently doesn't
+        new_test_ext().execute_with(|| {
+            pallet_oracle::Prices::insert(
+                ETH.ticker,
+                Price::from_nominal(ETH.ticker, "2000.00").value,
+            );
+            SupportedAssets::insert(&Eth, eth);
+
+            assert_eq!(
+                has_liquidity_to_reduce_asset::<Test>(
+                    ChainAccount::Eth([0u8; 20]),
+                    wbtc,
+                    Quantity::from_nominal("0.01", WBTC)
+                ),
+                Err(Reason::NoPrice)
+            );
+        })
+    }
+
+    // TODO: Consider what to do with unsupported assets
 
     #[test]
     fn test_has_liquidity_to_reduce_asset_with_fee() {

--- a/pallets/cash/src/reason.rs
+++ b/pallets/cash/src/reason.rs
@@ -64,6 +64,7 @@ pub enum Reason {
     ChangeValidatorsError,
     InsufficientCashForMaxTransfer,
     SufficientLiquidity,
+    AssetQuantityMismatch,
 }
 
 impl From<Reason> for frame_support::dispatch::DispatchError {
@@ -123,6 +124,7 @@ impl From<Reason> for frame_support::dispatch::DispatchError {
             Reason::ChangeValidatorsError => (31, 0, "change validators error"),
             Reason::InsufficientCashForMaxTransfer => (32, 0, "insufficient cash for max transfer"),
             Reason::SufficientLiquidity => (33, 0, "sufficient liquidity for borrower"),
+            Reason::AssetQuantityMismatch => (34, 0, "asset does not match quantity"),
         };
         frame_support::dispatch::DispatchError::Module {
             index,

--- a/pallets/oracle/src/error.rs
+++ b/pallets/oracle/src/error.rs
@@ -23,6 +23,7 @@ pub enum OracleError {
     NoPriceFeedURL,
     StalePrice,
     SubmitError,
+    NoPrice,
 }
 
 impl From<CryptoError> for OracleError {
@@ -49,6 +50,7 @@ impl From<OracleError> for frame_support::dispatch::DispatchError {
             OracleError::NoPriceFeedURL => (12, 0, "NoPriceFeedURL"),
             OracleError::StalePrice => (13, 0, "StalePrice"),
             OracleError::SubmitError => (14, 0, "SubmitError"),
+            OracleError::NoPrice => (15, 0, "NoPrice"),
         };
         frame_support::dispatch::DispatchError::Module {
             index,

--- a/types.json
+++ b/types.json
@@ -383,7 +383,8 @@
       "JsonParseError": "",
       "NoPriceFeedURL": "",
       "StalePrice": "",
-      "SubmitError": ""
+      "SubmitError": "",
+      "NoPrice": ""
     }
   },
   "Oracle__Timestamp": "u64",
@@ -469,7 +470,8 @@
       "PendingAuthNotice": "",
       "ChangeValidatorsError": "",
       "InsufficientCashForMaxTransfer": "",
-      "SufficientLiquidity": ""
+      "SufficientLiquidity": "",
+      "AssetQuantityMismatch": ""
     }
   },
   "ReasonIncorrectNonce": "(Nonce,Nonce)",


### PR DESCRIPTION
To improve completeness, we add checks for matching asset prices to the assets themselves and ensure prices are set when checking liquidity. We change the behavior from pallet-oracle to return an optional price and use a default zero in the places where it's currently expected. We make no effort here to decide if _that_ is the correct behavior- just to keep the status quo in that regard. A few other call sites may have assumed zero prices that will now receive an error, but that is _probably_ a good thing.