### PR TITLE
Update test workflow to not run audit and integrations

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -6,9 +6,13 @@ on: push
 jobs:
   cargo-audit:
     name: Cargo Audit Check
+    # This always fails because of Substrate depenedencies that we don't control
+    # We are hardcoding this to false to not run at the moment
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -200,6 +204,10 @@ jobs:
 
   integration-tests:
     name: Integration Tests
+    # We are currently hardcoding not to run integration tests because they take too long to provide feedback
+    # on their success or failure. We will introduce integration tests back to CI once we improve test times
+    # (hopefully down to ~10 minutes).
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/ethereum/package.json
+++ b/ethereum/package.json
@@ -11,7 +11,7 @@
     "postinstall": "cd node_modules/solidity-parser-antlr && yarn install && yarn build",
     "compile": "npx saddle compile",
     "test": "npx saddle compile && npx saddle test",
-    "coverage": "npx saddle compile --trace && npx saddle coverage && npx istanbul report --root=./coverage lcov json",
+    "coverage": "BUILD_FILE=.build/contracts-trace.json npx saddle compile --trace && npx saddle coverage && npx istanbul report --root=./coverage lcov json",
     "console": "NODE_OPTIONS='--experimental-repl-await' npx saddle console",
     "script": "npx saddle script"
   },

--- a/ethereum/package.json
+++ b/ethereum/package.json
@@ -11,7 +11,7 @@
     "postinstall": "cd node_modules/solidity-parser-antlr && yarn install && yarn build",
     "compile": "npx saddle compile",
     "test": "npx saddle compile && npx saddle test",
-    "coverage": "BUILD_FILE=.build/contracts-trace.json npx saddle compile --trace && npx saddle coverage && npx istanbul report --root=./coverage lcov json",
+    "coverage": "BUILD_FILE=.build/contracts-trace.json npx saddle compile --trace && BUILD_FILE=.build/contracts-trace.json npx saddle coverage && npx istanbul report --root=./coverage lcov json",
     "console": "NODE_OPTIONS='--experimental-repl-await' npx saddle console",
     "script": "npx saddle script"
   },


### PR DESCRIPTION
The goal of this patch was to make progress towards following a correct CI workflow. Currently our cargo audit job always fails based on dependencies for Substrate that we don't control. Our integration tests take well over an hour to give success/failure results, leading to PRs being merged before waiting for them to pass. This patch adjusts the `test-workflow` for GitHub actions to skip running the `cargo audit` and `integration` jobs. It also fixes a bug in `ethereum-coverage` that should now return proper test/pass results. We can hopefully begin to follow a pattern of only merging PRs with ✅, while we devise a strategy to improve our integrations testing for inclusion in CI.