### PR TITLE
m9, The Lesser

### DIFF
--- a/ethereum-client/src/lib.rs
+++ b/ethereum-client/src/lib.rs
@@ -13,6 +13,18 @@ use our_std::RuntimeDebug;
 use serde::Deserialize;
 use sp_runtime::offchain::{http, Duration};
 
+pub type EthereumBlockNumber = u64;
+
+pub type EthereumHash = [u8; 32];
+
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+pub struct EthereumBlock {
+    pub hash: EthereumHash,
+    pub parent_hash: EthereumHash,
+    pub number: EthereumBlockNumber,
+    pub events: Vec<EthereumEvent>,
+}
+
 #[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
 pub enum EthereumClientError {
     HttpIoError,

--- a/pallets/cash/src/chains.rs
+++ b/pallets/cash/src/chains.rs
@@ -222,6 +222,13 @@ impl ChainAccountSignature {
     }
 }
 
+/// Type for describing a block coming from an underlying chain.
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
+pub enum ChainBlock {
+    Reserved,
+    Eth(ethereum_client::EthereumBlock),
+}
+
 /// Type for an hash tied to a chain.
 #[derive(Copy, Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
 pub enum ChainHash {

--- a/pallets/cash/src/internal/validate_trx.rs
+++ b/pallets/cash/src/internal/validate_trx.rs
@@ -108,6 +108,22 @@ pub fn validate_unsigned<T: Config>(
             .and_provides("cull_notices")
             .propagate(false)
             .build()),
+        Call::set_starport(starport) => {
+            Ok(ValidTransaction::with_tag_prefix("Gateway::set_starport")
+                .priority(100)
+                .longevity(32)
+                .and_provides(starport)
+                .propagate(true)
+                .build())
+        }
+        Call::set_genesis_block(chain_id, genesis_block) => Ok(ValidTransaction::with_tag_prefix(
+            "Gateway::set_genesis_block",
+        )
+        .priority(100)
+        .longevity(32)
+        .and_provides((chain_id, genesis_block))
+        .propagate(true)
+        .build()),
         _ => Err(ValidationError::InvalidCall),
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -121,7 +121,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("gateway"),
     impl_name: create_runtime_str!("gateway"),
     authoring_version: 1,
-    spec_version: 8,
+    spec_version: 9,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/types.json
+++ b/types.json
@@ -460,5 +460,19 @@
     "balance": "String",
     "cash_yield": "String",
     "price": "String"
-  }
+  },
+  "ChainBlock": {
+    "_enum": {
+      "Reserved": "",
+      "Eth": "EthereumBlock"
+    }
+  },
+  "EthereumBlock": {
+    "hash": "EthereumHash",
+    "parent_hash": "EthereumHash",
+    "number": "EthereumBlockNumber",
+    "events": "Vec<EthereumEvent>"
+  },
+  "EthereumBlockNumber": "u64",
+  "EthereumHash": "[u8; 32]"
 }


### PR DESCRIPTION
This patch adds storage that will be used in m10. We allow setters to set the values so that we can ensure test-net has the proper values by the time it upgrades to m10. We do nothing more.