### PR TITLE
Upgrade to m9 Scenario

### DIFF
--- a/integration/__tests__/gov_scen.js
+++ b/integration/__tests__/gov_scen.js
@@ -25,7 +25,6 @@ buildScenarios('Gov Scenarios', gov_scen_info, [
     }
   },
   {
-    skip: true,
     name: "Upgrade Chain WASM [Allow Next Code]",
     info: {
       versions: ['m7'],
@@ -33,6 +32,7 @@ buildScenarios('Gov Scenarios', gov_scen_info, [
       validators: {
         alice: {
           version: 'm7',
+          extra_versions: ['curr']
         }
       },
     },
@@ -45,7 +45,7 @@ buildScenarios('Gov Scenarios', gov_scen_info, [
 
       expect(await chain.nextCodeHash()).toEqual(currHash);
 
-      let event = await chain.setNextCode(await curr.wasm());
+      let event = await chain.setNextCode(await curr.wasm(), curr, false);
       expect(event).toEqual({
         CodeHash: currHash,
         DispatchResult: {

--- a/integration/__tests__/upgrade_to_m3_scen.js
+++ b/integration/__tests__/upgrade_to_m3_scen.js
@@ -10,7 +10,6 @@ let scen_info = {
 
 buildScenarios('Upgrade to m3', scen_info, [
   {
-    skip: true,
     name: "Upgrade from m2 to m3 with Live Events",
     info: {
       versions: ['m2', 'm3'],

--- a/integration/__tests__/upgrade_to_m4_scen.js
+++ b/integration/__tests__/upgrade_to_m4_scen.js
@@ -11,7 +11,6 @@ let scen_info = {
 
 buildScenarios('Upgrade to m4', scen_info, [
   {
-    skip: true,
     name: "Upgrade from m3 to m4",
     info: {
       versions: ['m3', 'm4'],

--- a/integration/__tests__/upgrade_to_m8_scen.js
+++ b/integration/__tests__/upgrade_to_m8_scen.js
@@ -7,7 +7,6 @@ let scen_info = {};
 
 buildScenarios('Upgrade to m8', scen_info, [
   {
-    skip: true,
     name: "Upgrade from m7 to m8",
     info: {
       versions: ['m7', 'm8'],
@@ -36,7 +35,7 @@ buildScenarios('Upgrade to m8', scen_info, [
         { substrate_id: keyring.decodeAddress(bob.aura_key), eth_address: bob.eth_account }
       ];
 
-      // Just set validators to same, but Bob won't be able to sign it
+      // Just set validators to same, but Charlie won't be able to sign it
       let extrinsic = api.tx.cash.changeValidators(newAuthsRaw);
 
       let { notice } = await starport.executeProposal("Update authorities", [extrinsic], { awaitNotice: true });

--- a/integration/__tests__/upgrade_to_m9_scen.js
+++ b/integration/__tests__/upgrade_to_m9_scen.js
@@ -1,0 +1,87 @@
+const { buildScenarios } = require('../util/scenario');
+const { decodeCall, getEventData } = require('../util/substrate');
+const { bytes32 } = require('../util/util');
+const { getNotice } = require('../util/substrate');
+
+let scen_info = {
+  tokens: [
+    { token: 'usdc', balances: { ashley: 1000 } }
+  ]
+};
+
+/* TODO: Replace curr with m9 once release is built */
+buildScenarios('Upgrade to m9', scen_info, [
+  {
+    name: "Upgrade from m8 to m9",
+    info: {
+      versions: ['m8'],
+      genesis_version: 'm8',
+      validators: {
+        alice: {
+          version: 'm8',
+          extra_versions: ['curr'],
+        },
+        bob: {
+          version: 'm8',
+        },
+        charlie: {
+          version: 'm8',
+          eth_private_key: "0000000000000000000000000000000000000000000000000000000000000001" // Bad key
+        }
+      },
+    },
+    scenario: async ({ api, alice, ashley, bob, chain, curr, keyring, sleep, starport, usdc, validators }) => {
+      const newAuthsRaw = [
+        { substrate_id: keyring.decodeAddress(alice.info.aura_key), eth_address: alice.info.eth_account },
+        { substrate_id: keyring.decodeAddress(bob.info.aura_key), eth_address: bob.info.eth_account }
+      ];
+
+      // Just set validators to same, but Charlie won't be able to sign it
+      let { notice: notice0 } = await starport.executeProposal(
+        "Update authorities", [
+          api.tx.cash.changeValidators(newAuthsRaw)
+        ], { awaitNotice: true });
+      await chain.waitUntilSession(1);
+      expect(await chain.noticeHold('Eth')).toEqual([1, 0]);
+
+      let signatures0 = await chain.getNoticeSignatures(notice0, { signatures: 2 });
+      await starport.invoke(notice0, signatures0);
+      await sleep(20000);
+      expect(await chain.noticeState(notice0)).toEqual({"Executed": null});
+      expect(await chain.noticeHold('Eth')).toEqual(null);
+      expect(await chain.sessionValidators()).toEqualSet([alice.info.aura_key, bob.info.aura_key]);
+
+      // Try to lock
+      await ashley.lock(1, usdc);
+      expect(await ashley.chainBalance(usdc)).toEqual(1);
+
+      // Rotate again
+      let { notice: notice1 } = await starport.executeProposal(
+        "Update authorities", [
+          api.tx.cash.changeValidators(newAuthsRaw)
+        ], { awaitNotice: true });
+      await chain.waitUntilSession(2);
+      expect(await chain.noticeHold('Eth')).toEqual([2, 0]);
+
+      let signatures1 = await chain.getNoticeSignatures(notice1, { signatures: 2 });
+      await starport.invoke(notice1, signatures1);
+      await sleep(20000);
+      expect(await chain.noticeState(notice1)).toEqual({"Executed": null});
+      expect(await chain.noticeHold('Eth')).toEqual(null);
+      expect(await chain.sessionValidators()).toEqualSet([alice.info.aura_key, bob.info.aura_key]);
+
+      // Okay great, we've executed the change-over, but we still have a notice hold...
+      // But what if we upgrade to curr??
+      await chain.upgradeTo(curr);
+      expect(await chain.getSemVer()).toEqual([1, 8, 1]);
+      expect(await chain.noticeHold('Eth')).toEqual(null);
+
+      // start at 0, rotate through 1, actually perform change over on 2
+      await chain.waitUntilSession(2);
+
+      // Try to lock again
+      await ashley.lock(1, usdc);
+      expect(await ashley.chainBalance(usdc)).toEqual(2);
+    }
+  }
+]);

--- a/integration/util/scenario/versions.js
+++ b/integration/util/scenario/versions.js
@@ -197,6 +197,11 @@ async function buildVersion(version, ctx) {
 
 async function buildVersions(versionsInfo, ctx) {
   let versions = await versionsInfo.reduce(async (acc, versionInfo) => {
+    if (versionInfo === 'curr') {
+      // curr is automatically included
+      return acc;
+    }
+
     return [
       ...await acc,
       await buildVersion(versionInfo, ctx)


### PR DESCRIPTION
This patch gets the upgrade tests working. They are pretty crazy due to the stateful API connections that make it quite difficult to send an RPC that changes the encoding/decoding scheme, since they can't really be on version 1 (since they crash after changeover as soon as they see an event) nor version 2 (since they crash trying to init with an old types.json). You can try to blend the types.json from both versions (we do this) but you'll still get truly conflicting decoding schemes. It's just a mess so we actually mostly try to disconnect the APIs and reconnect them after the change. It's a bit flakey but it works somewhat okay.

With this strategy, we fix the previous upgrade scenarios and we add an m8 -> m9 scenario.

We were unable to get into the state seen on test-net (not sure how to repro), and thus we still don't have full confidence this upgrade will fix the issue, but we see no reason that it should specifically break it, either.