### PR TITLE
Limit Liqudations by Spec

### DIFF
--- a/pallets/cash/src/core.rs
+++ b/pallets/cash/src/core.rs
@@ -57,6 +57,17 @@ macro_rules! require {
 }
 
 #[macro_export]
+macro_rules! must {
+    ($expr:expr, $reason:expr) => {
+        if !$expr {
+            core::result::Result::Err($reason)
+        } else {
+            core::result::Result::Ok(())
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! require_min_tx_value {
     ($value:expr) => {
         require!($value >= MIN_TX_VALUE, Reason::MinTxValueNotMet);

--- a/pallets/cash/src/internal/liquidate.rs
+++ b/pallets/cash/src/internal/liquidate.rs
@@ -19,33 +19,44 @@ use crate::{
     pipeline::CashPipeline,
     reason::Reason,
     require, require_min_tx_value,
-    types::{AssetInfo, AssetQuantity, CashPrincipalAmount, CASH},
+    symbol::Units,
+    types::{AssetInfo, AssetQuantity, CashPrincipalAmount, Quantity, CASH},
     Config, Event, GlobalCashIndex, Module, TotalBorrowAssets, TotalSupplyAssets,
 };
+
+fn calculate_seize_quantity<T: Config>(
+    quantity: AssetQuantity,
+    collateral_units: Units,
+) -> Result<Quantity, Reason> {
+    let liquidation_incentive = Factor::from_nominal("1.08"); // XXX spec first
+    let asset_price = get_price::<T>(quantity.units)?;
+    let collateral_price = get_price::<T>(collateral_units)?;
+
+    if asset_price.value == 0 || collateral_price.value == 0 {
+        Err(Reason::NoPrice)?
+    }
+
+    Ok(quantity
+        .mul_factor(liquidation_incentive)?
+        .mul_price(asset_price)?
+        .div_price(collateral_price, collateral_units)?)
+}
 
 pub fn liquidate_internal<T: Config>(
     asset: AssetInfo,
     collateral_asset: AssetInfo,
     liquidator: ChainAccount,
     borrower: ChainAccount,
-    amount: AssetQuantity,
+    quantity: AssetQuantity,
 ) -> Result<(), Reason> {
-    require!(asset != collateral_asset, Reason::InKindLiquidation); // Note: this doesn't make sense with signed balances
-    require_min_tx_value!(get_value::<T>(amount)?);
-
-    let liquidation_incentive = Factor::from_nominal("1.08"); // XXX spec first
-    let seize_amount = amount
-        .mul_factor(liquidation_incentive)?
-        .mul_price(get_price::<T>(asset.units())?)?
-        .div_price(
-            get_price::<T>(collateral_asset.units())?,
-            collateral_asset.units(),
-        )?;
+    require!(asset != collateral_asset, Reason::InKindLiquidation);
+    require_min_tx_value!(get_value::<T>(quantity)?);
+    let seize_quantity = calculate_seize_quantity::<T>(quantity, collateral_asset.units())?;
 
     CashPipeline::new()
         .check_underwater::<T>(borrower)?
-        .transfer_asset::<T>(liquidator, borrower, asset.asset, amount)?
-        .transfer_asset::<T>(borrower, liquidator, collateral_asset.asset, seize_amount)?
+        .transfer_asset::<T>(liquidator, borrower, asset.asset, quantity)?
+        .transfer_asset::<T>(borrower, liquidator, collateral_asset.asset, seize_quantity)?
         .check_asset_balance::<T, _>(borrower, asset, |asset_balance| {
             must!(asset_balance.lte(0), Reason::RepayTooMuch)
         })?
@@ -60,7 +71,7 @@ pub fn liquidate_internal<T: Config>(
         collateral_asset.asset,
         liquidator,
         borrower,
-        amount.value,
+        quantity.value,
     ));
 
     Ok(())
@@ -73,23 +84,15 @@ pub fn liquidate_cash_principal_internal<T: Config>(
     principal: CashPrincipalAmount,
 ) -> Result<(), Reason> {
     let index = GlobalCashIndex::get();
-    let amount = index.cash_quantity(principal)?;
+    let quantity = index.cash_quantity(principal)?;
 
-    require_min_tx_value!(get_value::<T>(amount)?);
-
-    let liquidation_incentive = Factor::from_nominal("1.08"); // XXX spec first
-    let seize_amount = amount
-        .mul_factor(liquidation_incentive)?
-        .mul_price(get_price::<T>(CASH)?)?
-        .div_price(
-            get_price::<T>(collateral_asset.units())?,
-            collateral_asset.units(),
-        )?;
+    require_min_tx_value!(get_value::<T>(quantity)?);
+    let seize_quantity = calculate_seize_quantity::<T>(quantity, collateral_asset.units())?;
 
     CashPipeline::new()
         .check_underwater::<T>(borrower)?
         .transfer_cash::<T>(liquidator, borrower, principal)?
-        .transfer_asset::<T>(borrower, liquidator, collateral_asset.asset, seize_amount)?
+        .transfer_asset::<T>(borrower, liquidator, collateral_asset.asset, seize_quantity)?
         .check_cash_principal::<T, _>(borrower, |cash_principal| {
             must!(cash_principal.lte(0), Reason::RepayTooMuch)
         })?
@@ -114,22 +117,17 @@ pub fn liquidate_cash_collateral_internal<T: Config>(
     asset: AssetInfo,
     liquidator: ChainAccount,
     borrower: ChainAccount,
-    amount: AssetQuantity,
+    quantity: AssetQuantity,
 ) -> Result<(), Reason> {
     let index = GlobalCashIndex::get();
 
-    require_min_tx_value!(get_value::<T>(amount)?);
-
-    let liquidation_incentive = Factor::from_nominal("1.08"); // XXX spec first
-    let seize_amount = amount
-        .mul_factor(liquidation_incentive)?
-        .mul_price(get_price::<T>(asset.units())?)?
-        .div_price(get_price::<T>(CASH)?, CASH)?;
-    let seize_principal = index.cash_principal_amount(seize_amount)?;
+    require_min_tx_value!(get_value::<T>(quantity)?);
+    let seize_quantity = calculate_seize_quantity::<T>(quantity, CASH)?;
+    let seize_principal = index.cash_principal_amount(seize_quantity)?;
 
     CashPipeline::new()
         .check_underwater::<T>(borrower)?
-        .transfer_asset::<T>(liquidator, borrower, asset.asset, amount)?
+        .transfer_asset::<T>(liquidator, borrower, asset.asset, quantity)?
         .transfer_cash::<T>(borrower, liquidator, seize_principal)?
         .check_asset_balance::<T, _>(borrower, asset, |asset_balance| {
             must!(asset_balance.lte(0), Reason::RepayTooMuch)
@@ -144,7 +142,7 @@ pub fn liquidate_cash_collateral_internal<T: Config>(
         asset.asset,
         liquidator,
         borrower,
-        amount.value,
+        quantity.value,
     ));
 
     Ok(())
@@ -154,9 +152,9 @@ pub fn liquidate_cash_collateral_internal<T: Config>(
 mod tests {
     use super::*;
     use crate::{
-        chains::*,
-        tests::{assets::*, common::*, mock::*},
+        tests::{assert_ok, assets::*, common::*, mock::*},
         types::*,
+        *,
     };
     use pallet_oracle::types::Price;
 
@@ -168,6 +166,165 @@ mod tests {
     const liquidator: ChainAccount = ChainAccount::Eth([1u8; 20]);
     #[allow(non_upper_case_globals)]
     const borrower: ChainAccount = ChainAccount::Eth([2u8; 20]);
+
+    #[test]
+    fn test_calculate_seize_quantity_no_asset_price() {
+        new_test_ext().execute_with(|| {
+            let quantity: AssetQuantity = eth.as_quantity_nominal("1");
+
+            init_wbtc_asset().unwrap();
+
+            assert_eq!(
+                calculate_seize_quantity::<Test>(quantity, WBTC),
+                Err(Reason::NoPrice)
+            );
+        })
+    }
+
+    #[test]
+    fn test_calculate_seize_quantity_no_collateral_asset_price() {
+        new_test_ext().execute_with(|| {
+            let quantity: AssetQuantity = eth.as_quantity_nominal("1");
+
+            init_eth_asset().unwrap();
+
+            assert_eq!(
+                calculate_seize_quantity::<Test>(quantity, WBTC),
+                Err(Reason::NoPrice)
+            );
+        })
+    }
+
+    #[test]
+    fn test_calculate_seize_quantity_overflow_incentive() {
+        new_test_ext().execute_with(|| {
+            let quantity: AssetQuantity = Quantity {
+                value: u128::MAX,
+                units: ETH,
+            };
+
+            init_eth_asset().unwrap();
+            init_wbtc_asset().unwrap();
+
+            assert_eq!(
+                calculate_seize_quantity::<Test>(quantity, WBTC),
+                Err(Reason::MathError(MathError::Overflow))
+            );
+        })
+    }
+
+    #[test]
+    fn test_calculate_seize_quantity_overflow_price() {
+        new_test_ext().execute_with(|| {
+            let quantity: AssetQuantity = Quantity {
+                value: u128::MAX / 10,
+                units: ETH,
+            };
+
+            init_eth_asset().unwrap();
+            init_wbtc_asset().unwrap();
+
+            assert_eq!(
+                calculate_seize_quantity::<Test>(quantity, WBTC),
+                Err(Reason::MathError(MathError::Overflow))
+            );
+        })
+    }
+
+    #[test]
+    fn test_calculate_seize_quantity_zero_asset_price() {
+        new_test_ext().execute_with(|| {
+            let quantity: AssetQuantity = eth.as_quantity_nominal("1");
+
+            init_eth_asset().unwrap();
+            init_wbtc_asset().unwrap();
+            pallet_oracle::Prices::insert(ETH.ticker, Price::from_nominal(ETH.ticker, "0").value);
+
+            assert_eq!(
+                calculate_seize_quantity::<Test>(quantity, WBTC),
+                Err(Reason::NoPrice)
+            );
+        })
+    }
+
+    #[test]
+    fn test_calculate_seize_quantity_zero_price() {
+        new_test_ext().execute_with(|| {
+            let quantity: AssetQuantity = eth.as_quantity_nominal("1");
+
+            init_eth_asset().unwrap();
+            init_wbtc_asset().unwrap();
+            pallet_oracle::Prices::insert(WBTC.ticker, Price::from_nominal(WBTC.ticker, "0").value);
+
+            assert_eq!(
+                calculate_seize_quantity::<Test>(quantity, WBTC),
+                Err(Reason::NoPrice)
+            );
+        })
+    }
+
+    #[test]
+    fn test_calculate_seize_quantity_ok() {
+        new_test_ext().execute_with(|| {
+            let quantity: AssetQuantity = eth.as_quantity_nominal("1");
+
+            init_eth_asset().unwrap();
+            init_wbtc_asset().unwrap();
+            pallet_oracle::Prices::insert(
+                ETH.ticker,
+                Price::from_nominal(ETH.ticker, "2000").value,
+            );
+            pallet_oracle::Prices::insert(
+                WBTC.ticker,
+                Price::from_nominal(WBTC.ticker, "60000").value,
+            );
+
+            assert_eq!(
+                calculate_seize_quantity::<Test>(quantity, WBTC),
+                Ok(Quantity {
+                    value: 3600000, // 1.08 * 1 * 2000 / 60000 = 0.036e8
+                    units: WBTC
+                })
+            );
+
+            pallet_oracle::Prices::insert(
+                WBTC.ticker,
+                Price::from_nominal(WBTC.ticker, "50000").value,
+            );
+
+            assert_eq!(
+                calculate_seize_quantity::<Test>(quantity, WBTC),
+                Ok(Quantity {
+                    value: 4320000, // 1.08 * 1 * 2000 / 50000 = 0.0432e8
+                    units: WBTC
+                })
+            );
+
+            assert_eq!(
+                calculate_seize_quantity::<Test>(quantity, CASH),
+                Ok(Quantity {
+                    value: 2160000000, // 1.08 * 1 * 2000 / 1 = 2160e6
+                    units: CASH
+                })
+            );
+
+            assert_eq!(
+                calculate_seize_quantity::<Test>(
+                    Quantity {
+                        value: 1000000000,
+                        units: CASH
+                    },
+                    ETH
+                ),
+                Ok(Quantity {
+                    value: 540000000000000000, // 1.08 * 1 * 1000 / 2000 = 0.54e18
+                    units: ETH
+                })
+            );
+        })
+    }
+
+    // liquidate_internal
 
     #[test]
     fn test_liquidate_internal_self_liquidate() {
@@ -253,34 +410,6 @@ mod tests {
     }
 
     #[test]
-    fn test_liquidate_internal_no_asset_price() {
-        new_test_ext().execute_with(|| {
-            let amount: AssetQuantity = eth.as_quantity_nominal("1");
-
-            init_wbtc_asset().unwrap();
-
-            assert_eq!(
-                liquidate_internal::<Test>(asset, collateral_asset, liquidator, borrower, amount),
-                Err(Reason::NoPrice)
-            );
-        })
-    }
-
-    #[test]
-    fn test_liquidate_internal_no_collateral_asset_price() {
-        new_test_ext().execute_with(|| {
-            let amount: AssetQuantity = eth.as_quantity_nominal("1");
-
-            init_eth_asset().unwrap();
-
-            assert_eq!(
-                liquidate_internal::<Test>(asset, collateral_asset, liquidator, borrower, amount),
-                Err(Reason::NoPrice)
-            );
-        })
-    }
-
-    #[test]
     fn test_liquidate_internal_not_supported() {
         new_test_ext().execute_with(|| {
             let amount: AssetQuantity = eth.as_quantity_nominal("1");
@@ -356,7 +485,7 @@ mod tests {
 
             assert_eq!(
                 liquidate_internal::<Test>(asset, collateral_asset, liquidator, borrower, amount),
-                Err(Reason::MathError(MathError::DivisionByZero))
+                Err(Reason::NoPrice)
             );
         })
     }
@@ -373,6 +502,8 @@ mod tests {
             init_asset_balance(Wbtc, borrower, Balance::from_nominal("-1", WBTC).value); // 1 * 60000 / 0.6 = -100000
             init_cash(borrower, CashPrincipal::from_nominal("97000")); // 97000 + 4800 - 1000000 = 1800
 
+            // Seize amount = 1.08 * 1 * 2000 / 60000 = 0.036e8
+
             assert_eq!(
                 liquidate_internal::<Test>(asset, collateral_asset, liquidator, borrower, amount),
                 Err(Reason::SufficientLiquidity)
@@ -388,9 +519,9 @@ mod tests {
             init_eth_asset().unwrap();
             init_wbtc_asset().unwrap();
 
-            init_asset_balance(Eth, borrower, Balance::from_nominal("3", ETH).value); // 3 * 2000 * 0.8 = 4800
-            init_asset_balance(Wbtc, borrower, Balance::from_nominal("-1", WBTC).value); // 1 * 60000 / 0.6 = -100000
-            init_cash(borrower, CashPrincipal::from_nominal("95000")); // 95000 + 4800 - 1000000 = -200
+            init_asset_balance(Eth, borrower, Balance::from_nominal("-80", ETH).value); // -80 * 2000 / 0.8 = -200000
+            init_asset_balance(Wbtc, borrower, Balance::from_nominal("2", WBTC).value); // 2 * 60000 * 0.6 = 72000
+            init_cash(borrower, CashPrincipal::from_nominal("100000")); // 100000 + 72000 - 200000 = -28000
 
             assert_eq!(
                 liquidate_internal::<Test>(asset, collateral_asset, liquidator, borrower, amount),
@@ -400,169 +531,872 @@ mod tests {
     }
 
     #[test]
-    fn test_liquidate_internal_borrower_asset_overflow() {
+    fn test_liquidate_internal_repay_too_much() {
+        new_test_ext().execute_with(|| {
+            let amount: AssetQuantity = eth.as_quantity_nominal("90");
+
+            init_eth_asset().unwrap();
+            init_wbtc_asset().unwrap();
+
+            init_asset_balance(Eth, borrower, Balance::from_nominal("-80", ETH).value); // -80 * 2000 / 0.8 = -200000
+            init_asset_balance(Wbtc, borrower, Balance::from_nominal("2", WBTC).value); // 2 * 60000 * 0.6 = 72000
+            init_cash(borrower, CashPrincipal::from_nominal("100000")); // 100000 + 72000 - 200000 = -28000
+
+            init_cash(liquidator, CashPrincipal::from_nominal("100000"));
+
+            assert_eq!(
+                liquidate_internal::<Test>(asset, collateral_asset, liquidator, borrower, amount),
+                Err(Reason::RepayTooMuch)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_internal_repay_too_much_zero_balance_asset() {
+        new_test_ext().execute_with(|| {
+            let amount: AssetQuantity = uni.as_quantity_nominal("100");
+
+            init_uni_asset().unwrap();
+            init_eth_asset().unwrap();
+            init_wbtc_asset().unwrap();
+
+            init_asset_balance(Eth, borrower, Balance::from_nominal("-80", ETH).value); // -80 * 2000 / 0.8 = -200000
+            init_asset_balance(Wbtc, borrower, Balance::from_nominal("2", WBTC).value); // 2 * 60000 * 0.6 = 72000
+            init_cash(borrower, CashPrincipal::from_nominal("100000")); // 100000 + 72000 - 200000 = -28000
+
+            init_cash(liquidator, CashPrincipal::from_nominal("100000"));
+
+            assert_eq!(
+                liquidate_internal::<Test>(uni, collateral_asset, liquidator, borrower, amount),
+                Err(Reason::RepayTooMuch)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_internal_repay_too_much_positive_balance_asset() {
+        new_test_ext().execute_with(|| {
+            let amount: AssetQuantity = uni.as_quantity_nominal("100");
+
+            init_uni_asset().unwrap();
+            init_eth_asset().unwrap();
+            init_wbtc_asset().unwrap();
+
+            init_asset_balance(Uni, borrower, Balance::from_nominal("100", UNI).value);
+            init_asset_balance(Eth, borrower, Balance::from_nominal("-8000", ETH).value);
+            init_asset_balance(Wbtc, borrower, Balance::from_nominal("2", WBTC).value);
+
+            init_cash(liquidator, CashPrincipal::from_nominal("100000"));
+
+            assert_eq!(
+                liquidate_internal::<Test>(uni, collateral_asset, liquidator, borrower, amount),
+                Err(Reason::RepayTooMuch)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_internal_insufficient_collateral() {
         new_test_ext().execute_with(|| {
             let amount: AssetQuantity = eth.as_quantity_nominal("1");
 
             init_eth_asset().unwrap();
             init_wbtc_asset().unwrap();
 
-            init_asset_balance(Eth, borrower, i128::MAX);
-            init_asset_balance(Wbtc, borrower, i128::MIN + 1);
+            init_asset_balance(Eth, borrower, Balance::from_nominal("-80", ETH).value); // -80 * 2000 / 0.8 = -200000
+            init_cash(borrower, CashPrincipal::from_nominal("100000")); // 100000 + 200000 = -100000
 
-            init_cash(liquidator, CashPrincipal::from_nominal("1000000"));
+            init_cash(liquidator, CashPrincipal::from_nominal("100000"));
 
-            // I'm not entirely sure this is caused by the line I want,
-            // but it might be!
             assert_eq!(
                 liquidate_internal::<Test>(asset, collateral_asset, liquidator, borrower, amount),
+                Err(Reason::InsufficientCollateral)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_internal_insufficient_collateral_partial() {
+        new_test_ext().execute_with(|| {
+            let amount: AssetQuantity = eth.as_quantity_nominal("10");
+
+            init_eth_asset().unwrap();
+            init_wbtc_asset().unwrap();
+
+            init_asset_balance(Eth, borrower, Balance::from_nominal("-80", ETH).value); // -80 * 2000 / 0.8 = -200000
+            init_asset_balance(Wbtc, borrower, Balance::from_nominal("0.01", WBTC).value); // 2 * 60000 * 0.6 = 72000
+            init_cash(borrower, CashPrincipal::from_nominal("100000")); // 100000 + 200000 = -100000
+
+            init_cash(liquidator, CashPrincipal::from_nominal("100000"));
+
+            assert_eq!(
+                liquidate_internal::<Test>(asset, collateral_asset, liquidator, borrower, amount),
+                Err(Reason::InsufficientCollateral)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_internal_ok() {
+        new_test_ext().execute_with(|| {
+            let amount: AssetQuantity = eth.as_quantity_nominal("1");
+
+            init_eth_asset().unwrap();
+            init_wbtc_asset().unwrap();
+
+            init_asset_balance(Eth, borrower, Balance::from_nominal("-80", ETH).value); // -80 * 2000 / 0.8 = -200000
+            init_asset_balance(Wbtc, borrower, Balance::from_nominal("2", WBTC).value); // 2 * 60000 * 0.6 = 72000
+            init_cash(borrower, CashPrincipal::from_nominal("100000")); // 100000 + 72000 - 200000 = -28000
+
+            // Seize amount = 1.08 * 1 * 2000 / 60000 = 0.036 WBTC
+
+            init_asset_balance(Wbtc, liquidator, Balance::from_nominal("1", WBTC).value);
+            init_asset_balance(Eth, liquidator, Balance::from_nominal("0.5", ETH).value);
+            init_cash(liquidator, CashPrincipal::from_nominal("100000"));
+
+            assert_ok!(liquidate_internal::<Test>(
+                asset,
+                collateral_asset,
+                liquidator,
+                borrower,
+                amount
+            ));
+
+            assert_eq!(
+                TotalSupplyAssets::get(Eth),
+                Quantity::from_nominal("0", ETH).value
+            ); // All supply was closed
+            assert_eq!(
+                TotalBorrowAssets::get(Eth),
+                Quantity::from_nominal("79.5", ETH).value
+            ); // Part of liquidation was borrowed, part came from supply
+            assert_eq!(
+                TotalSupplyAssets::get(Wbtc),
+                Quantity::from_nominal("3", WBTC).value
+            );
+            assert_eq!(
+                TotalBorrowAssets::get(Wbtc),
+                Quantity::from_nominal("0", WBTC).value
+            );
+            assert_eq!(
+                AssetBalances::get(Eth, borrower),
+                Balance::from_nominal("-79", ETH).value
+            );
+            assert_eq!(
+                AssetBalances::get(Eth, liquidator),
+                Balance::from_nominal("-0.5", ETH).value
+            );
+            assert_eq!(
+                AssetBalances::get(Wbtc, borrower),
+                Balance::from_nominal("1.964", WBTC).value
+            );
+            assert_eq!(
+                AssetBalances::get(Wbtc, liquidator),
+                Balance::from_nominal("1.036", WBTC).value
+            );
+            assert_eq!(
+                AssetsWithNonZeroBalance::iter_prefix(borrower).collect::<Vec<_>>(),
+                vec![(Eth, ()), (Wbtc, ())]
+            );
+            assert_eq!(
+                AssetsWithNonZeroBalance::iter_prefix(liquidator).collect::<Vec<_>>(),
+                vec![(Eth, ()), (Wbtc, ())]
+            );
+            assert_eq!(
+                LastIndices::get(Eth, borrower),
+                AssetIndex::from_nominal("0")
+            );
+            assert_eq!(
+                LastIndices::get(Eth, liquidator),
+                AssetIndex::from_nominal("0")
+            );
+            assert_eq!(
+                LastIndices::get(Wbtc, borrower),
+                AssetIndex::from_nominal("0")
+            );
+            assert_eq!(
+                LastIndices::get(Wbtc, liquidator),
+                AssetIndex::from_nominal("0")
+            );
+            assert_eq!(
+                CashPrincipals::get(borrower),
+                CashPrincipal::from_nominal("100000")
+            );
+            assert_eq!(
+                CashPrincipals::get(liquidator),
+                CashPrincipal::from_nominal("100000")
+            );
+            assert_eq!(
+                TotalCashPrincipal::get(),
+                CashPrincipalAmount::from_nominal("200000")
+            );
+        })
+    }
+
+    // liquidate_cash_principal
+
+    #[test]
+    fn test_liquidate_cash_principal_internal_self_liquidate() {
+        new_test_ext().execute_with(|| {
+            init_eth_asset().unwrap();
+            let principal: CashPrincipalAmount = CashPrincipalAmount::from_nominal("100");
+
+            init_eth_asset().unwrap();
+            init_wbtc_asset().unwrap();
+
+            init_asset_balance(Wbtc, borrower, Balance::from_nominal("-1", WBTC).value); // 1 * 60000 / 0.6 = -100000
+
+            assert_eq!(
+                liquidate_cash_principal_internal::<Test>(
+                    collateral_asset,
+                    borrower,
+                    borrower,
+                    principal
+                ),
+                Err(Reason::SelfTransfer)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_cash_principal_internal_too_small() {
+        new_test_ext().execute_with(|| {
+            let principal: CashPrincipalAmount = CashPrincipalAmount::from_nominal("0.99");
+
+            init_wbtc_asset().unwrap();
+
+            assert_eq!(
+                liquidate_cash_principal_internal::<Test>(
+                    collateral_asset,
+                    liquidator,
+                    borrower,
+                    principal
+                ),
+                Err(Reason::MinTxValueNotMet)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_cash_principal_internal_too_large() {
+        new_test_ext().execute_with(|| {
+            let principal: CashPrincipalAmount = CashPrincipalAmount(u128::MAX);
+
+            init_wbtc_asset().unwrap();
+
+            assert_eq!(
+                liquidate_cash_principal_internal::<Test>(
+                    collateral_asset,
+                    liquidator,
+                    borrower,
+                    principal
+                ),
                 Err(Reason::MathError(MathError::Overflow))
             );
         })
     }
 
-    // #[test]
-    // fn test_liquidate_internal_liquidator_asset_underflow() {
-    //     new_test_ext().execute_with(|| {
-    //         // let amount: AssetQuantity = Quantity {
-    //         //     value: 2500,
-    //         //     units: ETH,
-    //         // };
-    //         let amount: AssetQuantity = eth.as_quantity_nominal("1");
-
-    //         pallet_oracle::Prices::insert(ETH.ticker, 1);
-
-    //         init_eth_asset().unwrap();
-    //         init_wbtc_asset().unwrap();
-
-    //         init_asset_balance(Eth, borrower, Balance::from_nominal("3", ETH).value); // 3 * 2000 * 0.8 = 4800
-    //         init_asset_balance(Wbtc, borrower, Balance::from_nominal("-1", WBTC).value); // 1 * 60000 / 0.6 = -100000
-    //         init_cash(borrower, CashPrincipal::from_nominal("95000")); // 95000 + 4800 - 1000000 = -200
-
-    //         init_asset_balance(Eth, borrower, i128::MIN / 100000);
-    //         init_cash(liquidator, CashPrincipal::from_nominal("1000000"));
-
-    //         // I'm not entirely sure this is caused by the line I want,
-    //         // but it might be!
-    //         assert_eq!(
-    //             liquidate_internal::<Test>(asset, collateral_asset, liquidator, borrower, amount),
-    //             Err(Reason::MathError(MathError::Overflow))
-    //         );
-    //     })
-    // }
-
+    // The hope on this test is to hit the overflow on mul'ing by price,
+    // not on mul'ing by the liquidation incentive (1.08).
     #[test]
-    fn test_liquidate_internal_total_supply_underflow() {
-        /* The underwater user has -3 Eth the liquidator has 3 Eth, but the protocol magically
-           has zero total supplied Eth. The liquidation causes a net-loss of Eth and thus underflows.
-           This scenario cannot happen in normal conditions due to the set-up
-        */
+    fn test_liquidate_cash_principal_internal_too_large_with_price() {
         new_test_ext().execute_with(|| {
-            let amount: AssetQuantity = eth.as_quantity_nominal("1");
+            let principal: CashPrincipalAmount = CashPrincipalAmount(u128::MAX / 10 * 9);
 
-            init_eth_asset().unwrap();
             init_wbtc_asset().unwrap();
 
-            init_asset_balance(Eth, borrower, Balance::from_nominal("-3", ETH).value);
-            init_asset_balance(Wbtc, borrower, Balance::from_nominal("-1", WBTC).value);
-
-            init_cash(liquidator, CashPrincipal::from_nominal("1000000"));
-
-            init_asset_balance(Eth, liquidator, Balance::from_nominal("3", ETH).value);
-            TotalSupplyAssets::insert(asset.asset, 0);
-
             assert_eq!(
-                liquidate_internal::<Test>(asset, collateral_asset, liquidator, borrower, amount),
-                Err(Reason::InsufficientTotalFunds)
+                liquidate_cash_principal_internal::<Test>(
+                    collateral_asset,
+                    liquidator,
+                    borrower,
+                    principal
+                ),
+                Err(Reason::MathError(MathError::Overflow))
             );
         })
     }
 
     #[test]
-    fn test_liquidate_internal_total_borrow_assets_overflow() {
+    fn test_liquidate_cash_principal_internal_not_supported_collateral() {
         new_test_ext().execute_with(|| {
-            let amount: AssetQuantity = eth.as_quantity_nominal("1");
+            let principal: CashPrincipalAmount = CashPrincipalAmount::from_nominal("100");
+
+            pallet_oracle::Prices::insert(
+                WBTC.ticker,
+                Price::from_nominal(WBTC.ticker, "60000.00").value,
+            );
+            init_asset_balance(Wbtc, borrower, Balance::from_nominal("-1", WBTC).value); // 1 * 60000 / 0.6 = -100000
+
+            assert_eq!(
+                liquidate_cash_principal_internal::<Test>(
+                    collateral_asset,
+                    liquidator,
+                    borrower,
+                    principal
+                ),
+                Err(Reason::AssetNotSupported)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_cash_principal_internal_collateral_asset_price_zero() {
+        new_test_ext().execute_with(|| {
+            let principal: CashPrincipalAmount = CashPrincipalAmount::from_nominal("100");
+
+            init_wbtc_asset().unwrap();
+
+            pallet_oracle::Prices::insert(WBTC.ticker, Price::from_nominal(WBTC.ticker, "0").value);
+
+            assert_eq!(
+                liquidate_cash_principal_internal::<Test>(
+                    collateral_asset,
+                    liquidator,
+                    borrower,
+                    principal
+                ),
+                Err(Reason::NoPrice)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_cash_principal_internal_sufficient_liquidity() {
+        new_test_ext().execute_with(|| {
+            let principal: CashPrincipalAmount = CashPrincipalAmount::from_nominal("100");
 
             init_eth_asset().unwrap();
             init_wbtc_asset().unwrap();
 
             init_asset_balance(Eth, borrower, Balance::from_nominal("3", ETH).value); // 3 * 2000 * 0.8 = 4800
             init_asset_balance(Wbtc, borrower, Balance::from_nominal("-1", WBTC).value); // 1 * 60000 / 0.6 = -100000
-            init_cash(borrower, CashPrincipal::from_nominal("95000")); // 95000 + 4800 - 1000000 = -200
-
-            init_cash(liquidator, CashPrincipal::from_nominal("1000000"));
-
-            TotalBorrowAssets::insert(asset.asset, u128::MAX);
+            init_cash(borrower, CashPrincipal::from_nominal("97000")); // 97000 + 4800 - 1000000 = 1800
 
             assert_eq!(
-                liquidate_internal::<Test>(asset, collateral_asset, liquidator, borrower, amount),
+                liquidate_cash_principal_internal::<Test>(
+                    collateral_asset,
+                    liquidator,
+                    borrower,
+                    principal
+                ),
+                Err(Reason::SufficientLiquidity)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_cash_principal_internal_insufficient_liquidity() {
+        new_test_ext().execute_with(|| {
+            let principal: CashPrincipalAmount = CashPrincipalAmount::from_nominal("100");
+
+            init_eth_asset().unwrap();
+            init_wbtc_asset().unwrap();
+
+            init_asset_balance(Eth, borrower, Balance::from_nominal("80", ETH).value); // 80 * 2000 / 0.8 = 200000
+            init_asset_balance(Wbtc, borrower, Balance::from_nominal("2", WBTC).value); // 2 * 60000 * 0.6 = 72000
+            init_cash(borrower, CashPrincipal::from_nominal("-300000")); // -300000 + 72000 + 200000 = -28000
+
+            assert_eq!(
+                liquidate_cash_principal_internal::<Test>(
+                    collateral_asset,
+                    liquidator,
+                    borrower,
+                    principal
+                ),
+                Err(Reason::InsufficientLiquidity)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_cash_principal_internal_repay_too_much() {
+        new_test_ext().execute_with(|| {
+            let principal: CashPrincipalAmount = CashPrincipalAmount::from_nominal("350000");
+
+            init_eth_asset().unwrap();
+            init_wbtc_asset().unwrap();
+
+            init_asset_balance(Eth, borrower, Balance::from_nominal("80", ETH).value); // 80 * 2000 / 0.8 = 200000
+            init_asset_balance(Wbtc, borrower, Balance::from_nominal("2", WBTC).value); // 2 * 60000 * 0.6 = 72000
+            init_cash(borrower, CashPrincipal::from_nominal("-300000")); // -300000 + 72000 + 200000 = -28000
+
+            init_cash(liquidator, CashPrincipal::from_nominal("400000"));
+
+            assert_eq!(
+                liquidate_cash_principal_internal::<Test>(
+                    collateral_asset,
+                    liquidator,
+                    borrower,
+                    principal
+                ),
+                Err(Reason::RepayTooMuch)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_cash_principal_internal_repay_too_much_positive_balance_asset() {
+        new_test_ext().execute_with(|| {
+            let principal: CashPrincipalAmount = CashPrincipalAmount::from_nominal("100");
+
+            init_uni_asset().unwrap();
+            init_eth_asset().unwrap();
+            init_wbtc_asset().unwrap();
+
+            init_asset_balance(Uni, borrower, Balance::from_nominal("100", UNI).value);
+            init_asset_balance(Eth, borrower, Balance::from_nominal("-8000", ETH).value);
+            init_asset_balance(Wbtc, borrower, Balance::from_nominal("2", WBTC).value);
+
+            init_cash(liquidator, CashPrincipal::from_nominal("100000"));
+
+            assert_eq!(
+                liquidate_cash_principal_internal::<Test>(
+                    collateral_asset,
+                    liquidator,
+                    borrower,
+                    principal
+                ),
+                Err(Reason::RepayTooMuch)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_cash_principal_internal_insufficient_collateral() {
+        new_test_ext().execute_with(|| {
+            let principal: CashPrincipalAmount = CashPrincipalAmount::from_nominal("100");
+
+            init_eth_asset().unwrap();
+            init_wbtc_asset().unwrap();
+
+            init_asset_balance(Eth, borrower, Balance::from_nominal("80", ETH).value); // -80 * 2000 / 0.8 = -200000
+            init_cash(borrower, CashPrincipal::from_nominal("-300000")); // -300000 + 200000 = -100000
+
+            init_cash(liquidator, CashPrincipal::from_nominal("100000"));
+
+            assert_eq!(
+                liquidate_cash_principal_internal::<Test>(
+                    collateral_asset,
+                    liquidator,
+                    borrower,
+                    principal
+                ),
+                Err(Reason::InsufficientCollateral)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_cash_principal_internal_insufficient_collateral_partial() {
+        new_test_ext().execute_with(|| {
+            let principal: CashPrincipalAmount = CashPrincipalAmount::from_nominal("10000");
+
+            init_eth_asset().unwrap();
+            init_wbtc_asset().unwrap();
+
+            init_asset_balance(Eth, borrower, Balance::from_nominal("80", ETH).value); // 80 * 2000 / 0.8 = 200000
+            init_asset_balance(Wbtc, borrower, Balance::from_nominal("0.01", WBTC).value); // 2 * 60000 * 0.6 = 72000
+            init_cash(borrower, CashPrincipal::from_nominal("-300000"));
+
+            init_cash(liquidator, CashPrincipal::from_nominal("100000"));
+
+            assert_eq!(
+                liquidate_cash_principal_internal::<Test>(
+                    collateral_asset,
+                    liquidator,
+                    borrower,
+                    principal
+                ),
+                Err(Reason::InsufficientCollateral)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_cash_principal_internal_ok() {
+        new_test_ext().execute_with(|| {
+            let principal: CashPrincipalAmount = CashPrincipalAmount::from_nominal("60000");
+
+            init_eth_asset().unwrap();
+            init_wbtc_asset().unwrap();
+
+            init_asset_balance(Eth, borrower, Balance::from_nominal("80", ETH).value); // 80 * 2000 / 0.8 = 200000
+            init_asset_balance(Wbtc, borrower, Balance::from_nominal("2", WBTC).value); // 2 * 60000 * 0.6 = 72000
+            init_cash(borrower, CashPrincipal::from_nominal("-300000")); // -300000 + 72000 + 200000 = -28000
+
+            // Seize amount = 1.08 * 1 * 60000 / 60000 = 1.08 WBTC
+
+            init_asset_balance(Wbtc, liquidator, Balance::from_nominal("-0.1", WBTC).value);
+            init_cash(liquidator, CashPrincipal::from_nominal("100000"));
+
+            // TODO: Check this number
+            assert_eq!(
+                TotalCashPrincipal::get(),
+                CashPrincipalAmount::from_nominal("100000")
+            );
+
+            assert_ok!(liquidate_cash_principal_internal::<Test>(
+                collateral_asset,
+                liquidator,
+                borrower,
+                principal
+            ));
+
+            assert_eq!(
+                TotalSupplyAssets::get(Wbtc),
+                Quantity::from_nominal("1.9", WBTC).value
+            );
+            assert_eq!(
+                TotalBorrowAssets::get(Wbtc),
+                Quantity::from_nominal("0", WBTC).value
+            );
+            assert_eq!(
+                AssetBalances::get(Wbtc, borrower),
+                Balance::from_nominal("0.92", WBTC).value
+            );
+            assert_eq!(
+                AssetBalances::get(Wbtc, liquidator),
+                Balance::from_nominal("0.98", WBTC).value
+            );
+            assert_eq!(
+                AssetsWithNonZeroBalance::iter_prefix(borrower).collect::<Vec<_>>(),
+                vec![(Eth, ()), (Wbtc, ())]
+            );
+            assert_eq!(
+                AssetsWithNonZeroBalance::iter_prefix(liquidator).collect::<Vec<_>>(),
+                vec![(Wbtc, ())]
+            );
+            assert_eq!(
+                LastIndices::get(Wbtc, borrower),
+                AssetIndex::from_nominal("0")
+            );
+            assert_eq!(
+                LastIndices::get(Wbtc, liquidator),
+                AssetIndex::from_nominal("0")
+            );
+            assert_eq!(
+                CashPrincipals::get(ChainAccount::Eth([0; 20])),
+                CashPrincipal::from_nominal("300000")
+            );
+            assert_eq!(
+                CashPrincipals::get(borrower),
+                CashPrincipal::from_nominal("-240000")
+            );
+            assert_eq!(
+                CashPrincipals::get(liquidator),
+                CashPrincipal::from_nominal("40000")
+            );
+            // TODO: Check this number
+            assert_eq!(
+                TotalCashPrincipal::get(),
+                CashPrincipalAmount::from_nominal("40000")
+            );
+        })
+    }
+
+    // liquidate_cash_collateral
+
+    #[test]
+    fn test_liquidate_cash_collateral_internal_self_liquidate() {
+        new_test_ext().execute_with(|| {
+            let amount: AssetQuantity = eth.as_quantity_nominal("1");
+
+            init_eth_asset().unwrap();
+            init_wbtc_asset().unwrap();
+
+            init_asset_balance(Eth, borrower, Balance::from_nominal("-40", ETH).value); // 40 * 2000 / 0.8 = -200000
+            init_cash(borrower, CashPrincipal::from_nominal("100000")); // -200000 + 100000 = -100000
+
+            assert_eq!(
+                liquidate_cash_collateral_internal::<Test>(asset, borrower, borrower, amount),
+                Err(Reason::SelfTransfer)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_cash_collateral_internal_too_small() {
+        new_test_ext().execute_with(|| {
+            let amount: AssetQuantity = eth.as_quantity_nominal("0.00000001");
+
+            init_eth_asset().unwrap();
+            init_wbtc_asset().unwrap();
+
+            assert_eq!(
+                liquidate_cash_collateral_internal::<Test>(asset, liquidator, borrower, amount),
+                Err(Reason::MinTxValueNotMet)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_cash_collateral_internal_too_large() {
+        new_test_ext().execute_with(|| {
+            let amount: AssetQuantity = Quantity {
+                value: u128::MAX,
+                units: ETH,
+            };
+
+            init_eth_asset().unwrap();
+            init_wbtc_asset().unwrap();
+
+            assert_eq!(
+                liquidate_cash_collateral_internal::<Test>(asset, liquidator, borrower, amount),
                 Err(Reason::MathError(MathError::Overflow))
             );
         })
     }
 
-    // #[test]
-    // fn test_liquidate_internal_xxx() {
-    //     new_test_ext().execute_with(|| {
-    //         let amount: AssetQuantity = eth.as_quantity_nominal("1");
+    // The hope on this test is to hit the overflow on mul'ing by price,
+    // not on mul'ing by the liquidation incentive (1.08).
+    #[test]
+    fn test_liquidate_cash_collateral_internal_too_large_with_price() {
+        new_test_ext().execute_with(|| {
+            let amount: AssetQuantity = Quantity {
+                value: u128::MAX / 10 * 9,
+                units: ETH,
+            };
 
-    //         init_eth_asset().unwrap();
-    //         init_wbtc_asset().unwrap();
+            init_eth_asset().unwrap();
+            init_wbtc_asset().unwrap();
 
-    //         init_asset_balance(Eth, borrower, Balance::from_nominal("3", ETH).value); // 3 * 2000 * 0.8 = 4800
-    //         init_asset_balance(Wbtc, borrower, Balance::from_nominal("-1", WBTC).value); // 1 * 60000 / 0.6 = -100000
-    //         init_cash(borrower, CashPrincipal::from_nominal("95000")); // 95000 + 4800 - 1000000 = -200
+            assert_eq!(
+                liquidate_cash_collateral_internal::<Test>(asset, liquidator, borrower, amount),
+                Err(Reason::MathError(MathError::Overflow))
+            );
+        })
+    }
 
-    //         init_cash(liquidator, CashPrincipal::from_nominal("1000000"));
+    #[test]
+    fn test_liquidate_cash_collateral_internal_not_supported() {
+        new_test_ext().execute_with(|| {
+            let amount: AssetQuantity = eth.as_quantity_nominal("1");
 
-    //         assert_eq!(
-    //             liquidate_internal::<Test>(asset, collateral_asset, liquidator, borrower, amount),
-    //             Err(Reason::MathError(MathError::DivisionByZero))
-    //         );
-    //     })
-    // }
+            pallet_oracle::Prices::insert(
+                ETH.ticker,
+                Price::from_nominal(ETH.ticker, "2000.00").value,
+            );
 
-    // #[test]
-    // fn test_liquidate_internal_ok() {
-    //     new_test_ext().execute_with(|| {
-    //         let asset: AssetInfo = eth;
-    //         let collateral_asset: AssetInfo = wbtc;
-    //         let liquidator: ChainAccount = ChainAccount::Eth([1u8; 20]);
-    //         let borrower: ChainAccount = ChainAccount::Eth([2u8; 20]);
-    //         let amount: AssetQuantity = eth.as_quantity_nominal("1");
+            assert_eq!(
+                liquidate_cash_collateral_internal::<Test>(asset, liquidator, borrower, amount),
+                Err(Reason::AssetNotSupported)
+            );
+        })
+    }
 
-    //         init_eth_asset().unwrap();
-    //         init_wbtc_asset().unwrap();
-    //         init_asset_balance(Eth, borrower, Balance::from_nominal("3", ETH).value); // 3 * 2000 * 0.8 = 4800
-    //         init_asset_balance(Wbtc, borrower, Balance::from_nominal("-1", WBTC).value); // 1 * 60000 / 0.6 = -100000
-    //         init_cash(borrower, CashPrincipal::from_nominal("95000")); // 95000 + 4800 - 1000000 = -200
+    #[test]
+    fn test_liquidate_cash_collateral_internal_asset_price_zero() {
+        new_test_ext().execute_with(|| {
+            let amount: AssetQuantity = eth.as_quantity_nominal("1");
 
-    //         assert_ok!(liquidate_internal::<Test>(
-    //             asset,
-    //             collateral_asset,
-    //             liquidator,
-    //             borrower,
-    //             amount
-    //         ));
+            init_eth_asset().unwrap();
 
-    //         // TODO: Checks for last indices and other written values
+            pallet_oracle::Prices::insert(ETH.ticker, Price::from_nominal(ETH.ticker, "0").value);
 
-    //         assert_eq!(
-    //             AssetBalances::get(Eth, liquidator),
-    //             Balance::from_nominal("32.4", ETH).value
-    //         );
-    //         assert_eq!(
-    //             AssetBalances::get(Eth, borrower),
-    //             Balance::from_nominal("-32.4", ETH).value
-    //         );
-    //         assert_eq!(
-    //             AssetBalances::get(Wbtc, liquidator),
-    //             Balance::from_nominal("2", WBTC).value
-    //         );
-    //         assert_eq!(
-    //             AssetBalances::get(Wbtc, borrower),
-    //             Balance::from_nominal("-4", WBTC).value
-    //         );
-    //     })
-    // }
+            // This will always trip first
+            assert_eq!(
+                liquidate_cash_collateral_internal::<Test>(asset, liquidator, borrower, amount),
+                Err(Reason::MinTxValueNotMet)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_cash_collateral_internal_sufficient_liquidity() {
+        new_test_ext().execute_with(|| {
+            let amount: AssetQuantity = eth.as_quantity_nominal("1");
+
+            init_eth_asset().unwrap();
+
+            init_asset_balance(Eth, borrower, Balance::from_nominal("-40", ETH).value); // 40 * 2000 / 0.8 = -200000
+            init_cash(borrower, CashPrincipal::from_nominal("1000000")); // -200000 + 1000000 = 800000
+
+            assert_eq!(
+                liquidate_cash_collateral_internal::<Test>(asset, liquidator, borrower, amount),
+                Err(Reason::SufficientLiquidity)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_cash_collateral_internal_insufficient_liquidity() {
+        new_test_ext().execute_with(|| {
+            let amount: AssetQuantity = eth.as_quantity_nominal("1");
+
+            init_eth_asset().unwrap();
+
+            init_asset_balance(Eth, borrower, Balance::from_nominal("-40", ETH).value); // 40 * 2000 / 0.8 = -200000
+            init_cash(borrower, CashPrincipal::from_nominal("100000")); // -200000 + 100000 = -100000
+
+            assert_eq!(
+                liquidate_cash_collateral_internal::<Test>(asset, liquidator, borrower, amount),
+                Err(Reason::InsufficientLiquidity)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_cash_collateral_internal_repay_too_much() {
+        new_test_ext().execute_with(|| {
+            let amount: AssetQuantity = eth.as_quantity_nominal("50");
+
+            init_eth_asset().unwrap();
+
+            init_asset_balance(Eth, borrower, Balance::from_nominal("-40", ETH).value); // 40 * 2000 / 0.8 = -200000
+            init_cash(borrower, CashPrincipal::from_nominal("100000")); // -200000 + 100000 = -100000
+
+            init_asset_balance(Eth, liquidator, Balance::from_nominal("80", ETH).value);
+
+            assert_eq!(
+                liquidate_cash_collateral_internal::<Test>(asset, liquidator, borrower, amount),
+                Err(Reason::RepayTooMuch)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_cash_collateral_internal_repay_too_much_zero_balance_asset() {
+        new_test_ext().execute_with(|| {
+            let amount: AssetQuantity = uni.as_quantity_nominal("100");
+
+            init_uni_asset().unwrap();
+            init_eth_asset().unwrap();
+
+            init_asset_balance(Eth, borrower, Balance::from_nominal("-40", ETH).value); // 40 * 2000 / 0.8 = -200000
+            init_cash(borrower, CashPrincipal::from_nominal("100000")); // -200000 + 100000 = -100000
+
+            init_asset_balance(Eth, liquidator, Balance::from_nominal("80", ETH).value);
+
+            assert_eq!(
+                liquidate_cash_collateral_internal::<Test>(uni, liquidator, borrower, amount),
+                Err(Reason::RepayTooMuch)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_cash_collateral_internal_repay_too_much_positive_balance_asset() {
+        new_test_ext().execute_with(|| {
+            let amount: AssetQuantity = uni.as_quantity_nominal("100");
+
+            init_uni_asset().unwrap();
+            init_eth_asset().unwrap();
+
+            init_asset_balance(Eth, borrower, Balance::from_nominal("-4000", ETH).value);
+            init_asset_balance(Uni, borrower, Balance::from_nominal("100", UNI).value);
+            init_cash(borrower, CashPrincipal::from_nominal("100000"));
+
+            init_asset_balance(Eth, liquidator, Balance::from_nominal("80", ETH).value);
+
+            assert_eq!(
+                liquidate_cash_collateral_internal::<Test>(uni, liquidator, borrower, amount),
+                Err(Reason::RepayTooMuch)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_cash_collateral_internal_insufficient_collateral() {
+        new_test_ext().execute_with(|| {
+            let amount: AssetQuantity = eth.as_quantity_nominal("1");
+
+            init_eth_asset().unwrap();
+
+            init_asset_balance(Eth, borrower, Balance::from_nominal("-40", ETH).value); // 40 * 2000 / 0.8 = -200000
+            init_asset_balance(Eth, liquidator, Balance::from_nominal("80", ETH).value);
+
+            assert_eq!(
+                liquidate_cash_collateral_internal::<Test>(asset, liquidator, borrower, amount),
+                Err(Reason::InsufficientCollateral)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_cash_collateral_internal_insufficient_collateral_partial() {
+        new_test_ext().execute_with(|| {
+            let amount: AssetQuantity = eth.as_quantity_nominal("10");
+
+            init_eth_asset().unwrap();
+            init_wbtc_asset().unwrap();
+
+            init_asset_balance(Eth, borrower, Balance::from_nominal("-40", ETH).value);
+            init_cash(borrower, CashPrincipal::from_nominal("100"));
+
+            init_asset_balance(Eth, liquidator, Balance::from_nominal("80", ETH).value);
+
+            assert_eq!(
+                liquidate_cash_collateral_internal::<Test>(asset, liquidator, borrower, amount),
+                Err(Reason::InsufficientCollateral)
+            );
+        })
+    }
+
+    #[test]
+    fn test_liquidate_cash_collateral_internal_ok() {
+        new_test_ext().execute_with(|| {
+            let amount: AssetQuantity = eth.as_quantity_nominal("10");
+
+            init_eth_asset().unwrap();
+
+            init_asset_balance(Eth, borrower, Balance::from_nominal("-40", ETH).value); // 40 * 2000 / 0.8 = -200000
+            init_cash(borrower, CashPrincipal::from_nominal("100000")); // -200000 + 100000 = -100000
+
+            init_asset_balance(Eth, liquidator, Balance::from_nominal("80", ETH).value);
+            init_cash(liquidator, CashPrincipal::from_nominal("-600"));
+
+            // Seize amount = 1.08 * 10 * 2000 / 1 = 21600 CASH
+
+            assert_ok!(liquidate_cash_collateral_internal::<Test>(
+                asset, liquidator, borrower, amount
+            ));
+
+            assert_eq!(
+                TotalSupplyAssets::get(Eth),
+                Quantity::from_nominal("70", ETH).value
+            ); // All supply was closed
+            assert_eq!(
+                TotalBorrowAssets::get(Eth),
+                Quantity::from_nominal("30", ETH).value
+            ); // Part of liquidation was borrowed, part came from supply
+            assert_eq!(
+                AssetBalances::get(Eth, borrower),
+                Balance::from_nominal("-30", ETH).value
+            );
+            assert_eq!(
+                AssetBalances::get(Eth, liquidator),
+                Balance::from_nominal("70", ETH).value
+            );
+            assert_eq!(
+                AssetsWithNonZeroBalance::iter_prefix(borrower).collect::<Vec<_>>(),
+                vec![(Eth, ())]
+            );
+            assert_eq!(
+                AssetsWithNonZeroBalance::iter_prefix(liquidator).collect::<Vec<_>>(),
+                vec![(Eth, ())]
+            );
+            assert_eq!(
+                LastIndices::get(Eth, borrower),
+                AssetIndex::from_nominal("0")
+            );
+            assert_eq!(
+                LastIndices::get(Eth, liquidator),
+                AssetIndex::from_nominal("0")
+            );
+            assert_eq!(
+                CashPrincipals::get(borrower),
+                CashPrincipal::from_nominal("78400")
+            );
+            assert_eq!(
+                CashPrincipals::get(liquidator),
+                CashPrincipal::from_nominal("21000")
+            );
+            // TODO: Check this number
+            assert_eq!(
+                TotalCashPrincipal::get(),
+                CashPrincipalAmount::from_nominal("99400")
+            );
+        })
+    }
 }

--- a/pallets/cash/src/pipeline.rs
+++ b/pallets/cash/src/pipeline.rs
@@ -526,6 +526,7 @@ mod tests {
         tests::{assert_ok, assets::*, common::*, mock::*},
         types::*,
     };
+    use our_std::convert::TryInto;
 
     #[allow(non_upper_case_globals)]
     const account_a: ChainAccount = ChainAccount::Eth([1u8; 20]);
@@ -709,6 +710,113 @@ mod tests {
                 .check_collateralized::<Test>(account_b);
 
             assert_eq!(res, Err(Reason::InsufficientLiquidity));
+        })
+    }
+
+    #[test]
+    fn test_check_underwater() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(init_eth_asset());
+            assert_ok!(init_wbtc_asset());
+
+            CashPrincipals::insert(account_a, CashPrincipal(100000000000)); // 100,000 CASH
+            AssetsWithNonZeroBalance::insert(account_a, Wbtc, ());
+
+            let eth_quantity = eth.as_quantity_nominal("1");
+            let wbtc_quantity = wbtc.as_quantity_nominal("0.02");
+
+            let res = CashPipeline::new()
+                .transfer_asset::<Test>(account_a, account_b, Eth, eth_quantity)
+                .expect("transfer_asset(eth) failed")
+                .transfer_asset::<Test>(account_b, account_a, Wbtc, wbtc_quantity)
+                .expect("transfer_asset(wbtc) failed")
+                .check_underwater::<Test>(account_b)
+                .expect("account_b should be underwater")
+                .check_underwater::<Test>(account_a);
+
+            assert_eq!(res, Err(Reason::SufficientLiquidity));
+        })
+    }
+
+    #[test]
+    fn test_check_asset_balance() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(init_eth_asset());
+            assert_ok!(init_wbtc_asset());
+
+            let eth_quantity = eth.as_quantity_nominal("1");
+            let wbtc_quantity = wbtc.as_quantity_nominal("0.02");
+
+            let res = CashPipeline::new()
+                .transfer_asset::<Test>(account_a, account_b, Eth, eth_quantity)
+                .expect("transfer_asset(eth) failed")
+                .transfer_asset::<Test>(account_b, account_a, Wbtc, wbtc_quantity)
+                .expect("transfer_asset(wbtc) failed")
+                .check_asset_balance::<Test, _>(account_a, eth, |balance| {
+                    if balance == eth_quantity.negate().unwrap() {
+                        Ok(())
+                    } else {
+                        Err(Reason::None)
+                    }
+                })
+                .expect("account_a balance should be -eth_quantity")
+                .check_asset_balance::<Test, _>(account_b, eth, |balance| {
+                    if balance == eth_quantity.try_into().unwrap() {
+                        Ok(())
+                    } else {
+                        Err(Reason::None)
+                    }
+                })
+                .expect("account_b balance should be eth_quantity")
+                .check_asset_balance::<Test, _>(account_a, wbtc, |balance| {
+                    if balance == wbtc_quantity.try_into().unwrap() {
+                        Ok(())
+                    } else {
+                        Err(Reason::None)
+                    }
+                })
+                .expect("account_a balance should be wbtc_quantity")
+                .check_asset_balance::<Test, _>(account_b, wbtc, |balance| {
+                    if balance == wbtc_quantity.negate().unwrap() {
+                        Ok(())
+                    } else {
+                        Err(Reason::None)
+                    }
+                })
+                .expect("account_b balance should be -wbtc_quantity")
+                .check_asset_balance::<Test, _>(account_a, wbtc, |_| Err(Reason::None));
+
+            assert_eq!(res, Err(Reason::None));
+        })
+    }
+
+    #[test]
+    fn test_check_cash_principal() {
+        new_test_ext().execute_with(|| {
+            let quantity = CashPrincipalAmount::from_nominal("1");
+
+            let res = CashPipeline::new()
+                .transfer_cash::<Test>(account_a, account_b, quantity)
+                .expect("transfer_cash failed")
+                .check_cash_principal::<Test, _>(account_a, |principal| {
+                    if principal.eq(-1000000) {
+                        Ok(())
+                    } else {
+                        Err(Reason::None)
+                    }
+                })
+                .expect("account_a principal should be -1 CASH")
+                .check_cash_principal::<Test, _>(account_b, |principal| {
+                    if principal.eq(1000000) {
+                        Ok(())
+                    } else {
+                        Err(Reason::None)
+                    }
+                })
+                .expect("account_b principal should be 1 CASH")
+                .check_cash_principal::<Test, _>(account_a, |_| Err(Reason::None));
+
+            assert_eq!(res, Err(Reason::None));
         })
     }
 

--- a/pallets/cash/src/pipeline.rs
+++ b/pallets/cash/src/pipeline.rs
@@ -461,6 +461,33 @@ impl CashPipeline {
         }
     }
 
+    pub fn check_asset_balance<T: Config, F>(
+        self: Self,
+        account: ChainAccount,
+        asset: AssetInfo,
+        check_fn: F,
+    ) -> Result<Self, Reason>
+    where
+        F: FnOnce(Balance) -> Result<(), Reason>,
+    {
+        let balance = self.state.get_asset_balance::<T>(asset, account);
+        check_fn(balance)?;
+        Ok(self)
+    }
+
+    pub fn check_cash_principal<T: Config, F>(
+        self: Self,
+        account: ChainAccount,
+        check_fn: F,
+    ) -> Result<Self, Reason>
+    where
+        F: FnOnce(CashPrincipal) -> Result<(), Reason>,
+    {
+        let principal = self.state.get_cash_principal::<T>(account);
+        check_fn(principal)?;
+        Ok(self)
+    }
+
     pub fn commit<T: Config>(self: Self) {
         self.state.commit::<T>();
     }

--- a/pallets/cash/src/reason.rs
+++ b/pallets/cash/src/reason.rs
@@ -71,6 +71,7 @@ pub enum Reason {
     AssetQuantityMismatch,
     Unreachable,
     TotalBorrowUnderflow,
+    InsufficientCollateral,
 }
 
 impl From<Reason> for frame_support::dispatch::DispatchError {
@@ -136,6 +137,11 @@ impl From<Reason> for frame_support::dispatch::DispatchError {
             Reason::AssetQuantityMismatch => (34, 0, "asset does not match quantity"),
             Reason::Unreachable => (35, 0, "unreachable state should be impossible"),
             Reason::TotalBorrowUnderflow => (36, 0, "total borrows underlflow"),
+            Reason::InsufficientCollateral => (
+                37,
+                0,
+                "borrower did not have sufficient collateral for seize",
+            ),
         };
         frame_support::dispatch::DispatchError::Module {
             index,

--- a/pallets/cash/src/tests/assets.rs
+++ b/pallets/cash/src/tests/assets.rs
@@ -55,7 +55,6 @@ pub const wbtc: AssetInfo = AssetInfo {
 };
 
 pub const Usdc: ChainAsset = ChainAsset::Eth(hex!("cccccccccccccccccccccccccccccccccccccccc"));
-#[allow(dead_code)]
 pub const usdc: AssetInfo = AssetInfo {
     asset: Usdc,
     decimals: USD.decimals,

--- a/pallets/cash/src/tests/common.rs
+++ b/pallets/cash/src/tests/common.rs
@@ -28,17 +28,27 @@ pub fn init_wbtc_asset() -> Result<ChainAsset, Reason> {
     Ok(Wbtc)
 }
 
+pub fn init_usdc_asset() -> Result<ChainAsset, Reason> {
+    SupportedAssets::insert(&Usdc, usdc);
+
+    Ok(Usdc)
+}
+
 pub fn init_asset_balance(asset: ChainAsset, account: ChainAccount, balance: AssetBalance) {
     AssetBalances::insert(asset, account, balance);
     if balance >= 0 {
         TotalSupplyAssets::insert(
             asset,
-            (TotalSupplyAssets::get(asset) as i128 + balance) as u128,
+            (TotalSupplyAssets::get(asset) as i128)
+                .checked_add(balance)
+                .unwrap() as u128,
         );
     } else {
         TotalBorrowAssets::insert(
             asset,
-            (TotalBorrowAssets::get(asset) as i128 + balance) as u128,
+            (TotalBorrowAssets::get(asset) as i128)
+                .checked_sub(balance)
+                .unwrap() as u128,
         );
     }
     AssetsWithNonZeroBalance::insert(account, asset, ());

--- a/pallets/cash/src/types.rs
+++ b/pallets/cash/src/types.rs
@@ -392,6 +392,16 @@ impl Balance {
         )?;
         Ok(Balance::new(result, self.units))
     }
+
+    /// Returns true if the balance is greater than or equal to given value
+    pub fn gte(self: &Self, v: i128) -> bool {
+        self.value >= v
+    }
+
+    /// Returns true if the balance is less than or equal to given value
+    pub fn lte(self: &Self, v: i128) -> bool {
+        self.value <= v
+    }
 }
 
 /// Type for representing a balance of CASH Principal.
@@ -451,6 +461,16 @@ impl CashPrincipal {
 
     pub fn negate(self) -> Self {
         Self(-self.0)
+    }
+
+    /// Returns true if the principal is greater than or equal to given value
+    pub fn gte(self: &Self, v: i128) -> bool {
+        self.0 >= v
+    }
+
+    /// Returns true if the principal is less than or equal to given value
+    pub fn lte(self: &Self, v: i128) -> bool {
+        self.0 <= v
     }
 }
 


### PR DESCRIPTION
This patch fixes liqudiations by limiting when they can occur, specifically prohibiting you from liquidating a borrow into a positive position (close > 100%) and preventing you from liquidating collateral into a borrow position (seize > 100% collateral). These are important fixes for real-life.

We will add better unit tests, but we are waiting on fixes for scenarios to test the current scenarios for this behavior.