### PR TITLE
Add checks for Extract, Liquidate and Transfer events

### DIFF
--- a/pallets/cash/src/internal/change_validators.rs
+++ b/pallets/cash/src/internal/change_validators.rs
@@ -105,6 +105,25 @@ mod tests {
                 vec![&(substrate_id, session_keys)],
                 Session::queued_keys().iter().collect::<Vec<_>>()
             );
+
+            // Check emitted `ChangeValidators` event
+            let mut events_iter = System::events().into_iter();
+            let change_validators_event = events_iter.next().unwrap();
+            assert_eq!(
+                mock::Event::pallet_cash(crate::Event::ChangeValidators(val_keys.clone())),
+                change_validators_event.event
+            );
+            // Check emitted `Notice` event
+            let notice_event = events_iter.next().unwrap();
+            let expected_notice_encoded = expected_notice.encode_notice();
+            assert_eq!(
+                mock::Event::pallet_cash(crate::Event::Notice(
+                    expected_notice_id,
+                    expected_notice.clone(),
+                    expected_notice_encoded
+                )),
+                notice_event.event
+            );
         });
     }
 

--- a/pallets/cash/src/internal/exec_trx_request.rs
+++ b/pallets/cash/src/internal/exec_trx_request.rs
@@ -256,12 +256,66 @@ mod tests {
             let res = exec_trx_request::<Test>(req_str, account, nonce);
             assert_eq!(res, Ok(()));
 
-            // TODO: Check for Notice
             assert_eq!(
                 CashPrincipals::get(account),
                 CashPrincipal::from_nominal("1")
             );
             assert_eq!(Nonces::get(account), 1);
+
+            let expected_notice_id = NoticeId(0, 1);
+            let expected_notice = Notice::CashExtractionNotice(CashExtractionNotice::Eth {
+                id: expected_notice_id,
+                parent: [0u8; 32],
+                account: [1; 20],
+                principal: 3000000,
+            });
+
+            // Check Notice
+            let (actual_notice_id, actual_notice) =
+                Notices::iter_prefix(ChainId::Eth).next().unwrap();
+            assert_eq!(actual_notice, expected_notice);
+            assert_eq!(actual_notice_id, expected_notice_id);
+            let (_, state_actual_notice_id, notice_state) = NoticeStates::iter().next().unwrap();
+            assert_eq!(state_actual_notice_id, expected_notice_id);
+            assert_eq!(
+                notice_state,
+                NoticeState::Pending {
+                    signature_pairs: ChainSignatureList::Eth([].to_vec())
+                }
+            );
+            let (hash_notice_id, _) = LatestNotice::get(ChainId::Eth).unwrap();
+            assert_eq!(hash_notice_id, expected_notice_id);
+            let (actual_chain_account, actual_notices) = AccountNotices::iter().next().unwrap();
+            assert_eq!(actual_chain_account, ChainAccount::Eth([1; 20]));
+            assert_eq!(actual_notices, [expected_notice_id]);
+
+            // Check emitted `Notice` event
+            let mut events_iter = System::events().into_iter();
+            let notice_event = events_iter.next().unwrap();
+            let expected_notice_encoded = expected_notice.encode_notice();
+            assert_eq!(
+                mock::Event::pallet_cash(crate::Event::Notice(
+                    expected_notice_id,
+                    expected_notice.clone(),
+                    expected_notice_encoded
+                )),
+                notice_event.event
+            );
+
+            // Check emitted `ExtractCash` event
+            let extract_cash_event = events_iter.next().unwrap();
+            let index = GlobalCashIndex::get();
+            assert_eq!(
+                mock::Event::pallet_cash(crate::Event::ExtractCash(
+                    account,
+                    ChainAccount::Eth([1; 20]),
+                    index
+                        .cash_principal_amount(Quantity::from_nominal("3", CASH))
+                        .unwrap(),
+                    index
+                )),
+                extract_cash_event.event
+            );
         });
     }
 

--- a/pallets/cash/src/internal/exec_trx_request.rs
+++ b/pallets/cash/src/internal/exec_trx_request.rs
@@ -456,7 +456,7 @@ mod tests {
             );
 
             // Check emitted `Extract` event
-            let extract_cash_event = events_iter.next().unwrap();
+            let extract_event = events_iter.next().unwrap();
             assert_eq!(
                 mock::Event::pallet_cash(crate::Event::Extract(
                     asset,
@@ -464,7 +464,7 @@ mod tests {
                     ChainAccount::Eth([1; 20]),
                     1000000000000000000
                 )),
-                extract_cash_event.event
+                extract_event.event
             );
         });
     }
