### PR TITLE
flexible CLI and ENV based configuration

### DIFF
--- a/integration/package.json
+++ b/integration/package.json
@@ -20,8 +20,10 @@
     "postinstall": "cat /dev/null > node_modules/source-map-support/register.js",
     "test": "PROFILE=release QUIET_SCENARIOS=true node --experimental-vm-modules node_modules/.bin/jest",
     "build": "yarn build:ethereum && yarn build:cargo",
+    "dbuild": "yarn build:ethereum && yarn dbuild:cargo",
     "build:ethereum": "(cd ../ethereum && yarn && yarn compile)",
     "build:cargo": "WASM_BUILD_RUSTFLAGS='--cfg feature=\"integration\"' cargo build --release --features integration",
+    "dbuild:cargo": "WASM_BUILD_RUSTFLAGS='--cfg feature=\"integration\"' cargo build --features integration",
     "console": "NODE_OPTIONS='--experimental-repl-await' npx saddle console",
     "repl": "NODE_OPTIONS='--experimental-repl-await --experimental-vm-modules' node repl.js"
   },

--- a/integration/util/scenario/validator.js
+++ b/integration/util/scenario/validator.js
@@ -220,12 +220,15 @@ class Validator {
     let newCliArgs = [];
     let ethRpcUrl = this.ethProxy ? this.ethProxy.serverUrl() : this.ctx.eth.web3Url;
     if (this.version.supports('full-cli-args')) {
-      newCliArgs = [
+      if (this.version.supports('generic-cli-args')) {
+        newCliArgs.push('--')
+      }
+      newCliArgs.push(...[
         '--eth-rpc-url', ethRpcUrl,
         '--eth-key-id', "my_eth_key_id",
         '--miner', `Eth:${this.ethAccount}`,
         '--opf-url', this.ctx.__opfUrl(),
-      ];
+      ]);
     } else {
       env['ETH_RPC_URL'] = ethRpcUrl;
       env['ETH_KEY_ID'] = "my_eth_key_id";
@@ -249,13 +252,13 @@ class Validator {
       '--no-mdns',
       '--node-key',
       this.nodeKey,
-      ...newCliArgs,
       '-laura=info,executor=info,runtime=info,gateway=info,pallet_cash=info,session=info',
       '--reserved-only',
       ...executionArgs,
       ...this.bootnodes,
       ...this.extraArgs,
-      ...this.validatorArgs
+      ...this.validatorArgs,
+      ...newCliArgs,
     ], { env });
 
     process.on('exit', () => {

--- a/integration/util/scenario/validator.js
+++ b/integration/util/scenario/validator.js
@@ -221,14 +221,21 @@ class Validator {
     let ethRpcUrl = this.ethProxy ? this.ethProxy.serverUrl() : this.ctx.eth.web3Url;
     if (this.version.supports('full-cli-args')) {
       if (this.version.supports('generic-cli-args')) {
-        newCliArgs.push('--')
+        newCliArgs = [
+          '--gateway-args',
+          'eth-rpc-url', ethRpcUrl,
+          'eth-key-id', "my_eth_key_id",
+          'miner', `Eth:${this.ethAccount}`,
+          'opf-url', this.ctx.__opfUrl(),
+        ];
+      } else {
+        newCliArgs = [
+          '--eth-rpc-url', ethRpcUrl,
+          '--eth-key-id', "my_eth_key_id",
+          '--miner', `Eth:${this.ethAccount}`,
+          '--opf-url', this.ctx.__opfUrl(),
+        ];
       }
-      newCliArgs.push(...[
-        '--eth-rpc-url', ethRpcUrl,
-        '--eth-key-id', "my_eth_key_id",
-        '--miner', `Eth:${this.ethAccount}`,
-        '--opf-url', this.ctx.__opfUrl(),
-      ]);
     } else {
       env['ETH_RPC_URL'] = ethRpcUrl;
       env['ETH_KEY_ID'] = "my_eth_key_id";

--- a/integration/util/scenario/validator.js
+++ b/integration/util/scenario/validator.js
@@ -222,11 +222,11 @@ class Validator {
     if (this.version.supports('full-cli-args')) {
       if (this.version.supports('generic-cli-args')) {
         newCliArgs = [
-          '--gateway-args',
-          'eth-rpc-url', ethRpcUrl,
-          'eth-key-id', "my_eth_key_id",
-          'miner', `Eth:${this.ethAccount}`,
-          'opf-url', this.ctx.__opfUrl(),
+          '--env',
+          `ETH_RPC_URL=${ethRpcUrl}`,
+          'ETH_KEY_ID=my_eth_key_id',
+          `MINER=Eth:${this.ethAccount}`,
+          `OPF_URL=${this.ctx.__opfUrl()}`
         ];
       } else {
         newCliArgs = [

--- a/integration/util/scenario/versions.js
+++ b/integration/util/scenario/versions.js
@@ -183,6 +183,7 @@ class Version {
       'full-cli-args': (v) => v >= 9,
       'eth-starport-parent-block': (v) => v >= 9,
       'new-artifacts': (v) => v >= 10,
+      'generic-cli-args': (v) => v >= 12, // todo: not sure exactly what this should be
     };
 
     if (!versionMap.hasOwnProperty(t)) {

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -1,23 +1,46 @@
 use sc_cli::RunCmd;
+use std::collections::HashMap;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 pub struct GatewayCmd {
-    /// Set the ETH Key ID for AWS KMS integration
-    #[structopt(long = "eth-key-id")]
-    pub eth_key_id: Option<String>,
+    // collect args after -- like cargo, eg cargo run -- --help for generic key-value configuration
+    // expected format is --eth-key-id abcdefg --miner 123456789
+    // OR
+    // ETH_KEY_ID abcdefg MINER 123456789
+    // equals = linking not supported as in --eth-key-id=abcdefg
+    #[structopt()]
+    pub args: Vec<String>,
+}
 
-    /// Set the ETH RPC Url for interfacing with ethereum
-    #[structopt(long = "eth-rpc-url")]
-    pub eth_rpc_url: Option<String>,
+impl GatewayCmd {
+    fn kebab_with_leading_dashes_to_screaming_snake(s: &str) -> String {
+        let range = if s.starts_with("--") { 2.. } else { 0.. };
+        s[range].replace("-", "_").to_uppercase()
+    }
 
-    /// Set the miner address (only useful for validator)
-    #[structopt(long = "miner")]
-    pub miner: Option<String>,
+    pub fn parse_cli_mapping(self) -> HashMap<String, String> {
+        if self.args.len() % 2 != 0 {
+            // note it is ok to panic here because this is a critical part of the booting up
+            // process of the node and is not expected to result in a bad state
+            panic!("odd number of arguments provided to gateway key value pair configuration.")
+        }
 
-    /// Open price feed URL
-    #[structopt(long = "opf-url")]
-    pub opf_url: Option<String>,
+        let mut return_value = HashMap::with_capacity(self.args.len() / 2);
+
+        for i in (0..self.args.len()).step_by(2) {
+            let raw_key = &self.args[i];
+            // note - we don't worry about going out of bounds because we know we
+            // have an even number of elements from above
+            let value = &self.args[i + 1];
+
+            let key = GatewayCmd::kebab_with_leading_dashes_to_screaming_snake(raw_key);
+
+            return_value.insert(key, value.clone());
+        }
+
+        return_value
+    }
 }
 
 #[derive(Debug, StructOpt)]
@@ -59,4 +82,78 @@ pub enum Subcommand {
     #[cfg(feature = "runtime-benchmarks")]
     #[structopt(name = "benchmark", about = "Benchmark runtime pallets.")]
     Benchmark(frame_benchmarking_cli::BenchmarkCmd),
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::GatewayCmd;
+
+    #[test]
+    fn test_kebab_with_leading_dashes_to_screaming_snake() {
+        assert_eq!(
+            GatewayCmd::kebab_with_leading_dashes_to_screaming_snake("--abc-def-ghi"),
+            "ABC_DEF_GHI".to_string()
+        );
+        assert_eq!(
+            GatewayCmd::kebab_with_leading_dashes_to_screaming_snake("abc-def-ghi"),
+            "ABC_DEF_GHI".to_string()
+        );
+        assert_eq!(
+            GatewayCmd::kebab_with_leading_dashes_to_screaming_snake("--abc--def-ghi"),
+            "ABC__DEF_GHI".to_string()
+        );
+        assert_eq!(
+            GatewayCmd::kebab_with_leading_dashes_to_screaming_snake("ABC_DEF_GHI"),
+            "ABC_DEF_GHI".to_string()
+        );
+        assert_eq!(
+            GatewayCmd::kebab_with_leading_dashes_to_screaming_snake("--abc-def-GHI"),
+            "ABC_DEF_GHI".to_string()
+        );
+        assert_eq!(
+            GatewayCmd::kebab_with_leading_dashes_to_screaming_snake("--"),
+            "".to_string()
+        );
+        assert_eq!(
+            GatewayCmd::kebab_with_leading_dashes_to_screaming_snake(""),
+            "".to_string()
+        );
+        assert_eq!(
+            GatewayCmd::kebab_with_leading_dashes_to_screaming_snake("---"),
+            "_".to_string()
+        );
+        assert_eq!(
+            GatewayCmd::kebab_with_leading_dashes_to_screaming_snake("----"),
+            "__".to_string()
+        );
+    }
+
+    #[test]
+    fn test_parse_cli_mapping() {
+        let args: Vec<String> = Vec::from([
+            "--eth-rpc-url".into(),
+            "expected eth rpc url".into(),
+            "--miner".into(),
+            "expected miner".into(),
+            "--eth-key-id".into(),
+            "expected eth key id".into(),
+            "--opf-url".into(),
+            "expected opf url".into(),
+        ]);
+
+        let unit_under_test = GatewayCmd { args };
+
+        let mut actual = unit_under_test.parse_cli_mapping();
+
+        assert_eq!(
+            actual.remove("ETH_RPC_URL"),
+            Some("expected eth rpc url".into())
+        );
+        assert_eq!(actual.remove("MINER"), Some("expected miner".into()));
+        assert_eq!(
+            actual.remove("ETH_KEY_ID"),
+            Some("expected eth key id".into())
+        );
+        assert_eq!(actual.remove("OPF_URL"), Some("expected opf url".into()));
+    }
 }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -4,13 +4,17 @@ use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 pub struct GatewayCmd {
-    // collect args after -- like cargo, eg cargo run -- --help for generic key-value configuration
-    // expected format is --eth-key-id abcdefg --miner 123456789
-    // OR
-    // ETH_KEY_ID abcdefg MINER 123456789
-    // equals = linking not supported as in --eth-key-id=abcdefg
-    #[structopt()]
-    pub args: Vec<String>,
+    #[structopt(long = "gateway-args", help = "set validator specific settings")]
+    /// The currently available options are
+    ///
+    /// ETH_KEY_ID
+    /// ETH_RPC_URL
+    /// MINER
+    /// OPF_URL
+    ///
+    /// example ./gateway .... --gateway-args eth-key-id abc/def-ghi eth-rpc-url https... miner 0xeeee....ee opf_url https..
+    ///
+    pub gateway_args: Vec<String>,
 }
 
 impl GatewayCmd {
@@ -20,19 +24,19 @@ impl GatewayCmd {
     }
 
     pub fn parse_cli_mapping(self) -> HashMap<String, String> {
-        if self.args.len() % 2 != 0 {
+        if self.gateway_args.len() % 2 != 0 {
             // note it is ok to panic here because this is a critical part of the booting up
             // process of the node and is not expected to result in a bad state
             panic!("odd number of arguments provided to gateway key value pair configuration.")
         }
 
-        let mut return_value = HashMap::with_capacity(self.args.len() / 2);
+        let mut return_value = HashMap::with_capacity(self.gateway_args.len() / 2);
 
-        for i in (0..self.args.len()).step_by(2) {
-            let raw_key = &self.args[i];
+        for i in (0..self.gateway_args.len()).step_by(2) {
+            let raw_key = &self.gateway_args[i];
             // note - we don't worry about going out of bounds because we know we
             // have an even number of elements from above
-            let value = &self.args[i + 1];
+            let value = &self.gateway_args[i + 1];
 
             let key = GatewayCmd::kebab_with_leading_dashes_to_screaming_snake(raw_key);
 
@@ -89,7 +93,7 @@ pub mod test {
     use super::GatewayCmd;
 
     #[test]
-    fn test_kebab_with_leading_dashes_to_screaming_snake() {
+    fn test_kebab_to_screaming_snake() {
         assert_eq!(
             GatewayCmd::kebab_with_leading_dashes_to_screaming_snake("--abc-def-ghi"),
             "ABC_DEF_GHI".to_string()
@@ -141,7 +145,7 @@ pub mod test {
             "expected opf url".into(),
         ]);
 
-        let unit_under_test = GatewayCmd { args };
+        let unit_under_test = GatewayCmd { gateway_args: args };
 
         let mut actual = unit_under_test.parse_cli_mapping();
 

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -133,12 +133,7 @@ pub fn run() -> sc_cli::Result<()> {
         }
         None => {
             let runner = cli.create_runner(&cli.run)?;
-            runtime_interfaces::initialize_validator_config(
-                cli.gateway.eth_key_id.clone(),
-                cli.gateway.eth_rpc_url.clone(),
-                cli.gateway.miner.clone(),
-                cli.gateway.opf_url.clone(),
-            );
+            runtime_interfaces::initialize_validator_config(cli.gateway.parse_cli_mapping());
             Ok(runner.run_node_until_exit(|config| async move {
                 match config.role {
                     Role::Light => service::new_light(config),

--- a/pallets/runtime-interfaces/src/lib.rs
+++ b/pallets/runtime-interfaces/src/lib.rs
@@ -53,9 +53,9 @@ const OPF_URL_DEFAULT: &str = "https://prices.compound.finance/coinbase";
 
 fn validator_config_interface_get_internal(key: &str) -> Option<String> {
     // check env override
-    if let Ok(eth_key_id_from_env) = std::env::var(key) {
-        if eth_key_id_from_env.len() > 0 {
-            return Some(eth_key_id_from_env);
+    if let Ok(value_from_env) = std::env::var(key) {
+        if value_from_env.len() > 0 {
+            return Some(value_from_env);
         }
     }
     // check config


### PR DESCRIPTION
This provides future proof configuration for validators. No longer will additional validator specific configuration upgrades (eg adding node RPC URL) need validators to update their binary, soft fork WITH validator setting new ENV is sufficient.

TL;DR

This is a breaking change

before

```shell
./gateway --chain ... --base-path ... ...... \
   --eth-rpc-url http://localhost:8004 \
   --eth-key-id my_eth_key_id \
   --miner Eth:0x8AD1b2918C34EE5d3E881A57c68574EA9dbEcB81 \ 
   --opf-url http://127.0.0.1:58718/
```

after

```shell
./gateway --chain ... --base-path ... ...... --env \
   ETH_RPC_URL=http://localhost:8004 \
   ETH_KEY_ID=my_eth_key_id \
   MINER=Eth:0x8AD1b2918C34EE5d3E881A57c68574EA9dbEcB81 \ 
   OPF_URL=http://127.0.0.1:58718/
```

The big difference is that we can now add whatever CLI args we want and read them via the runtime without needing to upgrade the node binary.
