### PR TITLE
refactor testing code to support multiple L1s

### DIFF
--- a/integration/__tests__/matic_scen.js
+++ b/integration/__tests__/matic_scen.js
@@ -1,0 +1,30 @@
+const { buildScenarios } = require('../util/scenario');
+const { getNotice } = require('../util/substrate');
+
+let lock_scen_info = {
+    tokens: [
+        { token: 'usdc', balances: { ashley: 1000 } },
+        { token: 'maticZrx', balances: { darlene: 1000 } }
+    ],
+    validators: ['alice', 'bob'],
+    actors: ['ashley', 'darlene'],
+    chain_opts: {
+        matic: {
+            name: 'matic',
+            provider: 'ganache', // [env=PROVIDER]
+            ganache: {
+                opts: {},
+                web3_port: null
+            },
+        },
+    },
+};
+
+buildScenarios('Matic', lock_scen_info, [
+    {
+        name: 'Matic',
+        scenario: async ({ darlene, maticZrx }) => {
+            await darlene.lock(1000, maticZrx);
+        }
+    },
+]);

--- a/integration/util/scenario/deployment.js
+++ b/integration/util/scenario/deployment.js
@@ -1,0 +1,56 @@
+
+const { buildCashToken } = require('./cash_token');
+const { buildStarport } = require('./starport');
+
+class Deployment {
+    constructor(starport, cashToken, chain, ctx) {
+        this.starport = starport;
+        this.cashToken = cashToken;
+        this.chain = chain;
+        this.name = `${chain.name}Deployment`
+        this.ctx = ctx;
+    }
+}
+
+class Deployments {
+    constructor(deployments, ctx) {
+        this.deployments = deployments;
+        this.ctx = ctx;
+    }
+
+    all() {
+        return this.deployments;
+    }
+
+    starports() {
+        return this.deployments.map(deployment => deployment.starport)
+    }
+
+    cashTokens() {
+        return this.deployments.map(deployment => deployment.cashToken)
+    }
+}
+
+async function buildDeployment(scenInfo, chain, ctx) {
+    // Note: `3` below is the number of transactions we expect to occur between now and when
+    //       the Starport token is deployed.
+    //       That's now: deploy Proxy Admin (1), Cash Token Impl (2), Starport Impl (3), Proxy (4)
+    let starportAddress = await chain.getNextContractAddress(4);
+    const cashToken = await buildCashToken(scenInfo.cash_token, ctx, starportAddress, chain);
+    const starport = await buildStarport(scenInfo.starport, scenInfo.validators, ctx, chain, cashToken);
+
+    return new Deployment(starport, cashToken, chain, ctx);
+}
+
+async function buildDeployments(scenInfo, ctx) {
+    const deployments = await Promise.all(
+        ctx.chains.all()
+        .map(chain => buildDeployment(scenInfo, chain, ctx))
+    );
+
+
+    return new Deployments(deployments, ctx);
+}
+module.exports = {
+    buildDeployments
+};

