### PR TITLE
Turn on `runtime-debug` for Releases

### DIFF
--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -35,7 +35,7 @@ contracts="./ethereum/.build/contracts.json"
 
 echo "*** Building release gateway ***"
 
-cargo +nightly build --release
+cargo +nightly build --release --features runtime-debug
 
 bin="./target/release/gateway"
 types="./types.json"


### PR DESCRIPTION
This patch (temporarily) turns on runtime debugging for releases. Specifically, this will allow us to get higher quality logs when running on WASM. Overall, this is not recommended as it makes the WASM larger and slower, but in the meanwhile while we're diagnosing issues, it'll probably be a 🙏 blessing.