### PR TITLE
Add Unit Tests for `assets.rs` and `transfer.rs`

### DIFF
--- a/pallets/cash/src/internal/assets.rs
+++ b/pallets/cash/src/internal/assets.rs
@@ -1,5 +1,3 @@
-use frame_support::storage::StorageMap;
-
 use crate::{
     chains::ChainAsset,
     core::get_asset,
@@ -8,6 +6,7 @@ use crate::{
     types::{AssetInfo, LiquidityFactor},
     Config, SupportedAssets,
 };
+use frame_support::storage::StorageMap;
 
 pub fn set_liquidity_factor<T: Config>(
     asset: ChainAsset,
@@ -41,6 +40,94 @@ pub fn set_rate_model<T: Config>(
 }
 
 pub fn support_asset<T: Config>(asset: ChainAsset, asset_info: AssetInfo) -> Result<(), Reason> {
+    // TODO: Should we perform sanity checks here?
     SupportedAssets::insert(&asset, asset_info);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        rates::*,
+        tests::{assert_ok, assets::*, common::*, mock::*},
+        types::*,
+        *,
+    };
+
+    #[test]
+    fn test_set_liquidity_factor_not_supported() {
+        new_test_ext().execute_with(|| {
+            assert_eq!(
+                set_liquidity_factor::<Test>(Eth, Factor::from_nominal("0.8")),
+                Err(Reason::AssetNotSupported)
+            );
+        });
+    }
+
+    #[test]
+    fn test_set_liquidity_factor_supported() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(init_eth_asset());
+            assert_ok!(set_liquidity_factor::<Test>(
+                Eth,
+                Factor::from_nominal("0.8")
+            ));
+            assert_eq!(
+                SupportedAssets::get(Eth).unwrap().liquidity_factor,
+                Factor::from_nominal("0.8")
+            );
+        });
+    }
+
+    #[test]
+    fn test_set_rate_model_not_supported() {
+        new_test_ext().execute_with(|| {
+            assert_eq!(
+                set_rate_model::<Test>(
+                    Eth,
+                    InterestRateModel::Fixed {
+                        rate: APR::from_nominal("0.10")
+                    }
+                ),
+                Err(Reason::AssetNotSupported)
+            );
+        });
+    }
+
+    #[test]
+    fn test_set_rate_model_supported() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(init_eth_asset());
+            assert_ok!(set_rate_model::<Test>(
+                Eth,
+                InterestRateModel::Fixed {
+                    rate: APR::from_nominal("0.10")
+                }
+            ));
+            assert_eq!(
+                SupportedAssets::get(Eth).unwrap().rate_model,
+                InterestRateModel::Fixed {
+                    rate: APR::from_nominal("0.10")
+                }
+            );
+        });
+    }
+
+    #[test]
+    fn test_support_asset() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(support_asset::<Test>(Eth, eth));
+            assert_eq!(SupportedAssets::get(Eth), Some(eth));
+        })
+    }
+
+    #[test]
+    fn test_support_asset_again() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(support_asset::<Test>(Eth, eth));
+            assert_ok!(support_asset::<Test>(Eth, eth));
+            assert_eq!(SupportedAssets::get(Eth), Some(eth));
+        })
+    }
 }

--- a/pallets/cash/src/internal/change_validators.rs
+++ b/pallets/cash/src/internal/change_validators.rs
@@ -1,9 +1,8 @@
-use frame_support::storage::{IterableStorageMap, StorageMap};
-
 use crate::{
     internal, reason::Reason, require, types::ValidatorKeys, Config, Event, Module, NextValidators,
     NoticeHolds, SessionInterface,
 };
