### PR TITLE
Use EIP-234 getLogs

### DIFF
--- a/ethereum-client/src/lib.rs
+++ b/ethereum-client/src/lib.rs
@@ -203,8 +203,7 @@ pub fn get_block(
     let block_obj = get_block_object(server, &block_str)?;
     let get_logs_params = vec![serde_json::json!({
         "address": format!("0x{}", ::hex::encode(&eth_starport_address[..])),
-        "fromBlock": &block_str,
-        "toBlock": &block_str,
+        "blockHash": &block_obj.hash
     })];
     debug!("get_logs_params: {:?}", get_logs_params.clone());
     let get_logs_response_str: String = send_rpc(server, "eth_getLogs".into(), get_logs_params)?;
@@ -297,7 +296,7 @@ mod tests {
                     method: "POST".into(),
                     uri: "https://mainnet-eth.compound.finance".into(),
                     headers: vec![("Content-Type".to_owned(), "application/json".to_owned())],
-                    body: br#"{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"address":"0x3a275655586a049fe860be867d10cdae2ffc0f33","fromBlock":"0x506","toBlock":"0x506"}],"id":1}"#.to_vec(),
+                    body: br#"{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"address":"0x3a275655586a049fe860be867d10cdae2ffc0f33","blockHash":"0x61314c1c6837e15e60c5b6732f092118dd25e3ec681f5e089b3a9ad2374e5a8a"}],"id":1}"#.to_vec(),
                     response: Some(br#"{"jsonrpc":"2.0","id":1,"result":[{"address":"0xd905abba1c5ea48c0598be9f3f8ae31290b58613","blockHash":"0xc94ceed3c8c68f09b1c7be28f594cc6fb01f9cdd7b68f3bf516cab9e89486fcf","blockNumber":"0x9928cb","data":"0x000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000006f05b59d3b2000000000000000000000000000000000000000000000000000000000000000000034554480000000000000000000000000000000000000000000000000000000000","logIndex":"0x58","removed":false,"topics":["0xc459acef3ffe957663bb49d644b20d0c790bcb41573893752a72ba6f023b9386","0x000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee","0x000000000000000000000000d3a38d4bd07b87e4516f30ee46cfe8ec4e8b73a4","0xd3a38d4bd07b87e4516f30ee46cfe8ec4e8b73a4000000000000000000000000"],"transactionHash":"0xbae1c242aea30e9ae20cb6c37e2f2d08982e31b42bf3d7dbde6466396abb360e","transactionIndex":"0x24"}]}"#.to_vec()),
                     sent: true,
                     ..Default::default()

--- a/integration/util/scenario/starport.js
+++ b/integration/util/scenario/starport.js
@@ -130,7 +130,6 @@ class Starport {
     let encoded = notice.EncodedNotice;
     let signatures = signaturePairs.map(([signer, sig]) => sig.toHex());
     let sendOpts = { from: this.ctx.eth.defaultFrom, gas: 5000000 };
-    console.log({sendOpts});
     return await this.starport.methods.invoke(encoded, signatures).send(sendOpts);
   }
 

--- a/pallets/cash/src/tests/worker.rs
+++ b/pallets/cash/src/tests/worker.rs
@@ -19,7 +19,7 @@ fn test_offchain_worker() {
             method: "POST".into(),
             uri: "https://ropsten-eth.compound.finance".to_string(),
             headers: vec![("Content-Type".to_owned(), "application/json".to_owned())],
-            body: br#"{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"address":"0x7777777777777777777777777777777777777777","fromBlock":"0x1","toBlock":"0x1"}],"id":1}"#.to_vec(),
+            body: br#"{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"address":"0x7777777777777777777777777777777777777777","blockHash":"0x61314c1c6837e15e60c5b6732f092118dd25e3ec681f5e089b3a9ad2374e5a8a"}],"id":1}"#.to_vec(),
             response: Some(testdata::json_responses::GET_LOGS_1.to_vec()),
             sent: true,
             ..Default::default()
@@ -37,7 +37,7 @@ fn test_offchain_worker() {
             method: "POST".into(),
             uri: "https://ropsten-eth.compound.finance".to_string(),
             headers: vec![("Content-Type".to_owned(), "application/json".to_owned())],
-            body: br#"{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"address":"0x7777777777777777777777777777777777777777","fromBlock":"0x2","toBlock":"0x2"}],"id":1}"#.to_vec(),
+            body: br#"{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"address":"0x7777777777777777777777777777777777777777","blockHash":"0x61314c1c6837e15e60c5b6732f092118dd25e3ec681f5e089b3a9ad2374e5a8a"}],"id":1}"#.to_vec(),
             response: Some(testdata::json_responses::GET_LOGS_2.to_vec()),
             sent: true,
             ..Default::default()


### PR DESCRIPTION
This patch switches from using `getLogs` with `fromBlock` and `toBlock` to using `blockHash`, in accordance with EIP-234. This can fix transient issues where we ask for a block, say 5, then we ask for the logs from block #5 but subsequently there's a new block 5 due to re-org and then we can the logs from the wrong block. This may also fix any glitches with Infura transiently sending empty logs when they are not loaded yet.

We also remove an errant console log message.