### PR TITLE
Fix PolkadotJS Client

### DIFF
--- a/integration/package.json
+++ b/integration/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "dependencies": {
-    "@polkadot/api": "^4.14.2-4",
+    "@polkadot/api": "^4.14.2-5",
     "chalk": "^4.1.0",
     "ganache-core": "^2.13.2",
     "getopts": "^2.3.0",
@@ -26,6 +26,7 @@
   },
   "resolutions": {
     "solidity-parser-antlr": "https://github.com/solidity-parser/parser.git",
-    "**/source-map-support": "=0.5.19"
+    "**/source-map-support": "=0.5.19",
+    "@polkadot/api-derive": "npm:@compound-finance/polkadot-api-derive"
   }
 }

--- a/integration/yarn.lock
+++ b/integration/yarn.lock
@@ -895,6 +895,24 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@compound-finance/polkadot-api@4.14.2-5":
+  version "4.14.2-5"
+  resolved "https://registry.yarnpkg.com/@compound-finance/polkadot-api/-/polkadot-api-4.14.2-5.tgz#b33f651c2c8a0414be5d8271b00e5d2ac4cc2476"
+  integrity sha512-KdB31Z7oIbFPKXpPHZykeGjpLPQgPdmDguiyJbuhBX8wAaiYU8BjFHVsnKf9NNL+kXSfM8aj9hYrqVK3sOZIhA==
+  dependencies:
+    "@babel/runtime" "^7.14.5"
+    "@compound-finance/polkadot-api" "4.14.2-5"
+    "@polkadot/keyring" "^6.8.1"
+    "@polkadot/metadata" "4.14.2-5"
+    "@polkadot/rpc-core" "4.14.2-5"
+    "@polkadot/rpc-provider" "4.14.2-5"
+    "@polkadot/types" "4.14.2-5"
+    "@polkadot/types-known" "4.14.2-5"
+    "@polkadot/util" "^6.8.1"
+    "@polkadot/util-crypto" "^6.8.1"
+    "@polkadot/x-rxjs" "^6.8.1"
+    eventemitter3 "^4.0.7"
+
 "@ethersproject/abi@5.0.0-beta.153":
   version "5.0.0-beta.153"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.0.0-beta.153.tgz#43a37172b33794e4562999f6e2d555b7599a8eee"
@@ -1305,32 +1323,32 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@polkadot/api-derive@4.14.2-4":
-  version "4.14.2-4"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-4.14.2-4.tgz#313aabb6bdb01f45c5e6a1fa2e66758ab7fe1028"
-  integrity sha512-gI2Mu1XrqqgTdUobt9gm8hqVUh67NgcBvhzmmST0TMIIdjF74GfZw+Xk3bjmaeU0/u3ua1pQlUOEolDLrNT4+Q==
+"@polkadot/api-derive@4.14.2-5", "@polkadot/api-derive@npm:@compound-finance/polkadot-api-derive":
+  version "4.14.2-5"
+  resolved "https://registry.yarnpkg.com/@compound-finance/polkadot-api-derive/-/polkadot-api-derive-4.14.2-5.tgz#0eb5346e0a6452efa16a66e60863c05f0a8f47f1"
+  integrity sha512-0DWbqUJkgR+R5aaNkFk2Qtt2jmNtHjCvrqzMcWAWlroWpPynK13MW7762ae+8YmHIGtgOF/wbP2wielKry+b2A==
   dependencies:
     "@babel/runtime" "^7.14.5"
-    "@polkadot/api" "4.14.2-4"
-    "@polkadot/rpc-core" "4.14.2-4"
-    "@polkadot/types" "4.14.2-4"
+    "@compound-finance/polkadot-api" "4.14.2-5"
+    "@polkadot/rpc-core" "4.14.2-5"
+    "@polkadot/types" "4.14.2-5"
     "@polkadot/util" "^6.8.1"
     "@polkadot/util-crypto" "^6.8.1"
     "@polkadot/x-rxjs" "^6.8.1"
 
