### PR TITLE
Cargo audit fixes

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -4,9 +4,18 @@ on: push
 # rustc version set with `rustup default` command in scripts/get_substrate.sh
 
 jobs:
+  cargo-audit:
+    name: Cargo Audit Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   cargo-format:
     name: Cargo Format Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -20,7 +29,7 @@ jobs:
 
   substrate-tests:
     name: Substrate Unit Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       # - uses: actions/cache@v2
@@ -74,7 +83,7 @@ jobs:
 
   substrate-coverage:
     name: Substrate Coverage
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       # - uses: actions/cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,9 +500,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "beef"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474a626a67200bd107d44179bb3d4fc61891172d11696609264589be6a0e6a43"
+checksum = "6736e2428df2ca2848d846c43e88745121a6654696e349ce0054a420815a7409"
 
 [[package]]
 name = "bincode"
@@ -1505,6 +1505,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
 name = "dyn-clonable"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1943,7 +1949,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "parity-scale-codec 2.1.1",
 ]
@@ -1961,7 +1967,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "3.1.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1980,7 +1986,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "Inflector",
  "chrono",
@@ -2003,7 +2009,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2018,7 +2024,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "13.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "parity-scale-codec 2.1.1",
  "serde",
@@ -2029,13 +2035,14 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "bitflags",
  "frame-metadata",
  "frame-support-procedural",
  "impl-trait-for-tuples",
  "log 0.4.14",
+ "max-encoded-len",
  "once_cell",
  "parity-scale-codec 2.1.1",
  "paste",
@@ -2055,7 +2062,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -2067,7 +2074,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.0.0",
@@ -2079,7 +2086,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
@@ -2089,7 +2096,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -2106,7 +2113,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2120,7 +2127,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "parity-scale-codec 2.1.1",
  "sp-api",
