### PR TITLE
Fix m8 Failure

### DIFF
--- a/integration/__tests__/version_m8.js
+++ b/integration/__tests__/version_m8.js
@@ -1,0 +1,41 @@
+const { buildScenarios } = require('../util/scenario');
+const { getNotice } = require('../util/substrate');
+
+let scen_info = {
+  tokens: [
+    { token: 'usdc', balances: { ashley: 2000 } }
+  ]
+};
+
+buildScenarios('Version m8', scen_info, [
+  {
+    only: true,
+    name: "Test Running m8",
+    info: {
+      versions: ['m8'],
+      genesis_version: 'm8',
+      eth_opts: {
+        version: 'm8',
+      },
+      validators: {
+        alice: {
+          version: 'm8',
+        },
+        bob: {
+          version: 'm8',
+        }
+      },
+    },
+    scenario: async ({ ashley, usdc, chain, cash, starport }) => {
+      await ashley.lock(1000, usdc);
+      let notice = getNotice(await ashley.extract(100, cash));
+      let signatures = await chain.getNoticeSignatures(notice);
+      await starport.invoke(notice, signatures);
+      // Don't check cash since we use a new RPC call that doesn't exist in m8
+
+      await ashley.lock(100, usdc);
+      expect(await ashley.tokenBalance(usdc)).toEqual(900);
+      expect(await ashley.chainBalance(usdc)).toEqual(1100);
+    }
+  }
+]);

--- a/integration/util/scenario/chain_spec.js
+++ b/integration/util/scenario/chain_spec.js
@@ -107,7 +107,7 @@ async function buildChainSpec(chainSpecInfo, validatorsInfoHash, tokenInfoHash, 
   let chainSpecFile = chainSpecInfo.use_temp ?
     await tmpFile('chainSpec.json') : path.join(__dirname, '..', '..', 'chainSpec.json');
   let target = ctx.__target();
-  ctx.log('Building chain spec from ' + target + ' to temp file ' + chainSpecFile);
+  ctx.log('[CHAINSPEC] Scenario chain_spec.json: ' + chainSpecFile);
   let chainSpecJson;
   try {
     let { error, stdout, stderr } =

--- a/pallets/cash/src/core.rs
+++ b/pallets/cash/src/core.rs
@@ -244,6 +244,7 @@ pub fn apply_chain_event_internal<T: Config>(event: &ChainBlockEvent) -> Result<
                 result.to_vec(),
             ),
         },
+        _ => Err(Reason::Unreachable),
     }
 }
 
@@ -280,6 +281,7 @@ pub fn unapply_chain_event_internal<T: Config>(event: &ChainBlockEvent) -> Resul
 
             _ => Ok(()),
         },
+        _ => Err(Reason::Unreachable),
     }
 }
 

--- a/pallets/cash/src/events.rs
+++ b/pallets/cash/src/events.rs
@@ -23,6 +23,7 @@ pub fn fetch_chain_block(
     number: ChainBlockNumber,
 ) -> Result<ChainBlock, Reason> {
     match chain_id {
+        ChainId::Reserved => Err(Reason::Unreachable),
         ChainId::Eth => Ok(fetch_eth_block(number).map(ChainBlock::Eth)?),
         ChainId::Dot => Err(Reason::Unreachable),
     }
@@ -35,6 +36,7 @@ pub fn fetch_chain_blocks(
     to: ChainBlockNumber,
 ) -> Result<ChainBlocks, Reason> {
     match chain_id {
+        ChainId::Reserved => Err(Reason::Unreachable),
         ChainId::Eth => Ok(fetch_eth_blocks(from, to)?),
         ChainId::Dot => Err(Reason::Unreachable),
     }

--- a/pallets/cash/src/internal/events.rs
+++ b/pallets/cash/src/internal/events.rs
@@ -77,6 +77,7 @@ pub fn risk_adjusted_value<T: Config>(
 
             _ => Ok(Quantity::new(0, USD)),
         },
+        _ => Err(Reason::Unreachable),
     }
 }
 