-"@polkadot/api@4.14.2-4", "@polkadot/api@^4.14.2-4":
-  version "4.14.2-4"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-4.14.2-4.tgz#37066b1dafd9df3d8b8e4eb5cf6b7d0fd14445d2"
-  integrity sha512-l+InKHXVFbxSjJ+FOuaG3cwvHImZ5Ps1Hr/0rxxleET+ApLnqdH29zW8eC6viWeB/UamrcblQhQVyfXAYj+cig==
+"@polkadot/api@^4.14.2-5":
+  version "4.14.2-5"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-4.14.2-5.tgz#62f13b944534367ea9ad8c1893faa09761ebbde8"
+  integrity sha512-VHz3KDTa4ZTYM5ZU6egckeD4f3N/nmLDOL8K/BKabamdoQvQxYP4MN52OZhqjvTIxGcmOwJf5qocS8QLt6wijA==
   dependencies:
     "@babel/runtime" "^7.14.5"
-    "@polkadot/api-derive" "4.14.2-4"
+    "@polkadot/api-derive" "4.14.2-5"
     "@polkadot/keyring" "^6.8.1"
-    "@polkadot/metadata" "4.14.2-4"
-    "@polkadot/rpc-core" "4.14.2-4"
-    "@polkadot/rpc-provider" "4.14.2-4"
-    "@polkadot/types" "4.14.2-4"
-    "@polkadot/types-known" "4.14.2-4"
+    "@polkadot/metadata" "4.14.2-5"
+    "@polkadot/rpc-core" "4.14.2-5"
+    "@polkadot/rpc-provider" "4.14.2-5"
+    "@polkadot/types" "4.14.2-5"
+    "@polkadot/types-known" "4.14.2-5"
     "@polkadot/util" "^6.8.1"
     "@polkadot/util-crypto" "^6.8.1"
     "@polkadot/x-rxjs" "^6.8.1"
@@ -1345,14 +1363,14 @@
     "@polkadot/util" "6.8.1"
     "@polkadot/util-crypto" "6.8.1"
 
-"@polkadot/metadata@4.14.2-4":
-  version "4.14.2-4"
-  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-4.14.2-4.tgz#586a47e166fb4ef27eefba40f8fda8359ef4f106"
-  integrity sha512-V9hqgSzNb6eJNi94ygTSSI0FfzWpXckQ4Och2yNqKBuViraCGLr0LyLYcGs8Mc+BcdC3XFUoPutF01O4Fzok0w==
+"@polkadot/metadata@4.14.2-5":
+  version "4.14.2-5"
+  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-4.14.2-5.tgz#b5f6530eb45c57d3ea7ff384640a00a639ab4313"
+  integrity sha512-TP75Q/MKKrxpDkTKFLyXDvj3Km+8485+i6C4pBca4+4gzxa1R5JQCekNVjHJqkRWUtEAq6BSqAFwDaBR6sQt4A==
   dependencies:
     "@babel/runtime" "^7.14.5"
-    "@polkadot/types" "4.14.2-4"
-    "@polkadot/types-known" "4.14.2-4"
+    "@polkadot/types" "4.14.2-5"
+    "@polkadot/types-known" "4.14.2-5"
     "@polkadot/util" "^6.8.1"
     "@polkadot/util-crypto" "^6.8.1"
 
@@ -1363,25 +1381,25 @@
   dependencies:
     "@babel/runtime" "^7.14.5"
 
-"@polkadot/rpc-core@4.14.2-4":
-  version "4.14.2-4"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-4.14.2-4.tgz#9d9de2bf607178d9e53237b90e3c942df7b9a973"
-  integrity sha512-LsgEOWzttCJiUu7ZAxc8b4MnNzujPowE1cujIKgXBG0l4DGNvar0ZOSblqtgbLNk3ztGwH/RcDEQhkqfOqToeg==
+"@polkadot/rpc-core@4.14.2-5":
+  version "4.14.2-5"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-4.14.2-5.tgz#6d27befeb5844a882df56da384e772ef28340f62"
+  integrity sha512-kJbeYtTuuZZzJ8rrkHQkaogRTU5r4CJc9CLVqnCORRw2bIl663PurJdNazMdx88ptDdTNPbmVKfAmUqCu4L7gg==
   dependencies:
     "@babel/runtime" "^7.14.5"