@@ -498,6 +498,18 @@ mod tests {
                 CashPrincipal::from_nominal("-0.01")
             );
             assert_eq!(Nonces::get(account), nonce + 1);
+
+            // Check emitted `Transfer` event
+            let transfer_event = System::events().into_iter().next().unwrap();
+            assert_eq!(
+                mock::Event::pallet_cash(crate::Event::Transfer(
+                    asset,
+                    account,
+                    ChainAccount::Eth([1; 20]),
+                    2000000000000000000
+                )),
+                transfer_event.event
+            );
         });
     }
 
@@ -522,6 +534,21 @@ mod tests {
                 CashPrincipal::from_nominal("3")
             );
             assert_eq!(Nonces::get(account), 1);
+
+            // Check emitted `TransferCash` event
+            let index = GlobalCashIndex::get();
+            let transfer_cash_event = System::events().into_iter().next().unwrap();
+            assert_eq!(
+                mock::Event::pallet_cash(crate::Event::TransferCash(
+                    account,
+                    ChainAccount::Eth([1; 20]),
+                    index
+                        .cash_principal_amount(Quantity::from_nominal("3", CASH))
+                        .unwrap(),
+                    index
+                )),
+                transfer_cash_event.event
+            );
         });
     }
 
@@ -546,6 +573,21 @@ mod tests {
                 CashPrincipal::from_nominal("3.99")
             );
             assert_eq!(Nonces::get(account), 1);
+
+            // Check emitted `TransferCash` event
+            let index = GlobalCashIndex::get();
+            let transfer_cash_event = System::events().into_iter().next().unwrap();
+            assert_eq!(
+                mock::Event::pallet_cash(crate::Event::TransferCash(
+                    account,
+                    ChainAccount::Eth([1; 20]),
+                    index
+                        .cash_principal_amount(Quantity::from_nominal("3.99", CASH))
+                        .unwrap(),
+                    index
+                )),
+                transfer_cash_event.event
+            );
         });
     }
 