@@ -113,7 +114,7 @@ pub fn track_chain_events_on<T: Config>(chain_id: ChainId) -> Result<(), Reason>
         submit_chain_blocks::<T>(&blocks)
     } else {
         debug!(
-            "Worker sees a different fork: {:?} {:?}",
+            "Worker sees a different fork: true={:?} last={:?}",
             true_block, last_block
         );
         let pending_reorgs = PendingChainReorgs::get(chain_id);
@@ -121,7 +122,7 @@ pub fn track_chain_events_on<T: Config>(chain_id: ChainId) -> Result<(), Reason>
         if !reorg.is_already_signed(&me.substrate_id, pending_reorgs) {
             submit_chain_reorg::<T>(&reorg)
         } else {
-            debug!("Worker already submitted...waiting");
+            debug!("Worker already submitted... waiting");
             // just wait for the reorg to succeed or fail,
             //  or we change our minds in another pass (noop)
             Ok(())
@@ -306,6 +307,7 @@ pub fn formulate_reorg<T: Config>(
                 .take_while(|b| b.parent_hash() != common_ancestor)
                 .filter_map(|b| match b {
                     ChainBlock::Eth(eth_block) => Some(eth_block),
+                    _ => None,
                 })
                 .collect(),
             forward_blocks: drawrof_blocks
@@ -313,6 +315,7 @@ pub fn formulate_reorg<T: Config>(
                 .take_while(|b| b.parent_hash() != common_ancestor)
                 .filter_map(|b| match b {
                     ChainBlock::Eth(eth_block) => Some(eth_block),
+                    _ => None,
                 })
                 .collect_rev(),
         }),

--- a/pallets/cash/src/tests/worker.rs
+++ b/pallets/cash/src/tests/worker.rs
@@ -104,6 +104,7 @@ fn test_offchain_worker() {
                         }
                     )
                 }
+                _ => panic!("not supposed to happen"),
             }
 
             assert_eq!(PendingChainBlocks::get(ChainId::Eth), vec![]); // XXX how to execute extrinsic?

--- a/types.json
+++ b/types.json
@@ -98,12 +98,14 @@
   "CashQuantity": "Quantity",
   "ChainAccount": {
     "_enum": {
+      "Reserved": "",
       "Eth": "Ethereum__Chain__Address",
       "Dot": "Polkadot__Chain__Address"
     }
   },
   "ChainAccountSignature": {
     "_enum": {
+      "Reserved": "",
       "Eth": "ChainAccountSignatureEth",
       "Dot": "ChainAccountSignatureDot"
     }
@@ -112,23 +114,27 @@
   "ChainAccountSignatureEth": "(Ethereum__Chain__Address,Ethereum__Chain__Signature)",
   "ChainAsset": {
     "_enum": {
+      "Reserved": "",
       "Eth": "Ethereum__Chain__Address",
       "Dot": "Polkadot__Chain__Address"
     }
   },
   "ChainBlock": {
     "_enum": {
+      "Reserved": "",
       "Eth": "Ethereum__Chain__Block"
     }
   },
   "ChainBlockEvent": {
     "_enum": {
+      "Reserved": "",
       "Eth": "ChainBlockEventEth"
     }
   },
   "ChainBlockEventEth": "(ChainBlockNumber,Ethereum__Chain__Event)",
   "ChainBlockEvents": {
     "_enum": {
+      "Reserved": "",
       "Eth": "Vec<(ChainBlockNumber,Ethereum__Chain__Event)>"
     }
   },
@@ -140,23 +146,27 @@
   },
   "ChainBlocks": {
     "_enum": {
+      "Reserved": "",
       "Eth": "Vec<Ethereum__Chain__Block>"
     }
   },
   "ChainHash": {
     "_enum": {
+      "Reserved": "",
       "Eth": "Ethereum__Chain__Hash",
       "Dot": "Polkadot__Chain__Hash"
     }
   },
   "ChainId": {
     "_enum": {
+      "Reserved": "",
       "Eth": "",
       "Dot": ""
     }
   },
   "ChainReorg": {
     "_enum": {
+      "Reserved": "",
       "Eth": "ChainReorgEth"
     }
   },
@@ -172,12 +182,14 @@
   },
   "ChainSignature": {
     "_enum": {
+      "Reserved": "",
       "Eth": "Ethereum__Chain__Signature",
       "Dot": "Polkadot__Chain__Signature"
     }
   },
   "ChainSignatureList": {
     "_enum": {
+      "Reserved": "",
       "Eth": "Vec<(Ethereum__Chain__Address,Ethereum__Chain__Signature)>",
       "Dot": "Vec<(Polkadot__Chain__Address,Polkadot__Chain__Signature)>"
     }


### PR DESCRIPTION
Fix m8 Failure
    
This patch fixes failures running m8 due to the enum shifting between versions. We add a reserved filler into the enums that can later be set to a different value, e.g. for another chain. We try to fill all of the slots since we would prefer that the numbering of chains stays constant and doesn't shift (e.g. it's #0 for ChainAccounts but #1 for ChainAssets and #5 for ChainBlocks).

## Previous Notes

Currently we cannot run m7 wasm in the native shell. This is likely due to some incompatability in the host functions versus the previously built wasm code. This new test shows off that behavior (it was broken with a Wasmi Trap). We fix the issue by changing the Dot/Eth order in chains.rs (not sure why this is the fix, but it worked). Note: this test now traps on missing a host function for getting cash data, but this is **not of any concern**. The original error was that blocks could not form, and we have a partial fix here that warrants more follow up. That is: why did this fix work? How can we make it work without changing the enum orders?

Again, the current error in the test is not the issue. The issue is "fixed" as we can mine blocks, but we need to figure out why this fix worked and if we can fix it without the "hack".