### PR TITLE
Use build_release.sh script

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           set -eo pipefail
           ./scripts/get_substrate.sh --fast
-          cargo build --release
+          ./scripts/build_release.sh mRelease
 
       - name: Upload Release Asset
         id: upload-gateway
@@ -45,9 +45,31 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: target/release/gateway
-          asset_name: gateway-x86_64-linux
+          asset_path: releases/mRelease
+          asset_name: gateway-linux-x64
           asset_content_type: application/octet-stream
+
+      - name: Upload Release Asset
+        id: upload-gateway-checksum
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: releases/mRelease
+          asset_name: gateway-linux-x64.checksum
+          asset_content_type: application/octet-stream
+
+      - name: Upload Release Asset
+        id: upload-contracts
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: releases/mRelease
+          asset_name: contracts.json
+          asset_content_type: application/json
 
       - name: Upload Release Asset
         id: upload-types
@@ -56,7 +78,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: types.json
+          asset_path: releases/mRelease
           asset_name: types.json
           asset_content_type: application/json
 
@@ -67,7 +89,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: rpc.json
+          asset_path: releases/mRelease
           asset_name: rpc.json
           asset_content_type: application/json
 
@@ -81,16 +103,48 @@ jobs:
         run: |
           set -eo pipefail
           ./scripts/get_substrate.sh --fast
-          cargo build --release
+          ./scripts/build_release.sh mRelease
 
       - name: Upload Release Asset
-        id: upload-release-asset
+        id: upload-gateway-darwin
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: target/release/gateway
-          asset_name: gateway-x86_64-macos
+          asset_path: releases/mRelease
+          asset_name: gateway-darwin-x64
+          asset_content_type: application/octet-stream
+
+      - name: Upload Release Asset
+        id: upload-gateway-darwin-checksum
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: releases/mRelease
+          asset_name: gateway-darwin-x64.checksum
+          asset_content_type: application/octet-stream
+
+      - name: Upload Release Asset
+        id: upload-gateway-wasm
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: releases/mRelease
+          asset_name: gateway.wasm
+          asset_content_type: application/octet-stream
+
+      - name: Upload Release Asset
+        id: upload-gateway-wasm-checksum
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: releases/mRelease
+          asset_name: gateway.wasm.checksum
           asset_content_type: application/octet-stream

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Create a tag and push to this repo:
 
 ```sh
 $ git tag -a <MILESTONE TAG> <OPTIONAL COMMIT HASH>
-$ git push origin <MILESTON TAG>
+$ git push origin <MILESTONE TAG>
 ```
 
 ### Manual Release Process

--- a/README.md
+++ b/README.md
@@ -239,21 +239,10 @@ A scenario test should be written to show that things work as expected after the
 The goal is to not break things on release.
 
 Releases should be cut from the `develop` (default) branch on [Github](https://github.com/compound-finance/gateway).
-For now, here's the manual process we follow for cutting releases:
 
 ### Bump Spec Version
 
 First increment the spec version in `runtime/src/lib.rs`.
-
-### Build Release Artifacts
-
-Build the release artifacts using the included script:
-
-```
-$ scripts/build_release.sh <MILESTONE TAG>
-```
-
-Where `<MILESTONE TAG>` should be a sequentially increasing counter beginning with `m`, followed by the spec version, e.g. `m7`, `m8`, `m9`.
 
 ### Update Chain Spec
 
@@ -267,7 +256,34 @@ $ CHAIN_BIN=target/<MILESTONE TAG>/gateway-<PLATFORM> chains/build_spec.js -s -c
 
 Where `<PLATFORM>` is your local platform used to name the binary build.
 
-### Upload Release Artifacts
+### Using Github Workflows Release Process (Easier -- Recommended)
+
+Github actions have been created to respond to git tags that are pushed to the repo that begin with `m`, followed by the spec version, e.g. `m3`.
+
+This process will create a draft/prerelease that can be modified and published on github once ready.
+
+Create a tag and push to this repo:
+
+```sh
+$ git tag -a <MILESTONE TAG> <OPTIONAL COMMIT HASH>
+$ git push origin <MILESTON TAG>
+```
+
+### Manual Release Process
+
+Cutting a release can also be accomplished manually by following the steps below.
+
+#### Build Release Artifacts
+
+Build the release artifacts using the included script:
+
+```
+$ scripts/build_release.sh <MILESTONE TAG>
+```
+
+Where `<MILESTONE TAG>` should be a sequentially increasing counter beginning with `m`, followed by the spec version, e.g. `m7`, `m8`, `m9`.
+
+#### Upload Release Artifacts
 
 The changes above should be committed to the `develop` branch and included in the version that is tagged in the repository below.
 

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -12,7 +12,7 @@ if [ -z "$version" ]; then
 	exit 1
 fi
 
-echo "*** Building release $version ***"
+echo "*** Building release $version on $machine ***"
 
 cd $(dirname ${BASH_SOURCE[0]})/..
 


### PR DESCRIPTION
This patch updates the `release-workflow` to utilize the `build_release.sh` script, and uploads all the necessary files to the newly created release.