--- a/pallets/cash/src/internal/exec_trx_request.rs
+++ b/pallets/cash/src/internal/exec_trx_request.rs
@@ -522,7 +522,7 @@ mod tests {
             );
             // Check emitted `TransferCash` event
             assert_eq!(
-                mock::Event::pallet_cash(crate::Event::TransferCashFee(
+                mock::Event::pallet_cash(crate::Event::TransferCash(
                     account,
                     miner,
                     index.cash_principal_amount(TRANSFER_FEE).unwrap(),
@@ -580,7 +580,7 @@ mod tests {
             );
             // Check emitted `TransferCash` event
             assert_eq!(
-                mock::Event::pallet_cash(crate::Event::TransferCashFee(
+                mock::Event::pallet_cash(crate::Event::TransferCash(
                     account,
                     miner,
                     index.cash_principal_amount(TRANSFER_FEE).unwrap(),
@@ -638,7 +638,7 @@ mod tests {
             );
             // Check emitted `TransferCash` event
             assert_eq!(
-                mock::Event::pallet_cash(crate::Event::TransferCashFee(
+                mock::Event::pallet_cash(crate::Event::TransferCash(
                     account,
                     miner,
                     index.cash_principal_amount(TRANSFER_FEE).unwrap(),

--- a/pallets/cash/src/internal/exec_trx_request.rs
+++ b/pallets/cash/src/internal/exec_trx_request.rs
@@ -481,6 +481,9 @@ mod tests {
             let to_account = ChainAccount::Eth([1; 20]);
             let nonce = 0;
 
+            let miner = ChainAccount::Eth([3; 20]);
+            Miner::put(miner);
+
             let res = exec_trx_request::<Test>(req_str, account, Some(nonce));
             assert_eq!(res, Ok(()));
 
@@ -497,10 +500,17 @@ mod tests {
                 CashPrincipals::get(account),
                 CashPrincipal::from_nominal("-0.01")
             );
+            assert_eq!(
+                CashPrincipals::get(miner),
+                CashPrincipal::from_nominal("0.01")
+            );
             assert_eq!(Nonces::get(account), nonce + 1);
 
             // Check emitted `Transfer` event
-            let transfer_event = System::events().into_iter().next().unwrap();
+            let mut events_iter = System::events().into_iter();
+            let transfer_event = events_iter.next().unwrap();
+            let transfer_fee_event = events_iter.next().unwrap();
+            let index = GlobalCashIndex::get();
             assert_eq!(
                 mock::Event::pallet_cash(crate::Event::Transfer(
                     asset,
@@ -509,6 +519,16 @@ mod tests {
                     2000000000000000000
                 )),
                 transfer_event.event
+            );
+            // Check emitted `TransferCash` event
+            assert_eq!(
+                mock::Event::pallet_cash(crate::Event::TransferCashFee(
+                    account,
+                    miner,
+                    index.cash_principal_amount(TRANSFER_FEE).unwrap(),
+                    index
+                )),
+                transfer_fee_event.event
             );
         });
     }
@@ -522,6 +542,9 @@ mod tests {
             init_cash(account, CashPrincipal::from_nominal("4"));
             let nonce = Some(0);
 
+            let miner = ChainAccount::Eth([3; 20]);
+            Miner::put(miner);
+
             let res = exec_trx_request::<Test>(req_str, account, nonce);
             assert_eq!(res, Ok(()));
 
@@ -533,11 +556,17 @@ mod tests {
                 CashPrincipals::get(to_account),
                 CashPrincipal::from_nominal("3")
             );
+            assert_eq!(
+                CashPrincipals::get(miner),
+                CashPrincipal::from_nominal("0.01")
+            );
             assert_eq!(Nonces::get(account), 1);
 
             // Check emitted `TransferCash` event
+            let mut events_iter = System::events().into_iter();
+            let transfer_cash_event = events_iter.next().unwrap();
+            let transfer_cash_fee_event = events_iter.next().unwrap();
             let index = GlobalCashIndex::get();
-            let transfer_cash_event = System::events().into_iter().next().unwrap();
             assert_eq!(
                 mock::Event::pallet_cash(crate::Event::TransferCash(
                     account,
@@ -548,6 +577,16 @@ mod tests {
                     index
                 )),
                 transfer_cash_event.event
+            );
+            // Check emitted `TransferCash` event
+            assert_eq!(
+                mock::Event::pallet_cash(crate::Event::TransferCashFee(
+                    account,
+                    miner,
+                    index.cash_principal_amount(TRANSFER_FEE).unwrap(),
+                    index
+                )),
+                transfer_cash_fee_event.event
             );
         });
     }
@@ -561,6 +600,9 @@ mod tests {
             init_cash(account, CashPrincipal::from_nominal("4"));
             let nonce = Some(0);
 
+            let miner = ChainAccount::Eth([3; 20]);
+            Miner::put(miner);
+
             let res = exec_trx_request::<Test>(req_str, account, nonce);
             assert_eq!(res, Ok(()));
 
@@ -572,11 +614,17 @@ mod tests {
                 CashPrincipals::get(to_account),
                 CashPrincipal::from_nominal("3.99")
             );
+            assert_eq!(
+                CashPrincipals::get(miner),
+                CashPrincipal::from_nominal("0.01")
+            );
             assert_eq!(Nonces::get(account), 1);
 
             // Check emitted `TransferCash` event
+            let mut events_iter = System::events().into_iter();
+            let transfer_cash_event = events_iter.next().unwrap();
+            let transfer_cash_fee_event = events_iter.next().unwrap();
             let index = GlobalCashIndex::get();
-            let transfer_cash_event = System::events().into_iter().next().unwrap();
             assert_eq!(
                 mock::Event::pallet_cash(crate::Event::TransferCash(
                     account,
@@ -587,6 +635,16 @@ mod tests {
                     index
                 )),
                 transfer_cash_event.event
+            );
+            // Check emitted `TransferCash` event
+            assert_eq!(
+                mock::Event::pallet_cash(crate::Event::TransferCashFee(
+                    account,
+                    miner,
+                    index.cash_principal_amount(TRANSFER_FEE).unwrap(),
+                    index
+                )),
+                transfer_cash_fee_event.event
             );
         });
     }

--- a/pallets/cash/src/internal/exec_trx_request.rs
+++ b/pallets/cash/src/internal/exec_trx_request.rs
@@ -808,6 +808,19 @@ mod tests {
             );
             assert_eq!(Nonces::get(liquidator_account), nonce + 1);
             assert_eq!(Nonces::get(borrower_account), 0);
+
+            // Check emitted `LiquidateCashCollateral` event
+            let liquidate_event = System::events().into_iter().next().unwrap();
+            assert_eq!(
+                //[asset, liquidator, borrower, amount]
+                mock::Event::pallet_cash(crate::Event::LiquidateCashCollateral(
+                    eth_asset,
+                    liquidator_account,
+                    borrower_account,
+                    1000000000000000000
+                )),
+                liquidate_event.event
+            );
         });
     }
 
@@ -880,6 +893,22 @@ mod tests {
             );
             assert_eq!(Nonces::get(liquidator_account), nonce + 1);
             assert_eq!(Nonces::get(borrower_account), 0);
+
+            // Check emitted `LiquidateCash` event
+            let index = GlobalCashIndex::get();
+            let liquidate_event = System::events().into_iter().next().unwrap();
+            assert_eq!(
+                mock::Event::pallet_cash(crate::Event::LiquidateCash(
+                    eth_asset,
+                    liquidator_account,
+                    borrower_account,
+                    index
+                        .cash_principal_amount(Quantity::from_nominal("1000", CASH))
+                        .unwrap(),
+                    index
+                )),
+                liquidate_event.event
+            );
         });
     }
 
@@ -1014,6 +1043,19 @@ mod tests {
             );
             assert_eq!(Nonces::get(liquidator_account), nonce + 1);
             assert_eq!(Nonces::get(borrower_account), 0);
+
+            // Check emitted `Liquidate` event
+            let liquidate_event = System::events().into_iter().next().unwrap();
+            assert_eq!(
+                mock::Event::pallet_cash(crate::Event::Liquidate(
+                    wbtc_asset,
+                    eth_asset,
+                    liquidator_account,
+                    borrower_account,
+                    100000000
+                )),
+                liquidate_event.event
+            );
         });
     }
 

--- a/pallets/cash/src/internal/lock.rs
+++ b/pallets/cash/src/internal/lock.rs
@@ -158,6 +158,19 @@ mod tests {
             );
             assert_eq!(CashPrincipals::get(JARED), twice_principal.negate());
             assert_eq!(TotalCashPrincipal::get(), twice_principal_amount);
+
+            // Check emitted `LockedCash` event
+            let index = GlobalCashIndex::get();
+            let locked_cash_event = System::events().into_iter().next().unwrap();
+            assert_eq!(
+                mock::Event::pallet_cash(crate::Event::LockedCash(
+                    GEOFF,
+                    JARED,
+                    once_principal_amount,
+                    index
+                )),
+                locked_cash_event.event
+            );
         });
     }
 