+use frame_support::storage::{IterableStorageMap, StorageMap};
 
 pub fn change_validators<T: Config>(validators: Vec<ValidatorKeys>) -> Result<(), Reason> {
     require!(NoticeHolds::iter().count() == 0, Reason::PendingAuthNotice);
@@ -43,7 +42,7 @@ mod tests {
     use mock::opaque::MockSessionKeys;
 
     #[test]
-    fn test_change_val() {
+    fn test_change_validators() {
         new_test_ext().execute_with(|| {
             let prev_substrate_id: AccountId32 = [8; 32].into();
             let prev_keys = ValidatorKeys {
@@ -110,7 +109,7 @@ mod tests {
     }
 
     #[test]
-    fn test_keys_unset() {
+    fn test_change_validators_with_unset_keys() {
         new_test_ext().execute_with(|| {
             let substrate_id: AccountId32 = [2; 32].into();
             let vals = vec![ValidatorKeys {

--- a/pallets/cash/src/internal/exec_trx_request.rs
+++ b/pallets/cash/src/internal/exec_trx_request.rs
@@ -1,5 +1,3 @@
-use frame_support::storage::{StorageMap, StorageValue};
-
 use crate::core::get_asset;
 use crate::{
     chains::{ChainAccount, ChainAccountSignature},
@@ -19,6 +17,7 @@ use crate::{
     types::{CashIndex, CashOrChainAsset, CashPrincipalAmount, Nonce, Quantity},
     CashPrincipals, Config, GlobalCashIndex, Nonces,
 };
+use frame_support::storage::{StorageMap, StorageValue};
 use our_std::{convert::TryInto, str};
 
 pub fn prepend_nonce(payload: &Vec<u8>, nonce: Nonce) -> Vec<u8> {

--- a/pallets/cash/src/internal/extract.rs
+++ b/pallets/cash/src/internal/extract.rs
@@ -1,7 +1,3 @@
-// Note: The substrate build requires these be re-exported.
-use frame_support::storage::StorageValue;
-
-// Import these traits so we can interact with the substrate storage modules.
 use crate::{
     chains::ChainAccount,
     core::get_value,
@@ -13,6 +9,7 @@ use crate::{
     types::{AssetInfo, AssetQuantity, CashIndex, CashPrincipalAmount},
     Config, Event, GlobalCashIndex, Module,
 };
+use frame_support::storage::StorageValue;
 
 pub fn extract_internal<T: Config>(
     asset: AssetInfo,
@@ -63,7 +60,6 @@ pub fn extract_cash_principal_internal<T: Config>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::tests::*;
     use pallet_oracle::{types::Price, Prices};
 

--- a/pallets/cash/src/internal/liquidate.rs
+++ b/pallets/cash/src/internal/liquidate.rs
@@ -1,15 +1,3 @@
-// Note: The substrate build requires these be re-exported.
-pub use our_std::{
-    cmp::{max, min},
-    collections::btree_set::BTreeSet,
-    convert::{TryFrom, TryInto},
-    fmt, if_std, result,
-    result::Result,
-    str,
-};
-
-use frame_support::storage::{StorageMap, StorageValue};
-
 use crate::{
     chains::ChainAccount,
     core::{self, get_price, get_value},
@@ -23,6 +11,8 @@ use crate::{
     types::{AssetInfo, AssetQuantity, CashPrincipalAmount, Quantity, CASH},
     Config, Event, GlobalCashIndex, Module,
 };
+use frame_support::storage::{StorageMap, StorageValue};
+use our_std::result::Result;
 
 fn calculate_seize_quantity<T: Config>(
     quantity: AssetQuantity,

--- a/pallets/cash/src/internal/lock.rs
+++ b/pallets/cash/src/internal/lock.rs
@@ -1,7 +1,3 @@
-// Note: The substrate build requires these be re-exported.
-use frame_support::storage::StorageValue;
-
-// Import these traits so we can interact with the substrate storage modules.
 use crate::{
     chains::ChainAccount,
     pipeline::CashPipeline,
@@ -9,6 +5,7 @@ use crate::{
     types::{AssetInfo, AssetQuantity, CashIndex, CashPrincipalAmount},
     Config, Event, GlobalCashIndex, Module,
 };
+use frame_support::storage::StorageValue;
 
 pub fn lock_internal<T: Config>(
     asset: AssetInfo,

--- a/pallets/cash/src/internal/next_code.rs
+++ b/pallets/cash/src/internal/next_code.rs
@@ -1,5 +1,3 @@
-use frame_support::{dispatch::DispatchResultWithPostInfo, storage::StorageValue};
-
 use crate::{
     chains::{Chain, Ethereum},
     reason::Reason,
@@ -7,6 +5,7 @@ use crate::{
     types::CodeHash,
     AllowedNextCodeHash, Config, Event, Module,
 };
+use frame_support::{dispatch::DispatchResultWithPostInfo, storage::StorageValue};
 
 pub fn allow_next_code_with_hash<T: Config>(hash: CodeHash) -> Result<(), Reason> {
     AllowedNextCodeHash::put(hash);

--- a/pallets/cash/src/internal/notices.rs
+++ b/pallets/cash/src/internal/notices.rs
@@ -1,8 +1,5 @@
-use frame_support::storage::{IterableStorageDoubleMap, StorageDoubleMap, StorageMap};
-use frame_system::offchain::SubmitTransaction;
-
 use crate::{
-    chains::{ChainAccount, ChainAsset, ChainHash, ChainId, ChainSignature, ChainSignatureList},
+    chains::{ChainAccount, ChainAsset, ChainHash, ChainId, ChainSignature},
     core::recover_validator,
     log,
     notices::{
@@ -17,6 +14,8 @@ use crate::{
     AccountNotices, Call, Config, Event, LatestNotice, Module, NoticeHashes, NoticeHolds,
     NoticeStates, Notices,
 };
+use frame_support::storage::{IterableStorageDoubleMap, StorageDoubleMap, StorageMap};
+use frame_system::offchain::SubmitTransaction;
 
 pub fn dispatch_extraction_notice<T: Config>(
     asset: ChainAsset,

--- a/pallets/cash/src/internal/set_yield_next.rs
+++ b/pallets/cash/src/internal/set_yield_next.rs
@@ -11,7 +11,6 @@ use crate::{
 use codec::{Decode, Encode};
 use frame_support::storage::StorageValue;
 use our_std::Debuggable;
-
 use types_derive::Types;
 
 #[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, Debuggable, Types)]

--- a/pallets/cash/src/internal/supply_cap.rs
+++ b/pallets/cash/src/internal/supply_cap.rs
@@ -1,5 +1,3 @@
-use frame_support::storage::StorageMap;
-
 use crate::{
     internal,
     reason::Reason,
@@ -7,6 +5,7 @@ use crate::{
     types::{AssetAmount, ChainAsset},
     Config, Event, Module, SupportedAssets,
 };
+use frame_support::storage::StorageMap;
 
 pub fn set_supply_cap<T: Config>(chain_asset: ChainAsset, cap: AssetAmount) -> Result<(), Reason> {
     require!(

--- a/pallets/cash/src/internal/validate_trx.rs
+++ b/pallets/cash/src/internal/validate_trx.rs
@@ -7,7 +7,6 @@ use crate::{
     reason::Reason,
     AllowedNextCodeHash, Call, Config, Notices, Validators,
 };
-
 use codec::Encode;
 use frame_support::storage::{IterableStorageMap, StorageDoubleMap, StorageValue};
 use our_std::{log, RuntimeDebug};


### PR DESCRIPTION
This patch simply adds unit tests for `assets.rs` and `transfer.rs` to make sure we actually have a large amounts of unit test coverage for our core functionality. Nothing surprising was found during these tests (except continued questions on the "right" value for TotalCashPrincipal and ChainCashPrincipals).