-    "@polkadot/metadata" "4.14.2-4"
-    "@polkadot/rpc-provider" "4.14.2-4"
-    "@polkadot/types" "4.14.2-4"
+    "@polkadot/metadata" "4.14.2-5"
+    "@polkadot/rpc-provider" "4.14.2-5"
+    "@polkadot/types" "4.14.2-5"
     "@polkadot/util" "^6.8.1"
     "@polkadot/x-rxjs" "^6.8.1"
 
-"@polkadot/rpc-provider@4.14.2-4":
-  version "4.14.2-4"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-4.14.2-4.tgz#20bc54825d6ab7fdd3ffd206762c2f8ec6bf995c"
-  integrity sha512-mauzPblXfhee/8YEreI/V8Kt5ds4Nz5QzcQ/E4qyDoQQU4jPni8z0MXHSGtzI5xA/57VERMT7HJuazowt6YQGA==
+"@polkadot/rpc-provider@4.14.2-5":
+  version "4.14.2-5"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-4.14.2-5.tgz#9dcdde7325fc3518b22db7d88dd5c4f245bc230e"
+  integrity sha512-LbZ/ZBgCiHWGPsbrTtT22zvw4nb4JyHZVq9sKSzbWebmPcOngj3rY96uGIWRu5VDPX5xqGMrjes4npxhorQ+5w==
   dependencies:
     "@babel/runtime" "^7.14.5"
-    "@polkadot/types" "4.14.2-4"
+    "@polkadot/types" "4.14.2-5"
     "@polkadot/util" "^6.8.1"
     "@polkadot/util-crypto" "^6.8.1"
     "@polkadot/x-fetch" "^6.8.1"
@@ -1389,23 +1407,23 @@
     "@polkadot/x-ws" "^6.8.1"
     eventemitter3 "^4.0.7"
 
-"@polkadot/types-known@4.14.2-4":
-  version "4.14.2-4"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-4.14.2-4.tgz#f060aeac78c30bf2dc7b25af18c9d80f45b2203a"
-  integrity sha512-AZeKS6GR7I/1qiC/nVDLHuB0GGnHbVwsPfi9ad0hjhqVsZxMqmdEtLUiyBo7agll75QtM58RGXWKwQtZPk7b+g==
+"@polkadot/types-known@4.14.2-5":
+  version "4.14.2-5"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-4.14.2-5.tgz#8b7f25b84022a9b89be15710db87e0de125356c3"
+  integrity sha512-swAZBoCiZp+gk78jVqKqpmds+9+05/ENKWgA6g7AyfrJCkFIajr/1C1OoMVwkPL1M3+KGzHiQSrCfXiHH4NEyg==
   dependencies:
     "@babel/runtime" "^7.14.5"
     "@polkadot/networks" "^6.8.1"
-    "@polkadot/types" "4.14.2-4"
+    "@polkadot/types" "4.14.2-5"
     "@polkadot/util" "^6.8.1"
 
-"@polkadot/types@4.14.2-4":
-  version "4.14.2-4"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-4.14.2-4.tgz#541fc93e0e7cd9bb3825cbbad8ec6e7a9d0b9723"
-  integrity sha512-/AZi/3e4GgJRX+3r0ByAzKG1NPbjZLpaH4dmmz0EyX+VbYJVCPrUNzNvPJRVNHPwh0Q4K/5ET2T1XigOse8FTw==
+"@polkadot/types@4.14.2-5":
+  version "4.14.2-5"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-4.14.2-5.tgz#a47cb54f780e751c0a08f7b7fa621190ff066adf"
+  integrity sha512-+z6vgVoXY0VNBjnALokf7Kbd6gaQR27kVT1w6G0n8ZPmrFfDnkpXKtpCBI4sv/bQXoHwaU6Ka+zfSMEGjOA3gw==
   dependencies:
     "@babel/runtime" "^7.14.5"
-    "@polkadot/metadata" "4.14.2-4"
+    "@polkadot/metadata" "4.14.2-5"
     "@polkadot/util" "^6.8.1"
     "@polkadot/util-crypto" "^6.8.1"
     "@polkadot/x-rxjs" "^6.8.1"


### PR DESCRIPTION
This patch fixes the PolkadotJS client with the patches from @jflatow by using yarn resolutions to grab the published version of those changes from npm. We should still work to get the fixes merged into the mainstream repo of PolkadotJS.