@@ -218,6 +231,20 @@ mod tests {
                 CashPrincipalAmount(0)
             );
 
+            // Check emitted `LockedCash` event
+            let index = GlobalCashIndex::get();
+            let mut events_iter = System::events().into_iter();
+            let jared_locked_cash_event = events_iter.next().unwrap();
+            assert_eq!(
+                mock::Event::pallet_cash(crate::Event::LockedCash(
+                    jared,
+                    jared,
+                    lock_principal,
+                    index
+                )),
+                jared_locked_cash_event.event
+            );
+
             ChainCashPrincipals::insert(ChainId::Eth, lock_principal);
             CashPrincipals::insert(&geoff, CashPrincipal::from_nominal("-1"));
             assert_err!(
@@ -231,6 +258,18 @@ mod tests {
                 lock_principal
             ));
             assert_eq!(TotalCashPrincipal::get(), CashPrincipalAmount(0));
+
+            // Check emitted `LockedCash` event
+            let geoff_locked_cash_event = System::events().into_iter().last().unwrap();
+            assert_eq!(
+                mock::Event::pallet_cash(crate::Event::LockedCash(
+                    geoff,
+                    geoff,
+                    lock_principal,
+                    index
+                )),
+                geoff_locked_cash_event.event
+            );
 
             Ok(())
         })

--- a/pallets/cash/src/internal/next_code.rs
+++ b/pallets/cash/src/internal/next_code.rs
@@ -106,6 +106,13 @@ mod tests {
             let events_post: Vec<_> = System::events().into_iter().collect();
             assert_eq!(events_pre.len() + 1, events_post.len());
             assert_eq!(AllowedNextCodeHash::get(), None);
+
+            // Check emitted `AttemptedSetCodeByHash` event
+            let attempted_set_code_event = events_post.into_iter().last().unwrap();
+            assert_eq!(
+                mock::Event::pallet_cash(crate::Event::AttemptedSetCodeByHash(hash, Ok(()))),
+                attempted_set_code_event.event
+            );
         });
     }
 }