@@ -3998,18 +4005,18 @@ dependencies = [
 
 [[package]]
 name = "logos"
-version = "0.11.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91c49573597a5d6c094f9031617bb1fed15c0db68c81e6546d313414ce107e4"
+checksum = "427e2abca5be13136da9afdbf874e6b34ad9001dd70f2b103b083a85daa7b345"
 dependencies = [
  "logos-derive",
 ]
 
 [[package]]
 name = "logos-derive"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797b1f8a0571b331c1b47e7db245af3dc634838da7a92b3bef4e30376ae1c347"
+checksum = "56a7d287fd2ac3f75b11f19a1c8a874a7d55744bd91f7a1b3e7cf87d4343c36d"
 dependencies = [
  "beef",
  "fnv",
@@ -4090,6 +4097,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a8a15b776d9dfaecd44b03c5828c2199cddff5247215858aac14624f8d6b741"
 dependencies = [
  "rawpointer",
+]
+
+[[package]]
+name = "max-encoded-len"
+version = "3.0.0"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
+dependencies = [
+ "impl-trait-for-tuples",
+ "max-encoded-len-derive",
+ "parity-scale-codec 2.1.1",
+ "primitive-types 0.9.0",
+]
+
+[[package]]
+name = "max-encoded-len-derive"
+version = "3.0.0"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
+dependencies = [
+ "proc-macro-crate 1.0.0",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -4696,7 +4725,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4712,14 +4741,13 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec 2.1.1",
  "sp-authorship",
- "sp-inherents",
  "sp-runtime",
  "sp-std",
 ]
@@ -4727,7 +4755,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4751,6 +4779,7 @@ dependencies = [
 name = "pallet-cash"
 version = "1.0.0"
 dependencies = [
+ "async-trait",
  "env_logger 0.8.3",
  "ethabi 12.0.0",
  "ethereum-client",
@@ -4799,8 +4828,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-grandpa"
-version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+version = "3.1.0"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4812,6 +4841,7 @@ dependencies = [
  "sp-application-crypto",
  "sp-core",
  "sp-finality-grandpa",
+ "sp-io",
  "sp-runtime",
  "sp-session",
  "sp-staking",
@@ -4822,6 +4852,7 @@ dependencies = [
 name = "pallet-oracle"
 version = "1.0.0"
 dependencies = [
+ "async-trait",
  "ethabi 12.0.0",
  "ethereum-client",
  "ethereum-types 0.11.0",
@@ -4854,7 +4885,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4867,7 +4898,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4886,7 +4917,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5036,9 +5067,9 @@ dependencies = [
 
 [[package]]
 name = "parity-wasm"
-version = "0.41.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
+checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
 
 [[package]]
 name = "parity-ws"
@@ -5560,13 +5591,13 @@ dependencies = [
 
 [[package]]
 name = "pwasm-utils"
-version = "0.14.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f53bc2558e8376358ebdc28301546471d67336584f6438ed4b7c7457a055fd7"
+checksum = "a0e517f47d9964362883182404b68d0b6949382c0baa40aa5ffca94f5f1e3481"
 dependencies = [
  "byteorder",
  "log 0.4.14",
- "parity-wasm 0.41.0",
+ "parity-wasm 0.42.2",
 ]
 
 [[package]]
@@ -6275,7 +6306,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "futures 0.3.15",
  "futures-timer 3.0.2",
@@ -6298,7 +6329,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "parity-scale-codec 2.1.1",
  "sc-client-api",
@@ -6314,7 +6345,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec 2.1.1",
@@ -6335,7 +6366,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2 1.0.27",
@@ -6346,7 +6377,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "chrono",
  "fdlimit",
@@ -6384,7 +6415,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "derive_more",
  "fnv",
@@ -6418,7 +6449,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -6448,7 +6479,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "parking_lot 0.11.1",
  "sc-client-api",
@@ -6460,7 +6491,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -6484,7 +6515,6 @@ dependencies = [
  "sp-io",
  "sp-keystore",
  "sp-runtime",
- "sp-timestamp",
  "sp-version",
  "substrate-prometheus-endpoint",
 ]
@@ -6492,7 +6522,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -6530,7 +6560,6 @@ dependencies = [
  "sp-io",
  "sp-keystore",
  "sp-runtime",
- "sp-timestamp",
  "sp-utils",
  "sp-version",
  "substrate-prometheus-endpoint",
@@ -6539,7 +6568,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "fork-tree",
  "parity-scale-codec 2.1.1",
@@ -6552,11 +6581,12 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "async-trait",
  "futures 0.3.15",
  "futures-timer 3.0.2",
+ "impl-trait-for-tuples",
  "log 0.4.14",
  "parity-scale-codec 2.1.1",
  "sc-client-api",
@@ -6579,28 +6609,25 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
- "log 0.4.14",
  "sc-client-api",
  "sp-authorship",
- "sp-consensus",
- "sp-core",
- "sp-inherents",
  "sp-runtime",
+ "thiserror",
 ]
 
 [[package]]
 name = "sc-executor"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "derive_more",
  "lazy_static",
  "libsecp256k1",
  "log 0.4.14",
  "parity-scale-codec 2.1.1",
- "parity-wasm 0.41.0",
+ "parity-wasm 0.42.2",
  "parking_lot 0.11.1",
  "sc-executor-common",
  "sc-executor-wasmi",
@@ -6609,7 +6636,6 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-io",
- "sp-maybe-compressed-blob",
  "sp-panic-handler",
  "sp-runtime-interface",
  "sp-serializer",
@@ -6623,14 +6649,14 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "derive_more",
  "parity-scale-codec 2.1.1",
- "parity-wasm 0.41.0",
  "pwasm-utils",
  "sp-allocator",
  "sp-core",
+ "sp-maybe-compressed-blob",
  "sp-serializer",
  "sp-wasm-interface",
  "thiserror",
@@ -6640,7 +6666,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "log 0.4.14",
  "parity-scale-codec 2.1.1",
@@ -6655,12 +6681,11 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "log 0.4.14",
  "parity-scale-codec 2.1.1",
- "parity-wasm 0.41.0",
- "pwasm-utils",
+ "parity-wasm 0.42.2",
  "sc-executor-common",
  "scoped-tls",
  "sp-allocator",
@@ -6673,7 +6698,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -6708,12 +6733,13 @@ dependencies = [
  "sp-runtime",
  "sp-utils",
  "substrate-prometheus-endpoint",
+ "wasm-timer",
 ]
 
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -6737,10 +6763,11 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.15",
+ "futures-timer 3.0.2",
  "log 0.4.14",
  "parity-util-mem",
  "sc-client-api",
@@ -6748,14 +6775,13 @@ dependencies = [
  "sp-blockchain",
  "sp-runtime",
  "sp-transaction-pool",
- "sp-utils",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sc-keystore"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -6775,7 +6801,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -6794,7 +6820,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "async-std",
  "async-trait",
@@ -6847,7 +6873,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "futures 0.3.15",
  "futures-timer 3.0.2",
@@ -6864,7 +6890,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -6892,7 +6918,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "futures 0.3.15",
  "libp2p",
@@ -6905,7 +6931,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "log 0.4.14",
  "substrate-prometheus-endpoint",
@@ -6914,7 +6940,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "futures 0.3.15",
  "hash-db",
@@ -6940,6 +6966,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-state-machine",
+ "sp-tracing",
  "sp-transaction-pool",
  "sp-utils",
  "sp-version",
@@ -6948,7 +6975,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "derive_more",
  "futures 0.3.15",
@@ -6965,6 +6992,7 @@ dependencies = [
  "sp-core",
  "sp-rpc",
  "sp-runtime",
+ "sp-tracing",
  "sp-transaction-pool",
  "sp-version",
 ]
@@ -6972,7 +7000,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "futures 0.1.31",
  "jsonrpc-core",
@@ -6990,7 +7018,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "async-trait",
  "directories",
@@ -7054,7 +7082,7 @@ dependencies = [
 [[package]]
 name = "sc-service-test"
 version = "2.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "fdlimit",
  "futures 0.1.31",
@@ -7091,7 +7119,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "log 0.4.14",
  "parity-scale-codec 2.1.1",
@@ -7106,7 +7134,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -7126,7 +7154,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "chrono",
  "futures 0.3.15",
@@ -7146,7 +7174,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -7157,23 +7185,33 @@ dependencies = [
  "parking_lot 0.11.1",
  "regex",
  "rustc-hash",
+ "sc-client-api",
+ "sc-rpc-server",
+ "sc-telemetry",
  "sc-tracing-proc-macro",
  "serde",
  "serde_json",
+ "sp-api",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-core",
+ "sp-rpc",
+ "sp-runtime",
+ "sp-storage",
  "sp-tracing",
  "thiserror",
  "tracing",
- "tracing-core",
  "tracing-log",
  "tracing-subscriber",
  "wasm-bindgen",
+ "wasm-timer",
  "web-sys",
 ]
 
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2 1.0.27",
@@ -7184,7 +7222,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "derive_more",
  "futures 0.3.15",
@@ -7206,7 +7244,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "futures 0.3.15",
  "futures-diagnose",
@@ -7579,6 +7617,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
+name = "slog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
+dependencies = [
+ "erased-serde",
+]
+
+[[package]]
 name = "smallvec"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7651,7 +7698,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "log 0.4.14",
  "sp-core",
@@ -7663,7 +7710,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "hash-db",
  "log 0.4.14",
@@ -7680,7 +7727,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate 1.0.0",
@@ -7692,8 +7739,9 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
+ "max-encoded-len",
  "parity-scale-codec 2.1.1",
  "serde",
  "sp-core",
@@ -7704,7 +7752,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -7718,8 +7766,9 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
+ "async-trait",
  "parity-scale-codec 2.1.1",
  "sp-inherents",
  "sp-runtime",
@@ -7729,7 +7778,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "parity-scale-codec 2.1.1",
  "sp-api",
@@ -7741,7 +7790,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "futures 0.3.15",
  "log 0.4.14",
@@ -7759,7 +7808,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "serde",
  "serde_json",
@@ -7768,7 +7817,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "async-trait",
  "futures 0.3.15",
@@ -7795,8 +7844,9 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
+ "async-trait",
  "parity-scale-codec 2.1.1",
  "sp-api",
  "sp-application-crypto",
@@ -7811,8 +7861,9 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
+ "async-trait",
  "merlin",
  "parity-scale-codec 2.1.1",
  "serde",
@@ -7832,7 +7883,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "parity-scale-codec 2.1.1",
  "sp-arithmetic",
@@ -7842,7 +7893,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "parity-scale-codec 2.1.1",
  "schnorrkel",
@@ -7854,7 +7905,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -7869,6 +7920,7 @@ dependencies = [
  "lazy_static",
  "libsecp256k1",
  "log 0.4.14",
+ "max-encoded-len",
  "merlin",
  "num-traits",
  "parity-scale-codec 2.1.1",
@@ -7898,7 +7950,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "kvdb",
  "parking_lot 0.11.1",
@@ -7907,7 +7959,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
@@ -7917,7 +7969,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "environmental",
  "parity-scale-codec 2.1.1",
@@ -7928,7 +7980,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "finality-grandpa",
  "log 0.4.14",
@@ -7945,11 +7997,13 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
+ "async-trait",
+ "impl-trait-for-tuples",
  "parity-scale-codec 2.1.1",
- "parking_lot 0.11.1",
  "sp-core",
+ "sp-runtime",
  "sp-std",
  "thiserror",
 ]
@@ -7957,7 +8011,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "futures 0.3.15",
  "hash-db",
@@ -7968,6 +8022,7 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-keystore",
+ "sp-maybe-compressed-blob",
  "sp-runtime-interface",
  "sp-state-machine",
  "sp-std",
@@ -7981,7 +8036,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -7992,7 +8047,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8009,7 +8064,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "ruzstd",
  "zstd",
@@ -8018,7 +8073,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -8028,7 +8083,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "backtrace",
 ]
@@ -8036,21 +8091,24 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
+ "rustc-hash",
  "serde",
  "sp-core",
+ "tracing-core",
 ]
 
 [[package]]
 name = "sp-runtime"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "either",
  "hash256-std-hasher",
  "impl-trait-for-tuples",
  "log 0.4.14",
+ "max-encoded-len",
  "parity-scale-codec 2.1.1",
  "parity-util-mem",
  "paste",
@@ -8066,7 +8124,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec 2.1.1",
@@ -8083,7 +8141,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.0.0",
@@ -8095,7 +8153,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "serde",
  "serde_json",
@@ -8104,7 +8162,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "parity-scale-codec 2.1.1",
  "sp-api",
@@ -8117,7 +8175,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "parity-scale-codec 2.1.1",
  "sp-runtime",
@@ -8127,7 +8185,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "hash-db",
  "log 0.4.14",
@@ -8142,6 +8200,7 @@ dependencies = [
  "sp-std",
  "sp-trie",
  "thiserror",
+ "tracing",
  "trie-db",
  "trie-root",
 ]
@@ -8149,12 +8208,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 
 [[package]]
 name = "sp-storage"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "impl-serde 0.3.1",
  "parity-scale-codec 2.1.1",
@@ -8167,7 +8226,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "log 0.4.14",
  "sp-core",
@@ -8180,23 +8239,32 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
+ "async-trait",
+ "futures-timer 3.0.2",
+ "log 0.4.14",
  "parity-scale-codec 2.1.1",
  "sp-api",
  "sp-inherents",
  "sp-runtime",
  "sp-std",
+ "thiserror",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sp-tracing"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
+ "erased-serde",
  "log 0.4.14",
  "parity-scale-codec 2.1.1",
+ "parking_lot 0.10.2",
+ "serde",
+ "serde_json",
+ "slog",
  "sp-std",
  "tracing",
  "tracing-core",
@@ -8206,7 +8274,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "derive_more",
  "futures 0.3.15",
@@ -8222,7 +8290,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -8236,7 +8304,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "futures 0.3.15",
  "futures-core",
@@ -8248,19 +8316,32 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "impl-serde 0.3.1",
  "parity-scale-codec 2.1.1",
  "serde",
  "sp-runtime",
  "sp-std",
+ "sp-version-proc-macro",
+]
+
+[[package]]
+name = "sp-version-proc-macro"
+version = "3.0.0"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
+dependencies = [
+ "parity-scale-codec 2.1.1",
+ "proc-macro-crate 1.0.0",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.72",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec 2.1.1",
@@ -8446,7 +8527,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "platforms",
 ]
@@ -8454,7 +8535,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "3.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.15",
@@ -8477,7 +8558,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.9.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "async-std",
  "derive_more",
@@ -8491,7 +8572,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "async-trait",
  "futures 0.1.31",
@@ -8520,7 +8601,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "cfg-if 1.0.0",
  "frame-support",
@@ -8561,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "futures 0.3.15",
  "parity-scale-codec 2.1.1",
@@ -8582,7 +8663,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "4.0.0"
-source = "git+https://github.com/compound-finance/substrate?branch=compound#cbb1f1f3695ab548010f11ed286ef4e78a55105d"
+source = "git+https://github.com/compound-finance/substrate?branch=jflatow/compound#2e62c6896a7e2a661366e0c10d525304fff80344"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -9703,25 +9784,26 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.6.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf617d864d25af3587aa745529f7aaa541066c876d57e050c0d0c85c61c92aff"
+checksum = "d2ee05bba3d1d994652079893941a2ef9324d2b58a63c31b40678fb7eddd7a5a"
 dependencies = [
+ "downcast-rs",
  "libc",
  "memory_units",
  "num-rational 0.2.4",
  "num-traits",
- "parity-wasm 0.41.0",
+ "parity-wasm 0.42.2",
  "wasmi-validation",
 ]
 
 [[package]]
 name = "wasmi-validation"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea78c597064ba73596099281e2f4cfc019075122a65cdda3205af94f0b264d93"
+checksum = "a2eb8e860796d8be48efef530b60eebf84e74a88bce107374fffb0da97d504b8"
 dependencies = [
- "parity-wasm 0.41.0",
+ "parity-wasm 0.42.2",
 ]
 
 [[package]]

--- a/ethereum-client/Cargo.toml
+++ b/ethereum-client/Cargo.toml
@@ -15,12 +15,12 @@ hex-buffer-serde = { version = "0.3.0", default-features = false, features = ['a
 codec = { package = 'parity-scale-codec', version = '2.0.0', default-features = false, features = ['derive'] }
 serde = { version = '1.0.125', features = ['derive'], default-features = false }
 serde_json = { version = '1.0.64', features = ['alloc'], default-features = false }
-frame-support = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-io = { default-features = false, features = ['disable_oom', 'disable_panic_handler'], git = 'https://github.com/compound-finance/substrate', branch = 'compound'}
-sp-core = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-runtime = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-runtime-interface = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-std = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
+frame-support = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-io = { default-features = false, features = ['disable_oom', 'disable_panic_handler'], git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound'}
+sp-core = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-runtime = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-runtime-interface = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-std = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
 
 our-std = { path = '../our-std', default-features = false }
 

--- a/gateway-crypto/Cargo.toml
+++ b/gateway-crypto/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { version = "0.2", optional = true, default-features = false, features =
 bytes = { version = "0.5.0", optional = true }
 der-parser = { version = "5.0.0", optional = true }
 
-sp-core = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
+sp-core = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
 
 our-std = { path = "../our-std", default-features = false }
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -16,7 +16,7 @@ name = 'gateway'
 targets = ['x86_64-unknown-linux-gnu']
 
 [build-dependencies]
-substrate-build-script-utils = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
+substrate-build-script-utils = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
 
 [dependencies]
 hex = "0.4.2"
@@ -32,47 +32,48 @@ serde_json = { version = "1.0.64", features=["alloc"] } # XXX 128 bit also arbit
 wasm-timer = "0.2"
 
 # Substrate dependencies
-frame-support = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-frame-system = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sc-chain-spec = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sc-client-api = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sc-cli = { features = ['wasmtime'], git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sc-client-db = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-core = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sc-consensus = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-consensus = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sc-consensus-aura = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-consensus-aura = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sc-consensus-epochs = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sc-consensus-slots = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sc-finality-grandpa = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sc-finality-grandpa-rpc = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-finality-grandpa = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sc-executor = { features = ['wasmtime'], git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-inherents = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sc-keystore = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-keystore = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sc-network = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-runtime = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sc-service = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sc-telemetry = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sc-transaction-pool = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-transaction-pool = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
+frame-support = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+frame-system = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sc-chain-spec = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sc-client-api = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sc-cli = { features = ['wasmtime'], git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sc-client-db = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-core = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sc-consensus = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-consensus = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sc-consensus-aura = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-consensus-aura = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sc-consensus-epochs = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sc-consensus-slots = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sc-finality-grandpa = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sc-finality-grandpa-rpc = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-finality-grandpa = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sc-executor = { features = ['wasmtime'], git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-inherents = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sc-keystore = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-keystore = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sc-network = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-runtime = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sc-service = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sc-telemetry = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-timestamp = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sc-transaction-pool = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-transaction-pool = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
 
 # These dependencies are used for the node's RPCs
-sc-rpc = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-api = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sc-rpc-api = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-blockchain = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-chain-spec = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-block-builder = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sc-basic-authorship = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sc-sync-state-rpc = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-substrate-frame-rpc-system = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
+sc-rpc = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-api = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sc-rpc-api = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-blockchain = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-chain-spec = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-block-builder = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sc-basic-authorship = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sc-sync-state-rpc = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+substrate-frame-rpc-system = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
 
 # Used only for runtime benchmarking
-frame-benchmarking = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-frame-benchmarking-cli = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound', optional = true }
+frame-benchmarking = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+frame-benchmarking-cli = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound', optional = true }
 
 # Local dependencies
 ethereum-client = { path = '../ethereum-client' }
@@ -89,10 +90,10 @@ types-derive = { path = '../types-derive' }
 [dev-dependencies]
 tempfile = "3.1.0"
 
-sc-consensus-aura = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-keyring = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sc-service-test = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-timestamp = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
+sc-consensus-aura = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-keyring = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sc-service-test = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-timestamp = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
 
 [features]
 default = ['with-parity-db']

--- a/our-std/Cargo.toml
+++ b/our-std/Cargo.toml
@@ -14,8 +14,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 hex = { version = '0.4.2', features = ['alloc'], default-features = false }
 log = { version = '0.4.14' }
 serde = { version = "1.0.125", features = ["derive"] }
-sp-runtime = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-std = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
+sp-runtime = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-std = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
 
 our-std-proc-macro = { path = "./proc-macro" }
 

--- a/pallets/cash/Cargo.toml
+++ b/pallets/cash/Cargo.toml
@@ -15,6 +15,7 @@ targets = ['x86_64-unknown-linux-gnu']
 codec = { package = 'parity-scale-codec', version = '2.0.0', default-features = false, features = ['derive'] }
 serde = { version = '1.0.125', features = ['derive'], default-features = false }
 serde_json = { version = '1.0.64', features=['alloc'], default-features = false}
+async-trait = { version = "0.1.48", optional = true }
 
 num-bigint = { default-features = false, version = '0.3' }
 num-traits = { default-features = false, version = '0.2' }
@@ -28,17 +29,17 @@ hex-literal = {version = '0.3.1', default-features = false}
 libsecp256k1 = { version = '0.3.2', default-features = false, features = ['hmac'] }
 tiny-keccak = { version = '2.0.0', features = ['keccak'], default-features = false }
 
-sp-core = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-io = { default-features = false, features = ['disable_oom', 'disable_panic_handler'], git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-inherents = { default-features = false, git = 'https://github.com/compound-finance/substrate.git', branch = 'compound' }
-sp-runtime = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-std = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound'  }
-sp-tracing = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-frame-benchmarking = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound', optional = true }
-frame-support = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-frame-system = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-pallet-session = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-pallet-timestamp = { default-features = false, git = 'https://github.com/compound-finance/substrate.git', branch = 'compound' }
+sp-core = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-io = { default-features = false, features = ['disable_oom', 'disable_panic_handler'], git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-inherents = { default-features = false, git = 'https://github.com/compound-finance/substrate.git', branch = 'jflatow/compound' }
+sp-runtime = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-std = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound'  }
+sp-tracing = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+frame-benchmarking = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound', optional = true }
+frame-support = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+frame-system = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+pallet-session = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+pallet-timestamp = { default-features = false, git = 'https://github.com/compound-finance/substrate.git', branch = 'jflatow/compound' }
 
 pallet-oracle = { path = '../oracle', default-features = false }
 runtime-interfaces = { path = '../runtime-interfaces', default-features = false }
@@ -51,7 +52,7 @@ types-derive = { path = '../../types-derive' }
 
 [dev-dependencies]
 env_logger = "*"
-frame-benchmarking = { git = 'https://github.com/compound-finance/substrate', branch = 'compound'}
+frame-benchmarking = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound'}
 serial_test = "*"
 test-env-log = "*"
 
@@ -72,6 +73,7 @@ std = [
     'our-std/std',
     'pallet-session/std',
     'pallet-oracle/std',
+    'async-trait',
 ]
 runtime-debug = ['our-std/runtime-debug']
 runtime-benchmarks = ['frame-benchmarking']

--- a/pallets/cash/runtime-api/Cargo.toml
+++ b/pallets/cash/runtime-api/Cargo.toml
@@ -11,8 +11,8 @@ version = '1.0.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [dependencies]
-sp-api = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-runtime = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
+sp-api = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-runtime = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
 
 pallet-cash = { path = '..', default-features = false }
 pallet-oracle = { path = '../../oracle', default-features = false }

--- a/pallets/oracle/Cargo.toml
+++ b/pallets/oracle/Cargo.toml
@@ -15,6 +15,7 @@ targets = ['x86_64-unknown-linux-gnu']
 codec = { package = 'parity-scale-codec', version = '2.0.0', default-features = false, features = ['derive'] }
 serde = { version = '1.0.125', features = ['derive'], default-features = false }
 serde_json = { version = '1.0.64', features=['alloc'], default-features = false}
+async-trait = { version = "0.1.48", optional = true }
 
 num-bigint = { default-features = false, version = '0.3' }
 num-traits = { default-features = false, version = '0.2' }
@@ -28,14 +29,14 @@ hex-literal = {version = '0.3.1', default-features = false}
 libsecp256k1 = { version = '0.3.2', default-features = false, features = ['hmac'] }
 tiny-keccak = { version = '2.0.0', features = ['keccak'], default-features = false }
 
-sp-core = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-io = { default-features = false, features = ['disable_oom', 'disable_panic_handler'], git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-inherents = { default-features = false, git = 'https://github.com/compound-finance/substrate.git', branch = 'compound' }
-sp-runtime = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-frame-support = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-frame-system = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-pallet-session = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-pallet-timestamp = { default-features = false, git = 'https://github.com/compound-finance/substrate.git', branch = 'compound' }
+sp-core = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-io = { default-features = false, features = ['disable_oom', 'disable_panic_handler'], git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-inherents = { default-features = false, git = 'https://github.com/compound-finance/substrate.git', branch = 'jflatow/compound' }
+sp-runtime = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+frame-support = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+frame-system = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+pallet-session = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+pallet-timestamp = { default-features = false, git = 'https://github.com/compound-finance/substrate.git', branch = 'jflatow/compound' }
 
 runtime-interfaces = { path = '../runtime-interfaces', default-features = false }
 ethereum-client = { path = '../../ethereum-client', default-features = false }
@@ -59,5 +60,6 @@ std = [
     'gateway-crypto/std',
     'our-std/std',
     'pallet-session/std',
+    'async-trait',
 ]
 runtime-debug = ['our-std/runtime-debug']

--- a/pallets/runtime-interfaces/Cargo.toml
+++ b/pallets/runtime-interfaces/Cargo.toml
@@ -11,10 +11,10 @@ version = '1.0.0'
 codec = { package = 'parity-scale-codec', version = '2.0.0', default-features = false, features = ['derive'] }
 lazy_static = '1.4.0'
 
-frame-support = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-runtime-interface = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-externalities = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-io = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
+frame-support = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-runtime-interface = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-externalities = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-io = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
 
 ethereum-client = { path = '../../ethereum-client', default-features = false }
 gateway-crypto = { path = "../../gateway-crypto", default-features = false }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,7 +10,7 @@ version = '1.0.0'
 targets = ['x86_64-unknown-linux-gnu']
 
 [build-dependencies]
-substrate-wasm-builder = { git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
+substrate-wasm-builder = { git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
 
 [dependencies]
 codec = { package = 'parity-scale-codec', version = '2.0.0' }
@@ -18,33 +18,33 @@ hex-literal = { version = '0.3.1', optional = true }
 serde = { version = '1.0.125', features = ['derive'], optional = true }
 
 # Substrate dependencies
-frame-executive = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-frame-support = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-frame-system = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-frame-system-rpc-runtime-api = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
+frame-executive = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+frame-support = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+frame-system = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+frame-system-rpc-runtime-api = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
 
-sp-api = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-block-builder = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-consensus-aura = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-core = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-inherents = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-offchain = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-runtime = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-session = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-std = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-transaction-pool = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-sp-version = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
+sp-api = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-block-builder = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-consensus-aura = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-core = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-inherents = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-offchain = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-runtime = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-session = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-std = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-transaction-pool = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+sp-version = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
 
 # Used only for runtime benchmarking
-frame-benchmarking = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound', optional = true }
-frame-system-benchmarking = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound', optional = true }
+frame-benchmarking = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound', optional = true }
+frame-system-benchmarking = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound', optional = true }
 
 # Other pallets
-pallet-aura = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-pallet-grandpa = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-pallet-randomness-collective-flip = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-pallet-timestamp = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
-pallet-session = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'compound' }
+pallet-aura = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+pallet-grandpa = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+pallet-randomness-collective-flip = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+pallet-timestamp = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
+pallet-session = { default-features = false, git = 'https://github.com/compound-finance/substrate', branch = 'jflatow/compound' }
 
 # Local dependencies
 pallet-cash = { path = '../pallets/cash', default-features = false }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -451,10 +451,6 @@ impl_runtime_apis! {
         ) -> sp_inherents::CheckInherentsResult {
             data.check_extrinsics(&block)
         }
-
-        fn random_seed() -> <Block as BlockT>::Hash {
-            RandomnessCollectiveFlip::random_seed().0
-        }
     }
 
     impl sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block> for Runtime {

--- a/trx-request/Cargo.toml
+++ b/trx-request/Cargo.toml
@@ -5,7 +5,7 @@ authors = ['Compound <https://compound.finance>']
 edition = "2018"
 
 [dependencies]
-logos = "0.11.4"
+logos = "0.12"
 hex = "0.4.2"
 
 [features]


### PR DESCRIPTION
Also upgrade substrate again in order to bump deps. This is using another substrate branch so as not to break the one others are using.

Couldn't update cranelift-codegen without starting to break stuff in substrate.