### PR TITLE
Factor out `Liquidate.rs` and `BalanceHelpers.rs` with Unit Tests

### DIFF
--- a/pallets/cash/src/core.rs
+++ b/pallets/cash/src/core.rs
@@ -26,7 +26,7 @@ use crate::{
     chains::{ChainAccount, ChainAsset, ChainHash, ChainId},
     events::ChainLogEvent,
     factor::Factor,
-    internal::{self, liquidity},
+    internal::{self, balance_helpers::*, liquidity},
     log,
     params::{MIN_TX_VALUE, TRANSFER_FEE},
     portfolio::Portfolio,
@@ -208,123 +208,6 @@ pub fn passes_validation_threshold(
     valid_signers.len() >= (2 * validators.len() + 3 - 1) / 3
 }
 
-// XXX use Balances instead of raw balances everywhere and put all fns on types?
-
-fn add_amount_to_raw(a: AssetAmount, b: AssetQuantity) -> Result<AssetAmount, MathError> {
-    Ok(a.checked_add(b.value).ok_or(MathError::Overflow)?)
-}
-
-fn add_amount_to_balance(
-    balance: AssetBalance,
-    amount: AssetQuantity,
-) -> Result<AssetBalance, MathError> {
-    let signed = AssetBalance::try_from(amount.value).or(Err(MathError::Overflow))?;
-    Ok(balance.checked_add(signed).ok_or(MathError::Overflow)?)
-}
-
-fn add_principal_amounts(
-    a: CashPrincipalAmount,
-    b: CashPrincipalAmount,
-) -> Result<CashPrincipalAmount, MathError> {
-    Ok(a.add(b)?)
-}
-
-fn sub_amount_from_raw(
-    a: AssetAmount,
-    b: AssetQuantity,
-    underflow: Reason,
-) -> Result<AssetAmount, Reason> {
-    Ok(a.checked_sub(b.value).ok_or(underflow)?)
-}
-
-fn sub_amount_from_balance(
-    balance: AssetBalance,
-    amount: AssetQuantity,
-) -> Result<AssetBalance, MathError> {
-    let signed = AssetBalance::try_from(amount.value).or(Err(MathError::Overflow))?;
-    Ok(balance.checked_sub(signed).ok_or(MathError::Underflow)?)
-}
-
-pub fn sub_principal_amounts(
-    a: CashPrincipalAmount,
-    b: CashPrincipalAmount,
-    underflow: Reason,
-) -> Result<CashPrincipalAmount, Reason> {
-    Ok(a.sub(b).map_err(|_| underflow)?)
-}
-
-fn neg_balance(balance: AssetBalance) -> AssetAmount {
-    if balance < 0 {
-        -balance as AssetAmount
-    } else {
-        0
-    }
-}
-
-fn pos_balance(balance: AssetBalance) -> AssetAmount {
-    if balance > 0 {
-        balance as AssetAmount
-    } else {
-        0
-    }
-}
-
-fn repay_and_supply_amount(
-    balance: AssetBalance,
-    amount: AssetQuantity,
-) -> (AssetQuantity, AssetQuantity) {
-    let Quantity {
-        value: raw_amount,
-        units,
-    } = amount;
-    let repay_amount = min(neg_balance(balance), raw_amount);
-    let supply_amount = raw_amount - repay_amount;
-    (
-        Quantity::new(repay_amount, units),
-        Quantity::new(supply_amount, units),
-    )
-}
-
-pub fn withdraw_and_borrow_amount(
-    balance: AssetBalance,
-    amount: AssetQuantity,
-) -> (AssetQuantity, AssetQuantity) {
-    let Quantity {
-        value: raw_amount,
-        units,
-    } = amount;
-    let withdraw_amount = min(pos_balance(balance), raw_amount);
-    let borrow_amount = raw_amount - withdraw_amount;
-    (
-        Quantity::new(withdraw_amount, units),
-        Quantity::new(borrow_amount, units),
-    )
-}
-
-pub fn repay_and_supply_principal(
-    balance: CashPrincipal,
-    principal: CashPrincipalAmount,
-) -> (CashPrincipalAmount, CashPrincipalAmount) {
-    let repay_principal = min(neg_balance(balance.0), principal.0);
-    let supply_principal = principal.0 - repay_principal;
-    (
-        CashPrincipalAmount(repay_principal),
-        CashPrincipalAmount(supply_principal),
-    )
-}
-
-fn withdraw_and_borrow_principal(
-    balance: CashPrincipal,
-    principal: CashPrincipalAmount,
-) -> (CashPrincipalAmount, CashPrincipalAmount) {
-    let withdraw_principal = min(pos_balance(balance.0), principal.0);
-    let borrow_principal = principal.0 - withdraw_principal;
-    (
-        CashPrincipalAmount(withdraw_principal),
-        CashPrincipalAmount(borrow_principal),
-    )
-}
-
 fn get_chain_account(chain: String, recipient: [u8; 32]) -> Result<ChainAccount, Reason> {
     match &chain.to_ascii_uppercase()[..] {
         "ETH" => {
@@ -399,7 +282,7 @@ pub fn apply_chain_event_internal<T: Config>(event: ChainLogEvent) -> Result<(),
 }
 
 /// Update the index of which assets an account has non-zero balances in.
-fn set_asset_balance_internal<T: Config>(
+pub fn set_asset_balance_internal<T: Config>(
     asset: ChainAsset,
     account: ChainAccount,
     balance: AssetBalance,
@@ -462,7 +345,8 @@ pub fn lock_internal<T: Config>(
     amount: AssetQuantity,
 ) -> Result<(), Reason> {
     let holder_asset = AssetBalances::get(asset.asset, holder);
-    let (holder_repay_amount, holder_supply_amount) = repay_and_supply_amount(holder_asset, amount);
+    let (holder_repay_amount, holder_supply_amount) =
+        repay_and_supply_amount(holder_asset, amount)?;
 
     let holder_asset_new = add_amount_to_balance(holder_asset, amount)?;
     let total_supply_new =
@@ -507,7 +391,7 @@ pub fn extract_internal<T: Config>(
 
     let holder_asset = AssetBalances::get(asset.asset, holder);
     let (holder_withdraw_amount, holder_borrow_amount) =
-        withdraw_and_borrow_amount(holder_asset, amount);
+        withdraw_and_borrow_amount(holder_asset, amount)?;
 
     let holder_asset_new = sub_amount_from_balance(holder_asset, amount)?;
     let total_supply_new = sub_amount_from_raw(
@@ -560,7 +444,7 @@ pub fn extract_cash_principal_internal<T: Config>(
 
     let holder_cash_principal = CashPrincipals::get(holder);
     let (_holder_withdraw_principal, holder_borrow_principal) =
-        withdraw_and_borrow_principal(holder_cash_principal, principal);
+        withdraw_and_borrow_principal(holder_cash_principal, principal)?;
 
     let chain_id = recipient.chain_id();
     let chain_cash_principal_new =
@@ -608,13 +492,13 @@ pub fn transfer_internal<T: Config>(
 
     let fee_principal = index.cash_principal_amount(TRANSFER_FEE)?;
     let (sender_withdraw_amount, sender_borrow_amount) =
-        withdraw_and_borrow_amount(sender_asset, amount);
+        withdraw_and_borrow_amount(sender_asset, amount)?;
     let (recipient_repay_amount, recipient_supply_amount) =
-        repay_and_supply_amount(recipient_asset, amount);
+        repay_and_supply_amount(recipient_asset, amount)?;
     let (_sender_withdraw_principal, sender_borrow_principal) =
-        withdraw_and_borrow_principal(sender_cash_principal, fee_principal);
+        withdraw_and_borrow_principal(sender_cash_principal, fee_principal)?;
     let (miner_repay_principal, _miner_supply_principal) =
-        repay_and_supply_principal(miner_cash_principal, fee_principal);
+        repay_and_supply_principal(miner_cash_principal, fee_principal)?;
 
     let miner_cash_principal_new = miner_cash_principal.add_amount(fee_principal)?;
     let sender_cash_principal_new = sender_cash_principal.sub_amount(fee_principal)?;
@@ -699,11 +583,11 @@ pub fn transfer_cash_principal_internal<T: Config>(
     let miner_cash_principal = CashPrincipals::get(miner);
 
     let (_sender_withdraw_principal, sender_borrow_principal) =
-        withdraw_and_borrow_principal(sender_cash_principal, principal_with_fee);
+        withdraw_and_borrow_principal(sender_cash_principal, principal_with_fee)?;
     let (recipient_repay_principal, _recipient_supply_principal) =
-        repay_and_supply_principal(recipient_cash_principal, principal);
+        repay_and_supply_principal(recipient_cash_principal, principal)?;
     let (miner_repay_principal, _miner_supply_principal) =
-        repay_and_supply_principal(miner_cash_principal, fee_principal);
+        repay_and_supply_principal(miner_cash_principal, fee_principal)?;
 
     let miner_cash_principal_new = miner_cash_principal.add_amount(fee_principal)?;
     let sender_cash_principal_new = sender_cash_principal.sub_amount(principal_with_fee)?;
@@ -721,403 +605,6 @@ pub fn transfer_cash_principal_internal<T: Config>(
     TotalCashPrincipal::put(total_cash_principal_new);
 
     <Module<T>>::deposit_event(Event::TransferCash(sender, recipient, principal, index));
-
-    Ok(())
-}
-
-pub fn liquidate_internal<T: Config>(
-    asset: AssetInfo,
-    collateral_asset: AssetInfo,
-    liquidator: ChainAccount,
-    borrower: ChainAccount,
-    amount: AssetQuantity,
-) -> Result<(), Reason> {
-    require!(borrower != liquidator, Reason::SelfTransfer);
-    require!(asset != collateral_asset, Reason::InKindLiquidation);
-    require_min_tx_value!(get_value::<T>(amount)?);
-
-    let liquidation_incentive = Factor::from_nominal("1.08"); // XXX spec first
-    let liquidator_asset = AssetBalances::get(asset.asset, liquidator);
-    let borrower_asset = AssetBalances::get(asset.asset, borrower);
-    let liquidator_collateral_asset = AssetBalances::get(collateral_asset.asset, liquidator);
-    let borrower_collateral_asset = AssetBalances::get(collateral_asset.asset, borrower);
-    let seize_amount = amount
-        .mul_factor(liquidation_incentive)?
-        .mul_price(get_price::<T>(asset.units())?)?
-        .div_price(
-            get_price::<T>(collateral_asset.units())?,
-            collateral_asset.units(),
-        )?;
-
-    require!(
-        !liquidity::has_non_negative_liquidity::<T>(borrower)?,
-        Reason::SufficientLiquidity
-    );
-    require!(
-        liquidity::has_liquidity_to_reduce_asset_with_added_collateral::<T>(
-            liquidator,
-            asset,
-            amount,
-            collateral_asset,
-            seize_amount,
-        )?,
-        Reason::InsufficientLiquidity
-    );
-
-    let (borrower_repay_amount, _borrower_supply_amount) =
-        repay_and_supply_amount(liquidator_asset, amount);
-    let (liquidator_withdraw_amount, liquidator_borrow_amount) =
-        withdraw_and_borrow_amount(borrower_asset, amount);
-    let (borrower_collateral_withdraw_amount, _borrower_collateral_borrow_amount) =
-        withdraw_and_borrow_amount(borrower_collateral_asset, seize_amount);
-    let (liquidator_collateral_repay_amount, liquidator_collateral_supply_amount) =
-        repay_and_supply_amount(liquidator_collateral_asset, seize_amount);
-
-    let borrower_asset_new = add_amount_to_balance(borrower_asset, amount)?;
-    let liquidator_asset_new = sub_amount_from_balance(liquidator_asset, amount)?;
-    let borrower_collateral_asset_new =
-        sub_amount_from_balance(borrower_collateral_asset, seize_amount)?;
-    let liquidator_collateral_asset_new =
-        add_amount_to_balance(liquidator_collateral_asset, seize_amount)?;
-
-    let total_supply_new = sub_amount_from_raw(
-        TotalSupplyAssets::get(asset.asset),
-        liquidator_withdraw_amount,
-        Reason::InsufficientTotalFunds,
-    )?;
-    let total_borrow_new = sub_amount_from_raw(
-        add_amount_to_raw(
-            TotalBorrowAssets::get(asset.asset),
-            liquidator_borrow_amount,
-        )?,
-        borrower_repay_amount,
-        Reason::RepayTooMuch,
-    )?;
-    let total_collateral_supply_new = sub_amount_from_raw(
-        add_amount_to_raw(
-            TotalSupplyAssets::get(collateral_asset.asset),
-            liquidator_collateral_supply_amount,
-        )?,
-        borrower_collateral_withdraw_amount,
-        Reason::InsufficientTotalFunds,
-    )?;
-    let total_collateral_borrow_new = sub_amount_from_raw(
-        TotalBorrowAssets::get(collateral_asset.asset),
-        liquidator_collateral_repay_amount,
-        Reason::RepayTooMuch,
-    )?;
-
-    let (borrower_cash_principal_post, borrower_last_index_post) =
-        effect_of_asset_interest_internal(
-            asset,
-            borrower,
-            borrower_asset,
-            borrower_asset_new,
-            CashPrincipals::get(borrower),
-        )?;
-    let (liquidator_cash_principal_post, liquidator_last_index_post) =
-        effect_of_asset_interest_internal(
-            asset,
-            liquidator,
-            liquidator_asset,
-            liquidator_asset_new,
-            CashPrincipals::get(liquidator),
-        )?;
-    let (borrower_cash_principal_post, borrower_collateral_last_index_post) =
-        effect_of_asset_interest_internal(
-            collateral_asset,
-            borrower,
-            borrower_collateral_asset,
-            borrower_collateral_asset_new,
-            borrower_cash_principal_post,
-        )?;
-    let (liquidator_cash_principal_post, liquidator_collateral_last_index_post) =
-        effect_of_asset_interest_internal(
-            collateral_asset,
-            liquidator,
-            liquidator_collateral_asset,
-            liquidator_collateral_asset_new,
-            liquidator_cash_principal_post,
-        )?;
-
-    LastIndices::insert(asset.asset, borrower, borrower_last_index_post);
-    LastIndices::insert(asset.asset, liquidator, liquidator_last_index_post);
-    LastIndices::insert(
-        collateral_asset.asset,
-        borrower,
-        borrower_collateral_last_index_post,
-    );
-    LastIndices::insert(
-        collateral_asset.asset,
-        liquidator,
-        liquidator_collateral_last_index_post,
-    );
-    CashPrincipals::insert(borrower, borrower_cash_principal_post);
-    CashPrincipals::insert(liquidator, liquidator_cash_principal_post);
-    TotalSupplyAssets::insert(asset.asset, total_supply_new);
-    TotalBorrowAssets::insert(asset.asset, total_borrow_new);
-    TotalSupplyAssets::insert(collateral_asset.asset, total_collateral_supply_new);
-    TotalBorrowAssets::insert(collateral_asset.asset, total_collateral_borrow_new);
-
-    set_asset_balance_internal::<T>(asset.asset, borrower, borrower_asset_new);
-    set_asset_balance_internal::<T>(asset.asset, liquidator, liquidator_asset_new);
-    set_asset_balance_internal::<T>(
-        collateral_asset.asset,
-        borrower,
-        borrower_collateral_asset_new,
-    );
-    set_asset_balance_internal::<T>(
-        collateral_asset.asset,
-        liquidator,
-        liquidator_collateral_asset_new,
-    );
-
-    <Module<T>>::deposit_event(Event::Liquidate(
-        asset.asset,
-        collateral_asset.asset,
-        liquidator,
-        borrower,
-        amount.value,
-    ));
-
-    Ok(())
-}
-
-pub fn liquidate_cash_principal_internal<T: Config>(
-    collateral_asset: AssetInfo,
-    liquidator: ChainAccount,
-    borrower: ChainAccount,
-    principal: CashPrincipalAmount,
-) -> Result<(), Reason> {
-    let index = GlobalCashIndex::get();
-    let amount = index.cash_quantity(principal)?;
-
-    require!(borrower != liquidator, Reason::SelfTransfer);
-    require_min_tx_value!(get_value::<T>(amount)?);
-
-    let liquidation_incentive = Factor::from_nominal("1.08"); // XXX spec first
-    let liquidator_cash_principal = CashPrincipals::get(liquidator);
-    let borrower_cash_principal = CashPrincipals::get(borrower);
-    let liquidator_collateral_asset = AssetBalances::get(collateral_asset.asset, liquidator);
-    let borrower_collateral_asset = AssetBalances::get(collateral_asset.asset, borrower);
-    let seize_amount = amount
-        .mul_factor(liquidation_incentive)?
-        .mul_price(get_price::<T>(CASH)?)?
-        .div_price(
-            get_price::<T>(collateral_asset.units())?,
-            collateral_asset.units(),
-        )?;
-
-    require!(
-        !liquidity::has_non_negative_liquidity::<T>(borrower)?,
-        Reason::SufficientLiquidity
-    );
-    require!(
-        liquidity::has_liquidity_to_reduce_cash_with_added_collateral::<T>(
-            liquidator,
-            amount,
-            collateral_asset,
-            seize_amount,
-        )?,
-        Reason::InsufficientLiquidity
-    );
-
-    let (borrower_repay_principal, _borrower_supply_principal) =
-        repay_and_supply_principal(liquidator_cash_principal, principal);
-    let (_liquidator_withdraw_principal, liquidator_borrow_principal) =
-        withdraw_and_borrow_principal(borrower_cash_principal, principal);
-    let (borrower_collateral_withdraw_amount, _borrower_collateral_borrow_amount) =
-        withdraw_and_borrow_amount(borrower_collateral_asset, seize_amount);
-    let (liquidator_collateral_repay_amount, liquidator_collateral_supply_amount) =
-        repay_and_supply_amount(liquidator_collateral_asset, seize_amount);
-
-    let borrower_cash_principal_new = borrower_cash_principal.add_amount(principal)?;
-    let liquidator_cash_principal_new = liquidator_cash_principal.sub_amount(principal)?;
-    let borrower_collateral_asset_new =
-        sub_amount_from_balance(borrower_collateral_asset, seize_amount)?;
-    let liquidator_collateral_asset_new =
-        add_amount_to_balance(liquidator_collateral_asset, seize_amount)?;
-
-    let total_cash_principal_new = sub_principal_amounts(
-        add_principal_amounts(TotalCashPrincipal::get(), liquidator_borrow_principal)?,
-        borrower_repay_principal,
-        Reason::RepayTooMuch,
-    )?;
-    let total_collateral_supply_new = sub_amount_from_raw(
-        add_amount_to_raw(
-            TotalSupplyAssets::get(collateral_asset.asset),
-            liquidator_collateral_supply_amount,
-        )?,
-        borrower_collateral_withdraw_amount,
-        Reason::InsufficientTotalFunds,
-    )?;
-    let total_collateral_borrow_new = sub_amount_from_raw(
-        TotalBorrowAssets::get(collateral_asset.asset),
-        liquidator_collateral_repay_amount,
-        Reason::RepayTooMuch,
-    )?;
-
-    let (borrower_cash_principal_post, borrower_collateral_last_index_post) =
-        effect_of_asset_interest_internal(
-            collateral_asset,
-            borrower,
-            borrower_collateral_asset,
-            borrower_collateral_asset_new,
-            borrower_cash_principal_new,
-        )?;
-    let (liquidator_cash_principal_post, liquidator_collateral_last_index_post) =
-        effect_of_asset_interest_internal(
-            collateral_asset,
-            liquidator,
-            liquidator_collateral_asset,
-            liquidator_collateral_asset_new,
-            liquidator_cash_principal_new,
-        )?;
-
-    LastIndices::insert(
-        collateral_asset.asset,
-        borrower,
-        borrower_collateral_last_index_post,
-    );
-    LastIndices::insert(
-        collateral_asset.asset,
-        liquidator,
-        liquidator_collateral_last_index_post,
-    );
-    CashPrincipals::insert(borrower, borrower_cash_principal_post);
-    CashPrincipals::insert(liquidator, liquidator_cash_principal_post);
-    TotalCashPrincipal::put(total_cash_principal_new);
-    TotalSupplyAssets::insert(collateral_asset.asset, total_collateral_supply_new);
-    TotalBorrowAssets::insert(collateral_asset.asset, total_collateral_borrow_new);
-
-    set_asset_balance_internal::<T>(
-        collateral_asset.asset,
-        borrower,
-        borrower_collateral_asset_new,
-    );
-    set_asset_balance_internal::<T>(
-        collateral_asset.asset,
-        liquidator,
-        liquidator_collateral_asset_new,
-    );
-
-    <Module<T>>::deposit_event(Event::LiquidateCash(
-        collateral_asset.asset,
-        liquidator,
-        borrower,
-        principal,
-        index,
-    ));
-
-    Ok(())
-}
-
-pub fn liquidate_cash_collateral_internal<T: Config>(
-    asset: AssetInfo,
-    liquidator: ChainAccount,
-    borrower: ChainAccount,
-    amount: AssetQuantity,
-) -> Result<(), Reason> {
-    let index = GlobalCashIndex::get();
-
-    require!(borrower != liquidator, Reason::SelfTransfer);
-    require_min_tx_value!(get_value::<T>(amount)?);
-
-    let liquidation_incentive = Factor::from_nominal("1.08"); // XXX spec first
-    let liquidator_asset = AssetBalances::get(asset.asset, liquidator);
-    let borrower_asset = AssetBalances::get(asset.asset, borrower);
-    let liquidator_cash_principal = CashPrincipals::get(liquidator);
-    let borrower_cash_principal = CashPrincipals::get(borrower);
-    let seize_amount = amount
-        .mul_factor(liquidation_incentive)?
-        .mul_price(get_price::<T>(asset.units())?)?
-        .div_price(get_price::<T>(CASH)?, CASH)?;
-    let seize_principal = index.cash_principal_amount(seize_amount)?;
-
-    require!(
-        !liquidity::has_non_negative_liquidity::<T>(borrower)?,
-        Reason::SufficientLiquidity
-    );
-    require!(
-        liquidity::has_liquidity_to_reduce_asset_with_added_cash::<T>(
-            liquidator,
-            asset,
-            amount,
-            seize_amount
-        )?,
-        Reason::InsufficientLiquidity
-    );
-
-    let (borrower_repay_amount, _borrower_supply_amount) =
-        repay_and_supply_amount(liquidator_asset, amount);
-    let (liquidator_withdraw_amount, liquidator_borrow_amount) =
-        withdraw_and_borrow_amount(borrower_asset, amount);
-    let (borrower_collateral_withdraw_principal, _borrower_collateral_borrow_principal) =
-        withdraw_and_borrow_principal(borrower_cash_principal, seize_principal);
-    let (liquidator_collateral_repay_principal, _liquidator_collateral_supply_principal) =
-        repay_and_supply_principal(
-            liquidator_cash_principal,
-            borrower_collateral_withdraw_principal,
-        );
-
-    let borrower_asset_new = add_amount_to_balance(borrower_asset, amount)?;
-    let liquidator_asset_new = sub_amount_from_balance(liquidator_asset, amount)?;
-    let borrower_cash_principal_new = borrower_cash_principal.sub_amount(seize_principal)?;
-    let liquidator_cash_principal_new = liquidator_cash_principal.add_amount(seize_principal)?;
-
-    let total_supply_new = sub_amount_from_raw(
-        TotalSupplyAssets::get(asset.asset),
-        liquidator_withdraw_amount,
-        Reason::InsufficientTotalFunds,
-    )?;
-    let total_borrow_new = sub_amount_from_raw(
-        add_amount_to_raw(
-            TotalBorrowAssets::get(asset.asset),
-            liquidator_borrow_amount,
-        )?,
-        borrower_repay_amount,
-        Reason::RepayTooMuch,
-    )?;
-    let total_cash_principal_new = sub_principal_amounts(
-        TotalCashPrincipal::get(),
-        liquidator_collateral_repay_principal,
-        Reason::RepayTooMuch,
-    )?;
-
-    let (borrower_cash_principal_post, borrower_last_index_post) =
-        effect_of_asset_interest_internal(
-            asset,
-            borrower,
-            borrower_asset,
-            borrower_asset_new,
-            borrower_cash_principal_new,
-        )?;
-    let (liquidator_cash_principal_post, liquidator_last_index_post) =
-        effect_of_asset_interest_internal(
-            asset,
-            liquidator,
-            liquidator_asset,
-            liquidator_asset_new,
-            liquidator_cash_principal_new,
-        )?;
-
-    LastIndices::insert(asset.asset, borrower, borrower_last_index_post);
-    LastIndices::insert(asset.asset, liquidator, liquidator_last_index_post);
-    CashPrincipals::insert(borrower, borrower_cash_principal_post);
-    CashPrincipals::insert(liquidator, liquidator_cash_principal_post);
-    TotalSupplyAssets::insert(asset.asset, total_supply_new);
-    TotalBorrowAssets::insert(asset.asset, total_borrow_new);
-    TotalCashPrincipal::put(total_cash_principal_new);
-
-    set_asset_balance_internal::<T>(asset.asset, borrower, borrower_asset_new);
-    set_asset_balance_internal::<T>(asset.asset, liquidator, liquidator_asset_new);
-
-    <Module<T>>::deposit_event(Event::LiquidateCashCollateral(
-        asset.asset,
-        liquidator,
-        borrower,
-        amount.value,
-    ));
 
     Ok(())
 }
@@ -1321,66 +808,6 @@ mod tests {
         types::*, *,
     };
     use pallet_oracle::types::Price;
-
-    #[test]
-    fn test_helpers() {
-        assert_eq!(neg_balance(100), 0);
-        assert_eq!(pos_balance(-100), 0);
-        assert_eq!(neg_balance(-100), 100);
-        assert_eq!(pos_balance(100), 100);
-
-        let amount = Quantity::new(100, USD);
-        assert_eq!(
-            repay_and_supply_amount(0, amount),
-            (Quantity::new(0, USD), amount)
-        );
-        assert_eq!(
-            repay_and_supply_amount(-50, amount),
-            (Quantity::new(50, USD), Quantity::new(50, USD))
-        );
-        assert_eq!(
-            repay_and_supply_amount(-100, amount),
-            (amount, Quantity::new(0, USD))
-        );
-        assert_eq!(
-            withdraw_and_borrow_amount(0, amount),
-            (Quantity::new(0, USD), amount)
-        );
-        assert_eq!(
-            withdraw_and_borrow_amount(50, amount),
-            (Quantity::new(50, USD), Quantity::new(50, USD))
-        );
-        assert_eq!(
-            withdraw_and_borrow_amount(100, amount),
-            (amount, Quantity::new(0, USD))
-        );
-
-        let principal = CashPrincipalAmount(100);
-        assert_eq!(
-            repay_and_supply_principal(CashPrincipal(0), principal),
-            (CashPrincipalAmount(0), principal)
-        );
-        assert_eq!(
-            repay_and_supply_principal(CashPrincipal(-50), principal),
-            (CashPrincipalAmount(50), CashPrincipalAmount(50))
-        );
-        assert_eq!(
-            repay_and_supply_principal(CashPrincipal(-100), principal),
-            (principal, CashPrincipalAmount(0))
-        );
-        assert_eq!(
-            withdraw_and_borrow_principal(CashPrincipal(0), principal),
-            (CashPrincipalAmount(0), principal)
-        );
-        assert_eq!(
-            withdraw_and_borrow_principal(CashPrincipal(50), principal),
-            (CashPrincipalAmount(50), CashPrincipalAmount(50))
-        );
-        assert_eq!(
-            withdraw_and_borrow_principal(CashPrincipal(100), principal),
-            (principal, CashPrincipalAmount(0))
-        );
-    }
 
     #[test]
     fn test_compute_cash_principal_per() -> Result<(), Reason> {

--- a/pallets/cash/src/internal/balance_helpers.rs
+++ b/pallets/cash/src/internal/balance_helpers.rs
@@ -1,0 +1,535 @@
+use crate::{
+    reason::{MathError, Reason},
+    types::{
+        AssetAmount, AssetBalance, AssetQuantity, CashPrincipal, CashPrincipalAmount, Quantity,
+    },
+};
+use our_std::{cmp::min, convert::TryFrom};
+
+// XXX use Balances instead of raw balances everywhere and put all fns on types?
+
+/// Adds an asset quantity to a given unsigned amount
+pub fn add_amount_to_raw(a: AssetAmount, b: AssetQuantity) -> Result<AssetAmount, MathError> {
+    Ok(a.checked_add(b.value).ok_or(MathError::Overflow)?)
+}
+
+/// Subtracts an asset quantity from a given unsigned amount, returning an unsigned amount
+/// TODO: Remove underflow param here and just return a math error
+pub fn sub_amount_from_raw(
+    a: AssetAmount,
+    b: AssetQuantity,
+    underflow: Reason,
+) -> Result<AssetAmount, Reason> {
+    Ok(a.checked_sub(b.value).ok_or(underflow)?)
+}
+
+/// Adds an asset quantity to a given signed balance
+pub fn add_amount_to_balance(
+    balance: AssetBalance,
+    amount: AssetQuantity,
+) -> Result<AssetBalance, MathError> {
+    let signed = AssetBalance::try_from(amount.value).or(Err(MathError::Overflow))?;
+    Ok(balance.checked_add(signed).ok_or(MathError::Overflow)?)
+}
+
+/// Subtracts an asset quantity to a given signed balance, returning a signed balance
+pub fn sub_amount_from_balance(
+    balance: AssetBalance,
+    amount: AssetQuantity,
+) -> Result<AssetBalance, MathError> {
+    let signed = AssetBalance::try_from(amount.value).or(Err(MathError::Overflow))?;
+    Ok(balance.checked_sub(signed).ok_or(MathError::Underflow)?)
+}
+
+/// Sums two cash unsigned principals
+pub fn add_principal_amounts(
+    a: CashPrincipalAmount,
+    b: CashPrincipalAmount,
+) -> Result<CashPrincipalAmount, MathError> {
+    Ok(a.add(b)?)
+}
+
+/// Subtracts two cash unsigned principals, returning an unsigned result or given error
+/// TODO: Simply return math error instead?
+pub fn sub_principal_amounts(
+    a: CashPrincipalAmount,
+    b: CashPrincipalAmount,
+    underflow: Reason,
+) -> Result<CashPrincipalAmount, Reason> {
+    Ok(a.sub(b).map_err(|_| underflow)?)
+}
+
+/// Returns value if it is above zero, otherwise 0.
+pub fn pos_balance(balance: AssetBalance) -> AssetAmount {
+    if balance > 0 {
+        balance as AssetAmount // This is safe since we've already checked value is > 0
+    } else {
+        0
+    }
+}
+
+/// Returns abs of value if it is less than zero, otherwise 0.
+pub fn neg_balance(balance: AssetBalance) -> Result<AssetAmount, MathError> {
+    if balance < 0 {
+        Ok(balance.checked_abs().ok_or(MathError::Overflow)? as AssetAmount)
+    } else {
+        Ok(0)
+    }
+}
+
+/// Given a signed balance and a infusion of that asset, determines how much will be
+/// used to repay debt versus added to supply. E.g. do I need to repay some debt and the
+/// rest is supply? Or am I still in debt? Or is it all supply? This judgement turns on
+/// whether the amount causes the balance to cross the zero threshold.
+pub fn repay_and_supply_amount(
+    balance: AssetBalance,
+    amount: AssetQuantity,
+) -> Result<(AssetQuantity, AssetQuantity), Reason> {
+    let Quantity {
+        value: raw_amount,
+        units,
+    } = amount;
+    let repay_amount = min(neg_balance(balance).map_err(Reason::MathError)?, raw_amount);
+    let supply_amount = raw_amount
+        .checked_sub(repay_amount)
+        .expect("repay_amount ≤ raw_amount");
+    Ok((
+        Quantity::new(repay_amount, units),
+        Quantity::new(supply_amount, units),
+    ))
+}
+
+/// Given a signed balance and a reduction of that asset, determines how much will be
+/// pulled from supply versus added to debt. This judgement turns on
+/// whether the amount causes the balance to cross the zero threshold.
+pub fn withdraw_and_borrow_amount(
+    balance: AssetBalance,
+    amount: AssetQuantity,
+) -> Result<(AssetQuantity, AssetQuantity), Reason> {
+    let Quantity {
+        value: raw_amount,
+        units,
+    } = amount;
+    let withdraw_amount = min(pos_balance(balance), raw_amount);
+    let borrow_amount = raw_amount
+        .checked_sub(withdraw_amount)
+        .expect("withdraw_amount ≤ raw_amount");
+    Ok((
+        Quantity::new(withdraw_amount, units),
+        Quantity::new(borrow_amount, units),
+    ))
+}
+
+/// Given a signed balance of cash and a infusion of cash, determines how much will be
+/// used to repay debt versus added to supply. This judgement turns on
+/// whether the amount causes the balance to cross the zero threshold.
+pub fn repay_and_supply_principal(
+    balance: CashPrincipal,
+    principal: CashPrincipalAmount,
+) -> Result<(CashPrincipalAmount, CashPrincipalAmount), Reason> {
+    let repay_principal = min(
+        neg_balance(balance.0).map_err(Reason::MathError)?,
+        principal.0,
+    );
+    let supply_principal = principal
+        .0
+        .checked_sub(repay_principal)
+        .expect("repay_principal ≤ principal");
+    Ok((
+        CashPrincipalAmount(repay_principal),
+        CashPrincipalAmount(supply_principal),
+    ))
+}
+
+/// Given a signed balance of cash and a reduction of cash, determines how much will be
+/// pulled from supply versus added to debt. This judgement turns on
+/// whether the amount causes the balance to cross the zero threshold.
+pub fn withdraw_and_borrow_principal(
+    balance: CashPrincipal,
+    principal: CashPrincipalAmount,
+) -> Result<(CashPrincipalAmount, CashPrincipalAmount), Reason> {
+    let withdraw_principal = min(pos_balance(balance.0), principal.0);
+    let borrow_principal = principal
+        .0
+        .checked_sub(withdraw_principal)
+        .expect("withdraw_principal ≤ principal");
+    Ok((
+        CashPrincipalAmount(withdraw_principal),
+        CashPrincipalAmount(borrow_principal),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::*;
+
+    #[test]
+    fn test_add_amount_to_raw_ok() {
+        assert_eq!(
+            add_amount_to_raw(1000000, Quantity::from_nominal("5", USD)),
+            Ok(6000000)
+        );
+    }
+
+    #[test]
+    fn test_add_amount_to_raw_overflow() {
+        assert_eq!(
+            add_amount_to_raw(u128::MAX, Quantity::from_nominal("5", USD)),
+            Err(MathError::Overflow)
+        );
+    }
+
+    #[test]
+    fn test_sub_amount_from_raw_ok() {
+        assert_eq!(
+            sub_amount_from_raw(6000000, Quantity::from_nominal("5", USD), Reason::None),
+            Ok(1000000)
+        );
+    }
+
+    #[test]
+    fn test_sub_amount_from_raw_underflow() {
+        assert_eq!(
+            sub_amount_from_raw(4000000, Quantity::from_nominal("5", USD), Reason::None),
+            Err(Reason::None)
+        );
+    }
+
+    #[test]
+    fn test_add_amount_to_balance_ok() {
+        assert_eq!(
+            add_amount_to_balance(-1000000, Quantity::from_nominal("5", USD)),
+            Ok(4000000)
+        );
+    }
+
+    #[test]
+    fn test_add_amount_to_balance_overflow() {
+        assert_eq!(
+            add_amount_to_balance(i128::MAX, Quantity::from_nominal("5", USD)),
+            Err(MathError::Overflow)
+        );
+    }
+
+    #[test]
+    fn test_sub_amount_from_balance_ok() {
+        assert_eq!(
+            sub_amount_from_balance(5000000, Quantity::from_nominal("1", USD)),
+            Ok(4000000)
+        );
+    }
+
+    #[test]
+    fn test_sub_amount_from_balance_ok_negative() {
+        assert_eq!(
+            sub_amount_from_balance(5000000, Quantity::from_nominal("6", USD)),
+            Ok(-1000000)
+        );
+    }
+
+    #[test]
+    fn test_sub_amount_from_balance_underflow() {
+        assert_eq!(
+            sub_amount_from_balance(i128::MIN, Quantity::from_nominal("6", USD)),
+            Err(MathError::Underflow)
+        );
+    }
+
+    #[test]
+    fn test_add_principal_amounts_ok() {
+        assert_eq!(
+            add_principal_amounts(
+                CashPrincipalAmount::from_nominal("5"),
+                CashPrincipalAmount::from_nominal("6")
+            ),
+            Ok(CashPrincipalAmount::from_nominal("11"),)
+        );
+    }
+
+    #[test]
+    fn test_add_principal_amounts_overflow() {
+        assert_eq!(
+            add_principal_amounts(
+                CashPrincipalAmount::from_nominal("5"),
+                CashPrincipalAmount(u128::MAX)
+            ),
+            Err(MathError::Overflow)
+        );
+    }
+
+    #[test]
+    fn test_sub_principal_amounts_ok() {
+        assert_eq!(
+            sub_principal_amounts(
+                CashPrincipalAmount::from_nominal("6"),
+                CashPrincipalAmount::from_nominal("5"),
+                Reason::None
+            ),
+            Ok(CashPrincipalAmount::from_nominal("1"),)
+        );
+    }
+
+    #[test]
+    fn test_sub_principal_amounts_overflow() {
+        assert_eq!(
+            sub_principal_amounts(
+                CashPrincipalAmount::from_nominal("5"),
+                CashPrincipalAmount::from_nominal("6"),
+                Reason::None
+            ),
+            Err(Reason::None)
+        );
+    }
+
+    #[test]
+    fn test_pos_balance_pos() {
+        assert_eq!(pos_balance(5000), 5000);
+    }
+
+    #[test]
+    fn test_pos_balance_zero() {
+        assert_eq!(pos_balance(0), 0);
+    }
+
+    #[test]
+    fn test_pos_balance_neg() {
+        assert_eq!(pos_balance(-1000), 0);
+    }
+
+    #[test]
+    fn test_neg_balance_pos() {
+        assert_eq!(neg_balance(5000), Ok(0));
+    }
+
+    #[test]
+    fn test_neg_balance_zero() {
+        assert_eq!(neg_balance(0), Ok(0));
+    }
+
+    #[test]
+    fn test_neg_balance_neg() {
+        assert_eq!(neg_balance(-1000), Ok(1000));
+    }
+
+    #[test]
+    fn test_neg_balance_very_neg() {
+        assert_eq!(neg_balance(i128::MIN), Err(MathError::Overflow));
+    }
+
+    #[test]
+    fn test_repay_and_supply_amount_all_supply() {
+        assert_eq!(
+            repay_and_supply_amount(1000000, Quantity::from_nominal("5", USD)),
+            Ok((
+                Quantity::from_nominal("0", USD),
+                Quantity::from_nominal("5", USD)
+            ))
+        );
+    }
+
+    #[test]
+    fn test_repay_and_supply_amount_all_repay() {
+        assert_eq!(
+            repay_and_supply_amount(-6000000, Quantity::from_nominal("5", USD)),
+            Ok((
+                Quantity::from_nominal("5", USD),
+                Quantity::from_nominal("0", USD)
+            ))
+        );
+    }
+
+    #[test]
+    fn test_repay_and_supply_amount_low_high() {
+        assert_eq!(
+            repay_and_supply_amount(
+                i128::MIN + 1,
+                Quantity {
+                    value: u128::MAX,
+                    units: USD
+                }
+            ),
+            Ok((
+                Quantity {
+                    value: 170141183460469231731687303715884105727,
+                    units: USD
+                },
+                Quantity {
+                    value: 170141183460469231731687303715884105728,
+                    units: USD
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn test_repay_and_supply_amount_overflow() {
+        assert_eq!(
+            repay_and_supply_amount(i128::MIN, Quantity::from_nominal("5", USD)),
+            Err(Reason::MathError(MathError::Overflow))
+        );
+    }
+
+    #[test]
+    fn test_withdraw_and_borrow_amount_all_withdraw() {
+        assert_eq!(
+            withdraw_and_borrow_amount(6000000, Quantity::from_nominal("5", USD)),
+            Ok((
+                Quantity::from_nominal("5", USD),
+                Quantity::from_nominal("0", USD)
+            ))
+        );
+    }
+
+    #[test]
+    fn test_withdraw_and_borrow_amount_all_borrow() {
+        assert_eq!(
+            withdraw_and_borrow_amount(-6000000, Quantity::from_nominal("5", USD)),
+            Ok((
+                Quantity::from_nominal("0", USD),
+                Quantity::from_nominal("5", USD)
+            ))
+        );
+    }
+
+    #[test]
+    fn test_withdraw_and_borrow_amount_low_high() {
+        assert_eq!(
+            withdraw_and_borrow_amount(
+                i128::MIN + 1,
+                Quantity {
+                    value: u128::MAX,
+                    units: USD
+                }
+            ),
+            Ok((
+                Quantity {
+                    value: 0,
+                    units: USD
+                },
+                Quantity {
+                    value: 340282366920938463463374607431768211455,
+                    units: USD
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn test_withdraw_and_borrow_amount_overflow() {
+        assert_eq!(
+            withdraw_and_borrow_amount(
+                i128::MAX,
+                Quantity {
+                    value: u128::MAX,
+                    units: USD
+                }
+            ),
+            Ok((
+                Quantity {
+                    value: 170141183460469231731687303715884105727,
+                    units: USD
+                },
+                Quantity {
+                    value: 170141183460469231731687303715884105728,
+                    units: USD
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn test_repay_and_supply_principal_all_supply() {
+        assert_eq!(
+            repay_and_supply_principal(
+                CashPrincipal::from_nominal("5"),
+                CashPrincipalAmount::from_nominal("1")
+            ),
+            Ok((
+                CashPrincipalAmount::from_nominal("0"),
+                CashPrincipalAmount::from_nominal("1")
+            ))
+        );
+    }
+
+    #[test]
+    fn test_repay_and_supply_principal_all_repay() {
+        assert_eq!(
+            repay_and_supply_principal(
+                CashPrincipal::from_nominal("-5"),
+                CashPrincipalAmount::from_nominal("1")
+            ),
+            Ok((
+                CashPrincipalAmount::from_nominal("1"),
+                CashPrincipalAmount::from_nominal("0")
+            ))
+        );
+    }
+
+    #[test]
+    fn test_repay_and_supply_principal_low_high() {
+        assert_eq!(
+            repay_and_supply_principal(
+                CashPrincipal(i128::MIN + 1),
+                CashPrincipalAmount(u128::MAX)
+            ),
+            Ok((
+                CashPrincipalAmount(170141183460469231731687303715884105727),
+                CashPrincipalAmount(170141183460469231731687303715884105728)
+            ))
+        );
+    }
+
+    #[test]
+    fn test_repay_and_supply_principal_overflow() {
+        assert_eq!(
+            repay_and_supply_principal(
+                CashPrincipal(i128::MIN),
+                CashPrincipalAmount::from_nominal("1")
+            ),
+            Err(Reason::MathError(MathError::Overflow))
+        );
+    }
+
+    #[test]
+    fn test_withdraw_and_borrow_principal_all_withdraw() {
+        assert_eq!(
+            withdraw_and_borrow_principal(
+                CashPrincipal::from_nominal("5"),
+                CashPrincipalAmount::from_nominal("1")
+            ),
+            Ok((
+                CashPrincipalAmount::from_nominal("1"),
+                CashPrincipalAmount::from_nominal("0")
+            ))
+        );
+    }
+
+    #[test]
+    fn test_withdraw_and_borrow_principal_all_borrow() {
+        assert_eq!(
+            withdraw_and_borrow_principal(
+                CashPrincipal::from_nominal("-5"),
+                CashPrincipalAmount::from_nominal("1")
+            ),
+            Ok((
+                CashPrincipalAmount::from_nominal("0"),
+                CashPrincipalAmount::from_nominal("1")
+            ))
+        );
+    }
+
+    #[test]
+    fn test_withdraw_and_borrow_principal_low_high() {
+        assert_eq!(
+            withdraw_and_borrow_principal(
+                CashPrincipal(i128::MIN + 1),
+                CashPrincipalAmount(u128::MAX)
+            ),
+            Ok((
+                CashPrincipalAmount(0),
+                CashPrincipalAmount(340282366920938463463374607431768211455)
+            ))
+        );
+    }
+}

--- a/pallets/cash/src/internal/exec_trx_request.rs
+++ b/pallets/cash/src/internal/exec_trx_request.rs
@@ -1,12 +1,14 @@
 use frame_support::storage::{StorageMap, StorageValue};
 
 use crate::core::{
-    extract_cash_principal_internal, extract_internal, get_asset,
-    liquidate_cash_collateral_internal, liquidate_cash_principal_internal, liquidate_internal,
-    transfer_cash_principal_internal, transfer_internal,
+    extract_cash_principal_internal, extract_internal, get_asset, transfer_cash_principal_internal,
+    transfer_internal,
 };
 use crate::{
     chains::{ChainAccount, ChainAccountSignature},
+    internal::liquidate::{
+        liquidate_cash_collateral_internal, liquidate_cash_principal_internal, liquidate_internal,
+    },
     log,
     params::TRANSFER_FEE,
     reason::Reason,

--- a/pallets/cash/src/internal/liquidate.rs
+++ b/pallets/cash/src/internal/liquidate.rs
@@ -1,0 +1,421 @@
+// Note: The substrate build requires these be re-exported.
+pub use our_std::{
+    cmp::{max, min},
+    collections::btree_set::BTreeSet,
+    convert::{TryFrom, TryInto},
+    fmt, if_std, result,
+    result::Result,
+    str,
+};
+
+use frame_support::storage::{StorageDoubleMap, StorageMap, StorageValue};
+
+use crate::{
+    chains::ChainAccount,
+    core::{self, get_price, get_value},
+    factor::Factor,
+    internal::{balance_helpers::*, liquidity},
+    params::MIN_TX_VALUE,
+    reason::Reason,
+    require, require_min_tx_value,
+    types::{AssetInfo, AssetQuantity, CashPrincipalAmount, CASH},
+    AssetBalances, CashPrincipals, Config, Event, GlobalCashIndex, LastIndices, Module,
+    TotalBorrowAssets, TotalCashPrincipal, TotalSupplyAssets,
+};
+
+pub fn liquidate_internal<T: Config>(
+    asset: AssetInfo,
+    collateral_asset: AssetInfo,
+    liquidator: ChainAccount,
+    borrower: ChainAccount,
+    amount: AssetQuantity,
+) -> Result<(), Reason> {
+    require!(borrower != liquidator, Reason::SelfTransfer);
+    require!(asset != collateral_asset, Reason::InKindLiquidation);
+    require_min_tx_value!(get_value::<T>(amount)?);
+
+    let liquidation_incentive = Factor::from_nominal("1.08"); // XXX spec first
+    let liquidator_asset = AssetBalances::get(asset.asset, liquidator);
+    let borrower_asset = AssetBalances::get(asset.asset, borrower);
+    let liquidator_collateral_asset = AssetBalances::get(collateral_asset.asset, liquidator);
+    let borrower_collateral_asset = AssetBalances::get(collateral_asset.asset, borrower);
+    let seize_amount = amount
+        .mul_factor(liquidation_incentive)?
+        .mul_price(get_price::<T>(asset.units())?)?
+        .div_price(
+            get_price::<T>(collateral_asset.units())?,
+            collateral_asset.units(),
+        )?;
+
+    require!(
+        !liquidity::has_non_negative_liquidity::<T>(borrower)?,
+        Reason::SufficientLiquidity
+    );
+    require!(
+        liquidity::has_liquidity_to_reduce_asset_with_added_collateral::<T>(
+            liquidator,
+            asset,
+            amount,
+            collateral_asset,
+            seize_amount,
+        )?,
+        Reason::InsufficientLiquidity
+    );
+
+    let (borrower_repay_amount, _borrower_supply_amount) =
+        repay_and_supply_amount(liquidator_asset, amount)?;
+    let (liquidator_withdraw_amount, liquidator_borrow_amount) =
+        withdraw_and_borrow_amount(borrower_asset, amount)?;
+    let (borrower_collateral_withdraw_amount, _borrower_collateral_borrow_amount) =
+        withdraw_and_borrow_amount(borrower_collateral_asset, seize_amount)?;
+    let (liquidator_collateral_repay_amount, liquidator_collateral_supply_amount) =
+        repay_and_supply_amount(liquidator_collateral_asset, seize_amount)?;
+
+    let borrower_asset_new = add_amount_to_balance(borrower_asset, amount)?;
+    let liquidator_asset_new = sub_amount_from_balance(liquidator_asset, amount)?;
+    let borrower_collateral_asset_new =
+        sub_amount_from_balance(borrower_collateral_asset, seize_amount)?;
+    let liquidator_collateral_asset_new =
+        add_amount_to_balance(liquidator_collateral_asset, seize_amount)?;
+
+    let total_supply_new = sub_amount_from_raw(
+        TotalSupplyAssets::get(asset.asset),
+        liquidator_withdraw_amount,
+        Reason::InsufficientTotalFunds,
+    )?;
+    let total_borrow_new = sub_amount_from_raw(
+        add_amount_to_raw(
+            TotalBorrowAssets::get(asset.asset),
+            liquidator_borrow_amount,
+        )?,
+        borrower_repay_amount,
+        Reason::RepayTooMuch,
+    )?;
+    let total_collateral_supply_new = sub_amount_from_raw(
+        add_amount_to_raw(
+            TotalSupplyAssets::get(collateral_asset.asset),
+            liquidator_collateral_supply_amount,
+        )?,
+        borrower_collateral_withdraw_amount,
+        Reason::InsufficientTotalFunds,
+    )?;
+    let total_collateral_borrow_new = sub_amount_from_raw(
+        TotalBorrowAssets::get(collateral_asset.asset),
+        liquidator_collateral_repay_amount,
+        Reason::RepayTooMuch,
+    )?;
+
+    let (borrower_cash_principal_post, borrower_last_index_post) =
+        core::effect_of_asset_interest_internal(
+            asset,
+            borrower,
+            borrower_asset,
+            borrower_asset_new,
+            CashPrincipals::get(borrower),
+        )?;
+    let (liquidator_cash_principal_post, liquidator_last_index_post) =
+        core::effect_of_asset_interest_internal(
+            asset,
+            liquidator,
+            liquidator_asset,
+            liquidator_asset_new,
+            CashPrincipals::get(liquidator),
+        )?;
+    let (borrower_cash_principal_post, borrower_collateral_last_index_post) =
+        core::effect_of_asset_interest_internal(
+            collateral_asset,
+            borrower,
+            borrower_collateral_asset,
+            borrower_collateral_asset_new,
+            borrower_cash_principal_post,
+        )?;
+    let (liquidator_cash_principal_post, liquidator_collateral_last_index_post) =
+        core::effect_of_asset_interest_internal(
+            collateral_asset,
+            liquidator,
+            liquidator_collateral_asset,
+            liquidator_collateral_asset_new,
+            liquidator_cash_principal_post,
+        )?;
+
+    LastIndices::insert(asset.asset, borrower, borrower_last_index_post);
+    LastIndices::insert(asset.asset, liquidator, liquidator_last_index_post);
+    LastIndices::insert(
+        collateral_asset.asset,
+        borrower,
+        borrower_collateral_last_index_post,
+    );
+    LastIndices::insert(
+        collateral_asset.asset,
+        liquidator,
+        liquidator_collateral_last_index_post,
+    );
+    CashPrincipals::insert(borrower, borrower_cash_principal_post);
+    CashPrincipals::insert(liquidator, liquidator_cash_principal_post);
+    TotalSupplyAssets::insert(asset.asset, total_supply_new);
+    TotalBorrowAssets::insert(asset.asset, total_borrow_new);
+    TotalSupplyAssets::insert(collateral_asset.asset, total_collateral_supply_new);
+    TotalBorrowAssets::insert(collateral_asset.asset, total_collateral_borrow_new);
+
+    core::set_asset_balance_internal::<T>(asset.asset, borrower, borrower_asset_new);
+    core::set_asset_balance_internal::<T>(asset.asset, liquidator, liquidator_asset_new);
+    core::set_asset_balance_internal::<T>(
+        collateral_asset.asset,
+        borrower,
+        borrower_collateral_asset_new,
+    );
+    core::set_asset_balance_internal::<T>(
+        collateral_asset.asset,
+        liquidator,
+        liquidator_collateral_asset_new,
+    );
+
+    <Module<T>>::deposit_event(Event::Liquidate(
+        asset.asset,
+        collateral_asset.asset,
+        liquidator,
+        borrower,
+        amount.value,
+    ));
+
+    Ok(())
+}
+
+pub fn liquidate_cash_principal_internal<T: Config>(
+    collateral_asset: AssetInfo,
+    liquidator: ChainAccount,
+    borrower: ChainAccount,
+    principal: CashPrincipalAmount,
+) -> Result<(), Reason> {
+    let index = GlobalCashIndex::get();
+    let amount = index.cash_quantity(principal)?;
+
+    require!(borrower != liquidator, Reason::SelfTransfer);
+    require_min_tx_value!(get_value::<T>(amount)?);
+
+    let liquidation_incentive = Factor::from_nominal("1.08"); // XXX spec first
+    let liquidator_cash_principal = CashPrincipals::get(liquidator);
+    let borrower_cash_principal = CashPrincipals::get(borrower);
+    let liquidator_collateral_asset = AssetBalances::get(collateral_asset.asset, liquidator);
+    let borrower_collateral_asset = AssetBalances::get(collateral_asset.asset, borrower);
+    let seize_amount = amount
+        .mul_factor(liquidation_incentive)?
+        .mul_price(get_price::<T>(CASH)?)?
+        .div_price(
+            get_price::<T>(collateral_asset.units())?,
+            collateral_asset.units(),
+        )?;
+
+    require!(
+        !liquidity::has_non_negative_liquidity::<T>(borrower)?,
+        Reason::SufficientLiquidity
+    );
+    require!(
+        liquidity::has_liquidity_to_reduce_cash_with_added_collateral::<T>(
+            liquidator,
+            amount,
+            collateral_asset,
+            seize_amount,
+        )?,
+        Reason::InsufficientLiquidity
+    );
+
+    let (borrower_repay_principal, _borrower_supply_principal) =
+        repay_and_supply_principal(liquidator_cash_principal, principal)?;
+    let (_liquidator_withdraw_principal, liquidator_borrow_principal) =
+        withdraw_and_borrow_principal(borrower_cash_principal, principal)?;
+    let (borrower_collateral_withdraw_amount, _borrower_collateral_borrow_amount) =
+        withdraw_and_borrow_amount(borrower_collateral_asset, seize_amount)?;
+    let (liquidator_collateral_repay_amount, liquidator_collateral_supply_amount) =
+        repay_and_supply_amount(liquidator_collateral_asset, seize_amount)?;
+
+    let borrower_cash_principal_new = borrower_cash_principal.add_amount(principal)?;
+    let liquidator_cash_principal_new = liquidator_cash_principal.sub_amount(principal)?;
+    let borrower_collateral_asset_new =
+        sub_amount_from_balance(borrower_collateral_asset, seize_amount)?;
+    let liquidator_collateral_asset_new =
+        add_amount_to_balance(liquidator_collateral_asset, seize_amount)?;
+
+    let total_cash_principal_new = sub_principal_amounts(
+        add_principal_amounts(TotalCashPrincipal::get(), liquidator_borrow_principal)?,
+        borrower_repay_principal,
+        Reason::RepayTooMuch,
+    )?;
+    let total_collateral_supply_new = sub_amount_from_raw(
+        add_amount_to_raw(
+            TotalSupplyAssets::get(collateral_asset.asset),
+            liquidator_collateral_supply_amount,
+        )?,
+        borrower_collateral_withdraw_amount,
+        Reason::InsufficientTotalFunds,
+    )?;
+    let total_collateral_borrow_new = sub_amount_from_raw(
+        TotalBorrowAssets::get(collateral_asset.asset),
+        liquidator_collateral_repay_amount,
+        Reason::RepayTooMuch,
+    )?;
+
+    let (borrower_cash_principal_post, borrower_collateral_last_index_post) =
+        core::effect_of_asset_interest_internal(
+            collateral_asset,
+            borrower,
+            borrower_collateral_asset,
+            borrower_collateral_asset_new,
+            borrower_cash_principal_new,
+        )?;
+    let (liquidator_cash_principal_post, liquidator_collateral_last_index_post) =
+        core::effect_of_asset_interest_internal(
+            collateral_asset,
+            liquidator,
+            liquidator_collateral_asset,
+            liquidator_collateral_asset_new,
+            liquidator_cash_principal_new,
+        )?;
+
+    LastIndices::insert(
+        collateral_asset.asset,
+        borrower,
+        borrower_collateral_last_index_post,
+    );
+    LastIndices::insert(
+        collateral_asset.asset,
+        liquidator,
+        liquidator_collateral_last_index_post,
+    );
+    CashPrincipals::insert(borrower, borrower_cash_principal_post);
+    CashPrincipals::insert(liquidator, liquidator_cash_principal_post);
+    TotalCashPrincipal::put(total_cash_principal_new);
+    TotalSupplyAssets::insert(collateral_asset.asset, total_collateral_supply_new);
+    TotalBorrowAssets::insert(collateral_asset.asset, total_collateral_borrow_new);
+
+    core::set_asset_balance_internal::<T>(
+        collateral_asset.asset,
+        borrower,
+        borrower_collateral_asset_new,
+    );
+    core::set_asset_balance_internal::<T>(
+        collateral_asset.asset,
+        liquidator,
+        liquidator_collateral_asset_new,
+    );
+
+    <Module<T>>::deposit_event(Event::LiquidateCash(
+        collateral_asset.asset,
+        liquidator,
+        borrower,
+        principal,
+        index,
+    ));
+
+    Ok(())
+}
+
+pub fn liquidate_cash_collateral_internal<T: Config>(
+    asset: AssetInfo,
+    liquidator: ChainAccount,
+    borrower: ChainAccount,
+    amount: AssetQuantity,
+) -> Result<(), Reason> {
+    let index = GlobalCashIndex::get();
+
+    require!(borrower != liquidator, Reason::SelfTransfer);
+    require_min_tx_value!(get_value::<T>(amount)?);
+
+    let liquidation_incentive = Factor::from_nominal("1.08"); // XXX spec first
+    let liquidator_asset = AssetBalances::get(asset.asset, liquidator);
+    let borrower_asset = AssetBalances::get(asset.asset, borrower);
+    let liquidator_cash_principal = CashPrincipals::get(liquidator);
+    let borrower_cash_principal = CashPrincipals::get(borrower);
+    let seize_amount = amount
+        .mul_factor(liquidation_incentive)?
+        .mul_price(get_price::<T>(asset.units())?)?
+        .div_price(get_price::<T>(CASH)?, CASH)?;
+    let seize_principal = index.cash_principal_amount(seize_amount)?;
+
+    require!(
+        !liquidity::has_non_negative_liquidity::<T>(borrower)?,
+        Reason::SufficientLiquidity
+    );
+    require!(
+        liquidity::has_liquidity_to_reduce_asset_with_added_cash::<T>(
+            liquidator,
+            asset,
+            amount,
+            seize_amount
+        )?,
+        Reason::InsufficientLiquidity
+    );
+
+    let (borrower_repay_amount, _borrower_supply_amount) =
+        repay_and_supply_amount(liquidator_asset, amount)?;
+    let (liquidator_withdraw_amount, liquidator_borrow_amount) =
+        withdraw_and_borrow_amount(borrower_asset, amount)?;
+    let (borrower_collateral_withdraw_principal, _borrower_collateral_borrow_principal) =
+        withdraw_and_borrow_principal(borrower_cash_principal, seize_principal)?;
+    let (liquidator_collateral_repay_principal, _liquidator_collateral_supply_principal) =
+        repay_and_supply_principal(
+            liquidator_cash_principal,
+            borrower_collateral_withdraw_principal,
+        )?;
+
+    let borrower_asset_new = add_amount_to_balance(borrower_asset, amount)?;
+    let liquidator_asset_new = sub_amount_from_balance(liquidator_asset, amount)?;
+    let borrower_cash_principal_new = borrower_cash_principal.sub_amount(seize_principal)?;
+    let liquidator_cash_principal_new = liquidator_cash_principal.add_amount(seize_principal)?;
+
+    let total_supply_new = sub_amount_from_raw(
+        TotalSupplyAssets::get(asset.asset),
+        liquidator_withdraw_amount,
+        Reason::InsufficientTotalFunds,
+    )?;
+    let total_borrow_new = sub_amount_from_raw(
+        add_amount_to_raw(
+            TotalBorrowAssets::get(asset.asset),
+            liquidator_borrow_amount,
+        )?,
+        borrower_repay_amount,
+        Reason::RepayTooMuch,
+    )?;
+    let total_cash_principal_new = sub_principal_amounts(
+        TotalCashPrincipal::get(),
+        liquidator_collateral_repay_principal,
+        Reason::RepayTooMuch,
+    )?;
+
+    let (borrower_cash_principal_post, borrower_last_index_post) =
+        core::effect_of_asset_interest_internal(
+            asset,
+            borrower,
+            borrower_asset,
+            borrower_asset_new,
+            borrower_cash_principal_new,
+        )?;
+    let (liquidator_cash_principal_post, liquidator_last_index_post) =
+        core::effect_of_asset_interest_internal(
+            asset,
+            liquidator,
+            liquidator_asset,
+            liquidator_asset_new,
+            liquidator_cash_principal_new,
+        )?;
+
+    LastIndices::insert(asset.asset, borrower, borrower_last_index_post);
+    LastIndices::insert(asset.asset, liquidator, liquidator_last_index_post);
+    CashPrincipals::insert(borrower, borrower_cash_principal_post);
+    CashPrincipals::insert(liquidator, liquidator_cash_principal_post);
+    TotalSupplyAssets::insert(asset.asset, total_supply_new);
+    TotalBorrowAssets::insert(asset.asset, total_borrow_new);
+    TotalCashPrincipal::put(total_cash_principal_new);
+
+    core::set_asset_balance_internal::<T>(asset.asset, borrower, borrower_asset_new);
+    core::set_asset_balance_internal::<T>(asset.asset, liquidator, liquidator_asset_new);
+
+    <Module<T>>::deposit_event(Event::LiquidateCashCollateral(
+        asset.asset,
+        liquidator,
+        borrower,
+        amount.value,
+    ));
+
+    Ok(())
+}

--- a/pallets/cash/src/internal/lock.rs
+++ b/pallets/cash/src/internal/lock.rs
@@ -4,7 +4,7 @@ use frame_support::storage::{StorageMap, StorageValue};
 // Import these traits so we can interact with the substrate storage modules.
 use crate::{
     chains::ChainAccount,
-    core::{repay_and_supply_principal, sub_principal_amounts},
+    internal::balance_helpers::{repay_and_supply_principal, sub_principal_amounts},
     reason::Reason,
     types::{CashIndex, CashPrincipalAmount},
     CashPrincipals, ChainCashPrincipals, Config, Event, GlobalCashIndex, Module,
@@ -18,7 +18,7 @@ pub fn lock_cash_principal_internal<T: Config>(
 ) -> Result<(), Reason> {
     let holder_cash_principal = CashPrincipals::get(holder);
     let (holder_repay_principal, _holder_supply_principal) =
-        repay_and_supply_principal(holder_cash_principal, principal);
+        repay_and_supply_principal(holder_cash_principal, principal)?;
 
     let chain_id = holder.chain_id();
     let chain_cash_principal_new = sub_principal_amounts(

--- a/pallets/cash/src/internal/mod.rs
+++ b/pallets/cash/src/internal/mod.rs
@@ -1,7 +1,9 @@
 pub mod assets;
+pub mod balance_helpers;
 pub mod change_validators;
 pub mod events;
 pub mod exec_trx_request;
+pub mod liquidate;
 pub mod liquidity;
 pub mod lock;
 pub mod miner;

--- a/pallets/cash/src/tests/assets.rs
+++ b/pallets/cash/src/tests/assets.rs
@@ -1,4 +1,4 @@
-use crate::tests::*;
+use crate::{symbol::USD, tests::*};
 
 pub const ETH: Units = Units::from_ticker_str("ETH", 18);
 pub const Eth: ChainAsset = ChainAsset::Eth(hex!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"));
@@ -52,4 +52,21 @@ pub const wbtc: AssetInfo = AssetInfo {
     supply_cap: Quantity::from_nominal("1000", WBTC).value,
     symbol: Symbol(WBTC.ticker.0),
     ticker: Ticker(WBTC.ticker.0),
+};
+
+pub const _Usdc: ChainAsset = ChainAsset::Eth(hex!("cccccccccccccccccccccccccccccccccccccccc"));
+pub const _usdc: AssetInfo = AssetInfo {
+    asset: Usdc,
+    decimals: USD.decimals,
+    liquidity_factor: LiquidityFactor::from_nominal("0.9"),
+    rate_model: InterestRateModel::Kink {
+        zero_rate: APR(0),
+        kink_rate: APR(500),
+        kink_utilization: Factor::from_nominal("0.8"),
+        full_rate: APR(2000),
+    },
+    miner_shares: Factor::from_nominal("0.05"),
+    supply_cap: Quantity::from_nominal("1000", USD).value,
+    symbol: Symbol(USD.ticker.0),
+    ticker: Ticker(USD.ticker.0),
 };


### PR DESCRIPTION
This patch starts to factor out `liquidate.rs` and `balance_helpers.rs` to their own modules in `internal/`. We significantly increase the test coverage for these functions, finding a few minor cases that could have otherwise panic'd. We thus return `results` here for these functions.

I intend to add unit tests to `liquidate.rs`, but I needed the helper functions to be shared first, which was completed in the current patch.