### PR TITLE
Add Stack Trace from Call-site not Error site

### DIFF
--- a/integration/util/scenario/event_tracker.js
+++ b/integration/util/scenario/event_tracker.js
@@ -119,6 +119,7 @@ class EventTracker {
   }
 
   sendAndWaitForEvents(call, opts = {}) {
+    let stackTrace = new Error().stack;
     opts = {
       onFinalize: true,
       rejectOnFailure: true,
@@ -180,6 +181,7 @@ class EventTracker {
         ];
 
         if (opts.rejectOnFailure && failures.length > 0) {
+          failures[0].stack = stackTrace; // Use original stacktrace
           reject(failures[0]);
         } else {
           resolve(events);


### PR DESCRIPTION
Due to the async callback nature of sendAndWaitForEvents, errors are raised in the callback code, which leads to an error's stacktrace being just that, in some generic callback code. This patch captures a backtrace at the original callsite and then attaches that to an error before it's returned. As such, it's possible to give the user a more helpful error. It's a bit of a hack, but not utilizing any undefined behavior.