--- a/pallets/cash/src/internal/set_yield_next.rs
+++ b/pallets/cash/src/internal/set_yield_next.rs
@@ -148,6 +148,25 @@ mod tests {
                 LatestNotice::get(ChainId::Eth),
                 Some((expected_notice_id, expected_notice.hash()))
             );
+
+            // Check emitted `SetYieldNext` event
+            let mut events_iter = System::events().into_iter();
+            let yield_next_event = events_iter.next().unwrap();
+            assert_eq!(
+                mock::Event::pallet_cash(crate::Event::SetYieldNext(APR(100), 86400500)),
+                yield_next_event.event
+            );
+            // Check emitted `Notice` event
+            let notice_event = events_iter.next().unwrap();
+            let expected_notice_encoded = expected_notice.encode_notice();
+            assert_eq!(
+                mock::Event::pallet_cash(crate::Event::Notice(
+                    expected_notice_id,
+                    expected_notice.clone(),
+                    expected_notice_encoded
+                )),
+                notice_event.event
+            );
         });
     }
 

--- a/pallets/cash/src/internal/transfer.rs
+++ b/pallets/cash/src/internal/transfer.rs
@@ -34,6 +34,7 @@ pub fn transfer_internal<T: Config>(
         recipient,
         amount.value,
     ));
+    <Module<T>>::deposit_event(Event::TransferCashFee(sender, miner, fee_principal, index));
 
     Ok(())
 }
@@ -57,6 +58,7 @@ pub fn transfer_cash_principal_internal<T: Config>(
         .commit::<T>();
 
     <Module<T>>::deposit_event(Event::TransferCash(sender, recipient, principal, index));
+    <Module<T>>::deposit_event(Event::TransferCashFee(sender, miner, fee_principal, index));
 
     Ok(())
 }

--- a/pallets/cash/src/internal/transfer.rs
+++ b/pallets/cash/src/internal/transfer.rs
@@ -34,7 +34,7 @@ pub fn transfer_internal<T: Config>(
         recipient,
         amount.value,
     ));
-    <Module<T>>::deposit_event(Event::TransferCashFee(sender, miner, fee_principal, index));
+    <Module<T>>::deposit_event(Event::TransferCash(sender, miner, fee_principal, index));
 
     Ok(())
 }
@@ -58,7 +58,7 @@ pub fn transfer_cash_principal_internal<T: Config>(
         .commit::<T>();
 
     <Module<T>>::deposit_event(Event::TransferCash(sender, recipient, principal, index));
-    <Module<T>>::deposit_event(Event::TransferCashFee(sender, miner, fee_principal, index));
+    <Module<T>>::deposit_event(Event::TransferCash(sender, miner, fee_principal, index));
 
     Ok(())
 }

--- a/pallets/cash/src/lib.rs
+++ b/pallets/cash/src/lib.rs
@@ -267,6 +267,9 @@ decl_event!(
         /// An account has transferred CASH. [sender, recipient, principal, index]
         TransferCash(ChainAccount, ChainAccount, CashPrincipalAmount, CashIndex),
 
+        /// An account has transferred CASH fee to the miner. [sender, miner, fee_principal, index]
+        TransferCashFee(ChainAccount, ChainAccount, CashPrincipalAmount, CashIndex),
+
         /// An account has been liquidated. [asset, collateral_asset, liquidator, borrower, amount]
         Liquidate(
             ChainAsset,

--- a/pallets/cash/src/lib.rs
+++ b/pallets/cash/src/lib.rs
@@ -267,9 +267,6 @@ decl_event!(
         /// An account has transferred CASH. [sender, recipient, principal, index]
         TransferCash(ChainAccount, ChainAccount, CashPrincipalAmount, CashIndex),
 
-        /// An account has transferred CASH fee to the miner. [sender, miner, fee_principal, index]
-        TransferCashFee(ChainAccount, ChainAccount, CashPrincipalAmount, CashIndex),
-
         /// An account has been liquidated. [asset, collateral_asset, liquidator, borrower, amount]
         Liquidate(
             ChainAsset,


### PR DESCRIPTION
1. Add checks for Extract, Liquidate, and Transfer events
2. Add `TransferCash` events for cash fee transfers to miners