### PR TITLE
wip MATIC/Polygon integration testing

### DIFF
--- a/integration/__tests__/matic_scen.js
+++ b/integration/__tests__/matic_scen.js
@@ -1,0 +1,17 @@
+const { buildScenarios } = require('../util/scenario');
+
+let lock_scen_info = {
+    tokens: [
+        { token: 'usdc', balances: { ashley: 1000 } }
+    ],
+    validators: ['alice', 'bob']
+};
+
+buildScenarios('Matic', lock_scen_info, [
+    {
+        name: 'Matic',
+        scenario: async ({ ashley, usdc, chain }) => {
+            expect(true);
+        }
+    },
+]);

--- a/integration/jest.config.js
+++ b/integration/jest.config.js
@@ -147,7 +147,8 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: [
-    "**/__tests__/**/*.[jt]s?(x)"
+    "**/__tests__/**/*.[jt]s?(x)",
+    "**/util/test.js"
   ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped

--- a/integration/util/scenario/ctx.js
+++ b/integration/util/scenario/ctx.js
@@ -15,6 +15,7 @@ const { buildTrxReq } = require('./trx_req');
 const { buildChain } = require('./chain');
 const { buildPrices } = require('./prices');
 const { buildVersions } = require('./versions');
+const { buildEthClone } = require('./eth_clone');
 const { buildLogger } = require('./logger');
 const { buildEventTracker } = require('./event_tracker');
 
@@ -300,15 +301,15 @@ async function buildCtx(scenInfo={}) {
   ctx.versions = await buildVersions(scenInfo.versions, ctx);
   ctx.eth = await buildEth(scenInfo.eth_opts, ctx);
 
-  // Note: `3` below is the number of transactions we expect to occur between now and when
+  // Note: `4` below is the number of transactions we expect to occur between now and when
   //       the Starport token is deployed.
   //       That's now: deploy Proxy Admin (1), Cash Token Impl (2), Starport Impl (3), Proxy (4)
   let starportAddress = await ctx.eth.getNextContractAddress(4);
-
   ctx.cashToken = await buildCashToken(scenInfo.cash_token, ctx, starportAddress);
-  ctx.starport = await buildStarport(scenInfo.starport, scenInfo.validators, ctx);
+  ctx.starport = await buildStarport(scenInfo.starport, scenInfo.validators, ctx, ctx.cashToken.ethAddress());
   ctx.actors = await buildActors(scenInfo.actors, scenInfo.default_actor, ctx);
   ctx.tokens = await buildTokens(scenInfo.tokens, scenInfo, ctx);
+  ctx.matic = await buildEthClone(ctx, scenInfo);
   ctx.chainSpec = await buildChainSpec(scenInfo.chain_spec, scenInfo.validators, scenInfo.tokens, ctx);
   ctx.prices = await buildPrices(scenInfo.prices, scenInfo.tokens, ctx);
   ctx.validators = await buildValidators(scenInfo.validators, ctx);

--- a/integration/util/scenario/eth_clone.js
+++ b/integration/util/scenario/eth_clone.js
@@ -1,0 +1,29 @@
+const { buildCashToken } = require('./cash_token');
+const { buildStarport } = require('./starport');
+const { buildTokens } = require('./token');
+
+class EthClone {
+    constructor(tokens, cashToken, starport) {
+        this.tokens = tokens;
+        this.cashToken = cashToken;
+        this.starport = starport;
+    }
+}
+
+
+async function buildEthClone(ctx, scenInfo) {
+    // Note: `4` below is the number of transactions we expect to occur between now and when
+    //       the Starport token is deployed.
+    //       That's now: deploy Proxy Admin (1), Cash Token Impl (2), Starport Impl (3), Proxy (4)
+    let starportAddress = await ctx.eth.getNextContractAddress(4);
+    const cashToken = await buildCashToken(scenInfo.cash_token, ctx, starportAddress);
+    const starport = await buildStarport(scenInfo.starport, scenInfo.validators, ctx, cashToken.ethAddress());
+    const tokens = await buildTokens(scenInfo.tokens, scenInfo, ctx);
+
+    return new EthClone(tokens, cashToken, starport );
+}
+
+module.exports = {
+    buildEthClone,
+    EthClone
+};

--- a/integration/util/scenario/starport.js
+++ b/integration/util/scenario/starport.js
@@ -165,7 +165,7 @@ class Starport {
   }
 }
 
-async function buildStarport(starportInfo, validatorsInfoHash, ctx) {
+async function buildStarport(starportInfo, validatorsInfoHash, ctx, cashTokenAddress) {
   ctx.log("Deploying Starport...");
   if (!ctx.cashToken) {
     throw new Error(`Cannot deploy Starport without first deploying Cash Token`);
@@ -175,7 +175,7 @@ async function buildStarport(starportInfo, validatorsInfoHash, ctx) {
 
   // Deploy Proxies and Starport
   let proxyAdmin = ctx.cashToken.proxyAdmin;
-  let starportImpl = await ctx.eth.__deploy('Starport', [ctx.cashToken.ethAddress(), ctx.eth.root()]);
+  let starportImpl = await ctx.eth.__deploy('Starport', [cashTokenAddress, ctx.eth.root()]);
   let proxy = await ctx.eth.__deploy('TransparentUpgradeableProxy', [
     starportImpl._address,
     proxyAdmin._address,

--- a/integration/util/scenario/token.js
+++ b/integration/util/scenario/token.js
@@ -319,7 +319,7 @@ async function buildToken(ticker, tokenInfo, ctx) {
 
 async function getTokensInfo(tokensInfoHash, ctx) {
   return await instantiateInfo(tokensInfoHash, 'Token', 'token', tokenInfoMap(ctx));
-};
+}
 
 async function buildTokens(tokensInfoHash, scenInfo, ctx) {
   ctx.log("Deploying Erc20 Tokens...");


### PR DESCRIPTION
Note: change the base branch back to develop when we are ready. This is just to show the diff better.

This testing approach uses the same ganache instance and the same contract code but we deploy two of everything. This allows us to simulate being on a different EVM compatible blockchain. The same actors / owners are used but this should not really cause any problem.  The one open question that I have is around how we want to handle token balances. Right now, the token balance is set on both matching tokens so given this code:

```
let lock_scen_info = {
    tokens: [
        { token: 'usdc', balances: { ashley: 1000 } }
    ],
    validators: ['alice', 'bob']
};
```

The ashley address will have 1000 usdc on both chains. That is not ideal but it is now a question of how we want to paramaterize this configuration to say where the balance reside. We could do something like an optional dict with default as in what is above is valid and will default to the ethereum chain and if you want something on a different chain you have to specify the chain name as below

```
let lock_scen_info = {
    tokens: [
        { token: 'usdc', balances: { ashley: {'matic': 1000} } }
    ],
    validators: ['alice', 'bob']
};
```

I admit that this would be preferable 


```
let lock_scen_info = {
    tokens: [
        { chain: 'matic', token: 'usdc', balances: { ashley: {'matic': 1000} } }
    ],
    validators: ['alice', 'bob']
};
```

but that would somehow seem to indicate that the entire token should _only_ exist on that chain which I dont _think_ we want. Perhaps it is something like 


```
let lock_scen_info = {
    tokens: [
        { chains: ['eth','matic'], token: 'usdc', balances: { ashley: {'matic': 1000} } }
    ],
    validators: ['alice', 'bob']
};
```

still a work in progress