--- a/integration/util/scenario/scen_info.js
+++ b/integration/util/scenario/scen_info.js
@@ -1,10 +1,13 @@
 
 const baseScenInfo = {
-  eth_opts: {
-    provider: 'ganache', // [env=PROVIDER]
-    ganache: {
-      opts: {},
-      web3_port: null
+  chain_opts: {
+    eth: {
+      name: 'eth',
+      provider: 'ganache', // [env=PROVIDER]
+      ganache: {
+        opts: {},
+        web3_port: null
+      },
     },
   },
   default_actor: null,

--- a/integration/util/scenario/token.js
+++ b/integration/util/scenario/token.js
@@ -4,7 +4,7 @@ const { lookupBy } = require('../util');
 const { descale } = require('../substrate');
 
 class Token {
-  constructor(ticker, symbol, name, decimals, priceTicker, liquidityFactor, token, owner, ctx) {
+  constructor(ticker, symbol, name, decimals, priceTicker, liquidityFactor, token, owner, chainName, ctx) {
     this.ticker = ticker;
     this.symbol = symbol;
     this.name = name;
@@ -13,7 +13,12 @@ class Token {
     this.liquidityFactor = liquidityFactor;
     this.token = token;
     this.owner = owner;
+    this.chainName = chainName;
     this.ctx = ctx;
+  }
+
+  chain() {
+    return this.ctx.chains.find(this.chainName);
   }
 
   ethAddress() {
@@ -70,10 +75,11 @@ class Token {
   }
 
   async setSupplyCap(tokenAmount) {
-    if (!this.ctx.starport) {
+    const chain = this.chain();
+    if (!chain || !chain.starport) {
       throw new Error(`Ctx: starport must be set before using set supply cap`);
     }
-    this.ctx.starport.setSupplyCap(this, tokenAmount);
+    chain.starport.setSupplyCap(this, tokenAmount);
   }
 
   async transfer(fromLookup, toLookup, tokenAmount) {
@@ -158,7 +164,7 @@ class Token {
 
 class EtherToken extends Token {
   constructor(liquidityFactor, ctx) {
-    super('ether', 'ETH', 'Ether', 18, 'ETH', liquidityFactor, null, null, ctx);
+    super('ether', 'ETH', 'Ether', 18, 'ETH', liquidityFactor, null, null, 'eth', ctx);
   }
 
   ethAddress() {
@@ -205,6 +211,16 @@ function tokenInfoMap(ctx) {
 
   return {
     zrx: {
+      chain: 'eth',
+      build: 'zrx.json',
+      contract: 'ZRXToken',
+      decimals: 18,
+      constructor_args: [],
+      supply_cap: 1000000,
+      liquidity_factor: 0.5,
+    },
+    maticZrx: {
+      chain: 'matic',
       build: 'zrx.json',
       contract: 'ZRXToken',
       decimals: 18,
@@ -213,6 +229,7 @@ function tokenInfoMap(ctx) {
       liquidity_factor: 0.5,
     },
     dai: {
+      chain: 'eth',
       build: 'dai.json',
       contract: 'Dai',
       decimals: 18,
@@ -221,6 +238,7 @@ function tokenInfoMap(ctx) {
       liquidity_factor: 0.8,
     },
     comp: {
+      chain: 'eth',
       build: 'compound.json',
       contract: 'Comp',
       decimals: 18,
@@ -229,6 +247,7 @@ function tokenInfoMap(ctx) {
       liquidity_factor: 0.75,
     },
     bat: {
+      chain: 'eth',
       build: 'bat.json',
       contract: 'BAToken',
       decimals: 18,
@@ -237,6 +256,7 @@ function tokenInfoMap(ctx) {
       liquidity_factor: 0.3,
     },
     wbtc: {
+      chain: 'eth',
       build: 'wbtc.json',
       contract: 'WBTC',
       decimals: 8,
@@ -246,6 +266,7 @@ function tokenInfoMap(ctx) {
       price_ticker: 'BTC',
     },
     usdc: {
+      chain: 'eth',
       build: 'FiatTokenV1.json',
       contract: 'FiatTokenV1',
       decimals: 6,
@@ -269,6 +290,7 @@ function tokenInfoMap(ctx) {
       }
     },
     fee: {
+      chain: 'eth',
       build: 'contracts.json',
       contract: 'FeeToken',
       decimals: 6,
@@ -289,10 +311,14 @@ function undec(tokenAmount, decimals) {
 }
 
 async function buildToken(ticker, tokenInfo, ctx) {
-  ctx.log(`Deploying ${ticker}...`);
+  ctx.log(`Deploying ${ticker} to ${tokenInfo.chain}...`);
+  const chain = ctx.chains.find(tokenInfo.chain);
+  if(!chain) {
+    throw new Error(`while initializing ${ticker} chain not found ${tokenInfo.chain}`)
+  }
 
-  let owner = ctx.eth.defaultFrom;
-  let tokenContract = await ctx.eth.__deployFull(ctx.__getContractsFile(tokenInfo.build), tokenInfo.contract, tokenInfo.constructor_args, { from: owner });
+  let owner = chain.defaultFrom;
+  let tokenContract = await chain.__deployFull(ctx.__getContractsFile(tokenInfo.build), tokenInfo.contract, tokenInfo.constructor_args, { from: owner });
   if (typeof (tokenInfo.afterDeploy) === 'function') {
     await tokenInfo.afterDeploy(tokenContract, owner);
   }
@@ -301,7 +327,7 @@ async function buildToken(ticker, tokenInfo, ctx) {
   let decimals = Number(await tokenContract.methods.decimals().call());
   let priceTicker = tokenInfo.price_ticker || symbol;
   let liquidityFactor = tokenInfo.liquidity_factor;
-  let token = new Token(ticker, symbol, name, decimals, priceTicker, liquidityFactor, tokenContract, owner, ctx);
+  let token = new Token(ticker, symbol, name, decimals, priceTicker, liquidityFactor, tokenContract, owner, tokenInfo.chain, ctx);
 
   if (tokenInfo.balances) {
     await Object.entries(tokenInfo.balances).reduce(async (acc, [actor, amount]) => {
@@ -319,7 +345,7 @@ async function buildToken(ticker, tokenInfo, ctx) {
 
 async function getTokensInfo(tokensInfoHash, ctx) {
   return await instantiateInfo(tokensInfoHash, 'Token', 'token', tokenInfoMap(ctx));
-};
+}
 
 async function buildTokens(tokensInfoHash, scenInfo, ctx) {
   ctx.log("Deploying Erc20 Tokens...");


### PR DESCRIPTION
* includes new `deployments` that packages starport and cashToken together due to their circular dependence
* uses existing patterns to strap ethStarport, ethCashToken on as well as supporting the old `starport` and `cashToken` properties
* should be able to include a new `matic` key in the `chain_opts` to support matic